### PR TITLE
Player unit tests ensuring they do not gain skills when using runes.

### DIFF
--- a/tests/NeoServer.Game.Creatures.Tests/NeoServer.Game.Creatures.Tests.csproj
+++ b/tests/NeoServer.Game.Creatures.Tests/NeoServer.Game.Creatures.Tests.csproj
@@ -27,6 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\data\extensions\NeoServer.Extensions.csproj" />
     <ProjectReference Include="..\..\src\Game\NeoServer.Game.Creatures\NeoServer.Game.Creatures.csproj" />
     <ProjectReference Include="..\..\src\Game\NeoServer.Game.Items\NeoServer.Game.Items.csproj" />
     <ProjectReference Include="..\..\src\Game\NeoServer.Game.World\NeoServer.Game.World.csproj" />

--- a/tests/NeoServer.Game.Creatures.Tests/NeoServer.Game.Creatures.Tests.csproj
+++ b/tests/NeoServer.Game.Creatures.Tests/NeoServer.Game.Creatures.Tests.csproj
@@ -27,7 +27,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\data\extensions\NeoServer.Extensions.csproj" />
     <ProjectReference Include="..\..\src\Game\NeoServer.Game.Creatures\NeoServer.Game.Creatures.csproj" />
     <ProjectReference Include="..\..\src\Game\NeoServer.Game.Items\NeoServer.Game.Items.csproj" />
     <ProjectReference Include="..\..\src\Game\NeoServer.Game.World\NeoServer.Game.World.csproj" />

--- a/tests/NeoServer.Game.Creatures.Tests/Players/PlayerTest.cs
+++ b/tests/NeoServer.Game.Creatures.Tests/Players/PlayerTest.cs
@@ -1,9 +1,8 @@
+using System;
+using System.Collections.Generic;
 using FluentAssertions;
-using Moq;
-using NeoServer.Extensions.Runes;
 using NeoServer.Game.Common.Combat.Structs;
 using NeoServer.Game.Common.Contracts.Creatures;
-using NeoServer.Game.Common.Contracts.Items;
 using NeoServer.Game.Common.Contracts.Items.Types;
 using NeoServer.Game.Common.Creatures;
 using NeoServer.Game.Common.Creatures.Players;
@@ -11,10 +10,7 @@ using NeoServer.Game.Common.Item;
 using NeoServer.Game.Common.Location.Structs;
 using NeoServer.Game.Creatures.Model;
 using NeoServer.Game.Creatures.Model.Players;
-using NeoServer.Game.Items.Items.UsableItems.Runes;
 using NeoServer.Game.Tests.Helpers;
-using System;
-using System.Collections.Generic;
 using Xunit;
 
 namespace NeoServer.Game.Creatures.Tests.Players
@@ -88,125 +84,6 @@ namespace NeoServer.Game.Creatures.Tests.Players
             sut.ChangeFightMode(FightMode.Attack);
 
             sut.FightMode.Should().Be(FightMode.Attack);
-        }
-
-        [Fact]
-        public void PlayerDoesNotGainSkillsWhenUsingAnAttackRune()
-        {
-            var player = PlayerTestDataBuilder.BuildPlayer();
-            var targetPlayer = PlayerTestDataBuilder.BuildPlayer();
-
-            var itemAttirbuteListMock = new Mock<IItemAttributeList>();
-
-            itemAttirbuteListMock
-                .Setup(x => x.GetAttribute<bool>(It.IsAny<ItemAttribute>()))
-                .Returns(true);
-
-            itemAttirbuteListMock
-                .Setup(x => x.GetAttributeArray(It.IsAny<string>()))
-                .Returns(new dynamic[] { "0.0", "0.0" });
-
-            var itemTypeMock = new Mock<IItemType>();
-            itemTypeMock
-                .Setup(x => x.Attributes)
-                .Returns(itemAttirbuteListMock.Object);
-
-            var rune = new AttackRune(itemTypeMock.Object, new Location(100, 100, 7), (byte)10);
-
-            var before = new Dictionary<SkillType, byte>()
-            {
-                { SkillType.Axe, player.GetSkillTries(SkillType.Axe) },
-                { SkillType.Club, player.GetSkillTries(SkillType.Club) },
-                { SkillType.Distance, player.GetSkillTries(SkillType.Distance) },
-                { SkillType.Fishing, player.GetSkillTries(SkillType.Fishing) },
-                { SkillType.Fist, player.GetSkillTries(SkillType.Fist) },
-                { SkillType.Level, player.GetSkillTries(SkillType.Level) },
-                { SkillType.Magic, player.GetSkillTries(SkillType.Magic) },
-                { SkillType.Shielding, player.GetSkillTries(SkillType.Shielding) },
-                { SkillType.Speed, player.GetSkillTries(SkillType.Speed) },
-                { SkillType.Sword, player.GetSkillTries(SkillType.Sword) },
-            };
-
-            var result = rune.Use(player, targetPlayer, out var attackType);
-            Assert.True(result);
-
-            var after = new Dictionary<SkillType, byte>()
-            {
-                { SkillType.Axe, player.GetSkillTries(SkillType.Axe) },
-                { SkillType.Club, player.GetSkillTries(SkillType.Club) },
-                { SkillType.Distance, player.GetSkillTries(SkillType.Distance) },
-                { SkillType.Fishing, player.GetSkillTries(SkillType.Fishing) },
-                { SkillType.Fist, player.GetSkillTries(SkillType.Fist) },
-                { SkillType.Level, player.GetSkillTries(SkillType.Level) },
-                { SkillType.Magic, player.GetSkillTries(SkillType.Magic) },
-                { SkillType.Shielding, player.GetSkillTries(SkillType.Shielding) },
-                { SkillType.Speed, player.GetSkillTries(SkillType.Speed) },
-                { SkillType.Sword, player.GetSkillTries(SkillType.Sword) },
-            };
-
-            foreach (var skillType in before.Keys)
-            {
-                Assert.Equal(before[skillType], after[skillType]);
-            }
-        }
-
-        [Fact]
-        public void PlayerDoesNotGainSkillsWhenUsingAHealingRune()
-        {
-            var player = PlayerTestDataBuilder.BuildPlayer();
-            var targetPlayer = PlayerTestDataBuilder.BuildPlayer();
-
-            var itemAttirbuteListMock = new Mock<IItemAttributeList>();
-
-            itemAttirbuteListMock
-                .Setup(x => x.GetAttribute<bool>(It.IsAny<ItemAttribute>()))
-                .Returns(true);
-
-            itemAttirbuteListMock
-                .Setup(x => x.GetAttributeArray(It.IsAny<string>()))
-                .Returns(new dynamic[] { "0.0", "0.0" });
-
-            var itemTypeMock = new Mock<IItemType>();
-            itemTypeMock
-                .Setup(x => x.Attributes)
-                .Returns(itemAttirbuteListMock.Object);
-
-            var rune = new HealingRune(itemTypeMock.Object, new Location(100, 100, 7), new Dictionary<ItemAttribute, IConvertible>());
-
-            var before = new Dictionary<SkillType, byte>()
-            {
-                { SkillType.Axe, player.GetSkillTries(SkillType.Axe) },
-                { SkillType.Club, player.GetSkillTries(SkillType.Club) },
-                { SkillType.Distance, player.GetSkillTries(SkillType.Distance) },
-                { SkillType.Fishing, player.GetSkillTries(SkillType.Fishing) },
-                { SkillType.Fist, player.GetSkillTries(SkillType.Fist) },
-                { SkillType.Level, player.GetSkillTries(SkillType.Level) },
-                { SkillType.Magic, player.GetSkillTries(SkillType.Magic) },
-                { SkillType.Shielding, player.GetSkillTries(SkillType.Shielding) },
-                { SkillType.Speed, player.GetSkillTries(SkillType.Speed) },
-                { SkillType.Sword, player.GetSkillTries(SkillType.Sword) },
-            };
-
-            rune.Use(player, targetPlayer);
-
-            var after = new Dictionary<SkillType, byte>()
-            {
-                { SkillType.Axe, player.GetSkillTries(SkillType.Axe) },
-                { SkillType.Club, player.GetSkillTries(SkillType.Club) },
-                { SkillType.Distance, player.GetSkillTries(SkillType.Distance) },
-                { SkillType.Fishing, player.GetSkillTries(SkillType.Fishing) },
-                { SkillType.Fist, player.GetSkillTries(SkillType.Fist) },
-                { SkillType.Level, player.GetSkillTries(SkillType.Level) },
-                { SkillType.Magic, player.GetSkillTries(SkillType.Magic) },
-                { SkillType.Shielding, player.GetSkillTries(SkillType.Shielding) },
-                { SkillType.Speed, player.GetSkillTries(SkillType.Speed) },
-                { SkillType.Sword, player.GetSkillTries(SkillType.Sword) },
-            };
-
-            foreach (var skillType in before.Keys)
-            {
-                Assert.Equal(before[skillType], after[skillType]);
-            }
         }
     }
 }

--- a/tests/NeoServer.Game.Creatures.Tests/Players/PlayerTest.cs
+++ b/tests/NeoServer.Game.Creatures.Tests/Players/PlayerTest.cs
@@ -1,8 +1,9 @@
-using System;
-using System.Collections.Generic;
 using FluentAssertions;
+using Moq;
+using NeoServer.Extensions.Runes;
 using NeoServer.Game.Common.Combat.Structs;
 using NeoServer.Game.Common.Contracts.Creatures;
+using NeoServer.Game.Common.Contracts.Items;
 using NeoServer.Game.Common.Contracts.Items.Types;
 using NeoServer.Game.Common.Creatures;
 using NeoServer.Game.Common.Creatures.Players;
@@ -10,7 +11,10 @@ using NeoServer.Game.Common.Item;
 using NeoServer.Game.Common.Location.Structs;
 using NeoServer.Game.Creatures.Model;
 using NeoServer.Game.Creatures.Model.Players;
+using NeoServer.Game.Items.Items.UsableItems.Runes;
 using NeoServer.Game.Tests.Helpers;
+using System;
+using System.Collections.Generic;
 using Xunit;
 
 namespace NeoServer.Game.Creatures.Tests.Players
@@ -84,6 +88,125 @@ namespace NeoServer.Game.Creatures.Tests.Players
             sut.ChangeFightMode(FightMode.Attack);
 
             sut.FightMode.Should().Be(FightMode.Attack);
+        }
+
+        [Fact]
+        public void PlayerDoesNotGainSkillsWhenUsingAnAttackRune()
+        {
+            var player = PlayerTestDataBuilder.BuildPlayer();
+            var targetPlayer = PlayerTestDataBuilder.BuildPlayer();
+
+            var itemAttirbuteListMock = new Mock<IItemAttributeList>();
+
+            itemAttirbuteListMock
+                .Setup(x => x.GetAttribute<bool>(It.IsAny<ItemAttribute>()))
+                .Returns(true);
+
+            itemAttirbuteListMock
+                .Setup(x => x.GetAttributeArray(It.IsAny<string>()))
+                .Returns(new dynamic[] { "0.0", "0.0" });
+
+            var itemTypeMock = new Mock<IItemType>();
+            itemTypeMock
+                .Setup(x => x.Attributes)
+                .Returns(itemAttirbuteListMock.Object);
+
+            var rune = new AttackRune(itemTypeMock.Object, new Location(100, 100, 7), (byte)10);
+
+            var before = new Dictionary<SkillType, byte>()
+            {
+                { SkillType.Axe, player.GetSkillTries(SkillType.Axe) },
+                { SkillType.Club, player.GetSkillTries(SkillType.Club) },
+                { SkillType.Distance, player.GetSkillTries(SkillType.Distance) },
+                { SkillType.Fishing, player.GetSkillTries(SkillType.Fishing) },
+                { SkillType.Fist, player.GetSkillTries(SkillType.Fist) },
+                { SkillType.Level, player.GetSkillTries(SkillType.Level) },
+                { SkillType.Magic, player.GetSkillTries(SkillType.Magic) },
+                { SkillType.Shielding, player.GetSkillTries(SkillType.Shielding) },
+                { SkillType.Speed, player.GetSkillTries(SkillType.Speed) },
+                { SkillType.Sword, player.GetSkillTries(SkillType.Sword) },
+            };
+
+            var result = rune.Use(player, targetPlayer, out var attackType);
+            Assert.True(result);
+
+            var after = new Dictionary<SkillType, byte>()
+            {
+                { SkillType.Axe, player.GetSkillTries(SkillType.Axe) },
+                { SkillType.Club, player.GetSkillTries(SkillType.Club) },
+                { SkillType.Distance, player.GetSkillTries(SkillType.Distance) },
+                { SkillType.Fishing, player.GetSkillTries(SkillType.Fishing) },
+                { SkillType.Fist, player.GetSkillTries(SkillType.Fist) },
+                { SkillType.Level, player.GetSkillTries(SkillType.Level) },
+                { SkillType.Magic, player.GetSkillTries(SkillType.Magic) },
+                { SkillType.Shielding, player.GetSkillTries(SkillType.Shielding) },
+                { SkillType.Speed, player.GetSkillTries(SkillType.Speed) },
+                { SkillType.Sword, player.GetSkillTries(SkillType.Sword) },
+            };
+
+            foreach (var skillType in before.Keys)
+            {
+                Assert.Equal(before[skillType], after[skillType]);
+            }
+        }
+
+        [Fact]
+        public void PlayerDoesNotGainSkillsWhenUsingAHealingRune()
+        {
+            var player = PlayerTestDataBuilder.BuildPlayer();
+            var targetPlayer = PlayerTestDataBuilder.BuildPlayer();
+
+            var itemAttirbuteListMock = new Mock<IItemAttributeList>();
+
+            itemAttirbuteListMock
+                .Setup(x => x.GetAttribute<bool>(It.IsAny<ItemAttribute>()))
+                .Returns(true);
+
+            itemAttirbuteListMock
+                .Setup(x => x.GetAttributeArray(It.IsAny<string>()))
+                .Returns(new dynamic[] { "0.0", "0.0" });
+
+            var itemTypeMock = new Mock<IItemType>();
+            itemTypeMock
+                .Setup(x => x.Attributes)
+                .Returns(itemAttirbuteListMock.Object);
+
+            var rune = new HealingRune(itemTypeMock.Object, new Location(100, 100, 7), new Dictionary<ItemAttribute, IConvertible>());
+
+            var before = new Dictionary<SkillType, byte>()
+            {
+                { SkillType.Axe, player.GetSkillTries(SkillType.Axe) },
+                { SkillType.Club, player.GetSkillTries(SkillType.Club) },
+                { SkillType.Distance, player.GetSkillTries(SkillType.Distance) },
+                { SkillType.Fishing, player.GetSkillTries(SkillType.Fishing) },
+                { SkillType.Fist, player.GetSkillTries(SkillType.Fist) },
+                { SkillType.Level, player.GetSkillTries(SkillType.Level) },
+                { SkillType.Magic, player.GetSkillTries(SkillType.Magic) },
+                { SkillType.Shielding, player.GetSkillTries(SkillType.Shielding) },
+                { SkillType.Speed, player.GetSkillTries(SkillType.Speed) },
+                { SkillType.Sword, player.GetSkillTries(SkillType.Sword) },
+            };
+
+            rune.Use(player, targetPlayer);
+
+            var after = new Dictionary<SkillType, byte>()
+            {
+                { SkillType.Axe, player.GetSkillTries(SkillType.Axe) },
+                { SkillType.Club, player.GetSkillTries(SkillType.Club) },
+                { SkillType.Distance, player.GetSkillTries(SkillType.Distance) },
+                { SkillType.Fishing, player.GetSkillTries(SkillType.Fishing) },
+                { SkillType.Fist, player.GetSkillTries(SkillType.Fist) },
+                { SkillType.Level, player.GetSkillTries(SkillType.Level) },
+                { SkillType.Magic, player.GetSkillTries(SkillType.Magic) },
+                { SkillType.Shielding, player.GetSkillTries(SkillType.Shielding) },
+                { SkillType.Speed, player.GetSkillTries(SkillType.Speed) },
+                { SkillType.Sword, player.GetSkillTries(SkillType.Sword) },
+            };
+
+            foreach (var skillType in before.Keys)
+            {
+                Assert.Equal(before[skillType], after[skillType]);
+            }
         }
     }
 }

--- a/tests/NeoServer.Game.Creatures.Tests/WalkableCreature/PlayerTest.cs
+++ b/tests/NeoServer.Game.Creatures.Tests/WalkableCreature/PlayerTest.cs
@@ -1,13 +1,18 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using Moq;
+using NeoServer.Extensions.Runes;
 using NeoServer.Game.Common.Contracts.Creatures;
+using NeoServer.Game.Common.Contracts.Items;
 using NeoServer.Game.Common.Contracts.World;
 using NeoServer.Game.Common.Contracts.World.Tiles;
 using NeoServer.Game.Common.Creatures;
+using NeoServer.Game.Common.Item;
 using NeoServer.Game.Common.Location;
 using NeoServer.Game.Common.Location.Structs;
 using NeoServer.Game.Creatures.Model.Players;
 using NeoServer.Game.DataStore;
+using NeoServer.Game.Items.Items.UsableItems.Runes;
 using NeoServer.Game.Tests;
 using NeoServer.Game.Tests.Helpers;
 using Xunit;
@@ -177,6 +182,125 @@ namespace NeoServer.Game.Creatures.Tests.WalkableCreature
             Assert.True(startedWalkingEvent);
             Assert.Equal(Direction.North, sut.GetNextStep());
             Assert.Equal(Direction.East, sut.GetNextStep());
+        }
+
+        [Fact]
+        public void PlayerDoesNotGainSkillsWhenUsingAnAttackRune()
+        {
+            var player = PlayerTestDataBuilder.BuildPlayer();
+            var targetPlayer = PlayerTestDataBuilder.BuildPlayer();
+
+            var itemAttirbuteListMock = new Mock<IItemAttributeList>();
+
+            itemAttirbuteListMock
+                .Setup(x => x.GetAttribute<bool>(It.IsAny<ItemAttribute>()))
+                .Returns(true);
+
+            itemAttirbuteListMock
+                .Setup(x => x.GetAttributeArray(It.IsAny<string>()))
+                .Returns(new dynamic[] { "0.0", "0.0" });
+
+            var itemTypeMock = new Mock<IItemType>();
+            itemTypeMock
+                .Setup(x => x.Attributes)
+                .Returns(itemAttirbuteListMock.Object);
+
+            var rune = new AttackRune(itemTypeMock.Object, new Location(100, 100, 7), (byte)10);
+
+            var before = new Dictionary<SkillType, byte>()
+            {
+                { SkillType.Axe, player.GetSkillTries(SkillType.Axe) },
+                { SkillType.Club, player.GetSkillTries(SkillType.Club) },
+                { SkillType.Distance, player.GetSkillTries(SkillType.Distance) },
+                { SkillType.Fishing, player.GetSkillTries(SkillType.Fishing) },
+                { SkillType.Fist, player.GetSkillTries(SkillType.Fist) },
+                { SkillType.Level, player.GetSkillTries(SkillType.Level) },
+                { SkillType.Magic, player.GetSkillTries(SkillType.Magic) },
+                { SkillType.Shielding, player.GetSkillTries(SkillType.Shielding) },
+                { SkillType.Speed, player.GetSkillTries(SkillType.Speed) },
+                { SkillType.Sword, player.GetSkillTries(SkillType.Sword) },
+            };
+
+            var result = rune.Use(player, targetPlayer, out var attackType);
+            Assert.True(result);
+
+            var after = new Dictionary<SkillType, byte>()
+            {
+                { SkillType.Axe, player.GetSkillTries(SkillType.Axe) },
+                { SkillType.Club, player.GetSkillTries(SkillType.Club) },
+                { SkillType.Distance, player.GetSkillTries(SkillType.Distance) },
+                { SkillType.Fishing, player.GetSkillTries(SkillType.Fishing) },
+                { SkillType.Fist, player.GetSkillTries(SkillType.Fist) },
+                { SkillType.Level, player.GetSkillTries(SkillType.Level) },
+                { SkillType.Magic, player.GetSkillTries(SkillType.Magic) },
+                { SkillType.Shielding, player.GetSkillTries(SkillType.Shielding) },
+                { SkillType.Speed, player.GetSkillTries(SkillType.Speed) },
+                { SkillType.Sword, player.GetSkillTries(SkillType.Sword) },
+            };
+
+            foreach (var skillType in before.Keys)
+            {
+                Assert.Equal(before[skillType], after[skillType]);
+            }
+        }
+
+        [Fact]
+        public void PlayerDoesNotGainSkillsWhenUsingAHealingRune()
+        {
+            var player = PlayerTestDataBuilder.BuildPlayer();
+            var targetPlayer = PlayerTestDataBuilder.BuildPlayer();
+
+            var itemAttirbuteListMock = new Mock<IItemAttributeList>();
+
+            itemAttirbuteListMock
+                .Setup(x => x.GetAttribute<bool>(It.IsAny<ItemAttribute>()))
+                .Returns(true);
+
+            itemAttirbuteListMock
+                .Setup(x => x.GetAttributeArray(It.IsAny<string>()))
+                .Returns(new dynamic[] { "0.0", "0.0" });
+
+            var itemTypeMock = new Mock<IItemType>();
+            itemTypeMock
+                .Setup(x => x.Attributes)
+                .Returns(itemAttirbuteListMock.Object);
+
+            var rune = new HealingRune(itemTypeMock.Object, new Location(100, 100, 7), new Dictionary<ItemAttribute, IConvertible>());
+
+            var before = new Dictionary<SkillType, byte>()
+            {
+                { SkillType.Axe, player.GetSkillTries(SkillType.Axe) },
+                { SkillType.Club, player.GetSkillTries(SkillType.Club) },
+                { SkillType.Distance, player.GetSkillTries(SkillType.Distance) },
+                { SkillType.Fishing, player.GetSkillTries(SkillType.Fishing) },
+                { SkillType.Fist, player.GetSkillTries(SkillType.Fist) },
+                { SkillType.Level, player.GetSkillTries(SkillType.Level) },
+                { SkillType.Magic, player.GetSkillTries(SkillType.Magic) },
+                { SkillType.Shielding, player.GetSkillTries(SkillType.Shielding) },
+                { SkillType.Speed, player.GetSkillTries(SkillType.Speed) },
+                { SkillType.Sword, player.GetSkillTries(SkillType.Sword) },
+            };
+
+            rune.Use(player, targetPlayer);
+
+            var after = new Dictionary<SkillType, byte>()
+            {
+                { SkillType.Axe, player.GetSkillTries(SkillType.Axe) },
+                { SkillType.Club, player.GetSkillTries(SkillType.Club) },
+                { SkillType.Distance, player.GetSkillTries(SkillType.Distance) },
+                { SkillType.Fishing, player.GetSkillTries(SkillType.Fishing) },
+                { SkillType.Fist, player.GetSkillTries(SkillType.Fist) },
+                { SkillType.Level, player.GetSkillTries(SkillType.Level) },
+                { SkillType.Magic, player.GetSkillTries(SkillType.Magic) },
+                { SkillType.Shielding, player.GetSkillTries(SkillType.Shielding) },
+                { SkillType.Speed, player.GetSkillTries(SkillType.Speed) },
+                { SkillType.Sword, player.GetSkillTries(SkillType.Sword) },
+            };
+
+            foreach (var skillType in before.Keys)
+            {
+                Assert.Equal(before[skillType], after[skillType]);
+            }
         }
     }
 }


### PR DESCRIPTION
Created unit tests checking if using runes grants skills. 
I suspect it may still happen despite the tests due to event subscribers and other like events, but this is at least one small step towards making sure that players do not gain skills by using runes.