### PR TITLE
Fix/spell create item

### DIFF
--- a/data/extensions/Items/Doors/LevelDoor.cs
+++ b/data/extensions/Items/Doors/LevelDoor.cs
@@ -62,7 +62,7 @@ namespace NeoServer.Extensions.Items.Doors
                 player.TeleportTo(Location.X, (ushort)(Location.Y + 1), Location.Z);
         }
 
-        public override string GetLookText(IInspectionTextBuilder inspectionTextBuilder, bool isClose = false)
+        public override string GetLookText(IInspectionTextBuilder inspectionTextBuilder, IPlayer player, bool isClose = false)
         {
             Metadata.Attributes.TryGetAttribute(ItemAttribute.ActionId, out int actionId);
 

--- a/data/extensions/Players/God.cs
+++ b/data/extensions/Players/God.cs
@@ -25,7 +25,7 @@ namespace NeoServer.Extensions.Players
         public override bool CanSeeInvisible => FlagIsEnabled(PlayerFlag.CanSeeInvisibility);
         public override bool CannotLogout => false;
         public override bool CanBeSeen => false;
-        public override bool CanSeeLookDetails => true;
+        public override bool CanSeeInspectionDetails => true;
 
         public override void GainExperience(uint exp)
         {

--- a/data/extensions/Players/God.cs
+++ b/data/extensions/Players/God.cs
@@ -25,6 +25,7 @@ namespace NeoServer.Extensions.Players
         public override bool CanSeeInvisible => FlagIsEnabled(PlayerFlag.CanSeeInvisibility);
         public override bool CannotLogout => false;
         public override bool CanBeSeen => false;
+        public override bool CanSeeLookDetails => true;
 
         public override void GainExperience(uint exp)
         {

--- a/data/extensions/Spells/Commands/ItemCreator.cs
+++ b/data/extensions/Spells/Commands/ItemCreator.cs
@@ -22,16 +22,12 @@ namespace NeoServer.Extensions.Spells.Commands
                 : 1;
 
             var item = Item(actor, amount);
+            var result = CreateItem(actor, item);
 
-            if (item is null) return false;
+            if (!result)
+                error = InvalidOperation.NotEnoughRoom;
 
-            if (actor is IPlayer player && player.Inventory.BackpackSlot is { } container &&
-                container.AddItem(item, true).Succeeded) return true;
-
-            if (actor.Tile is { } tile && tile.AddItem(item).Succeeded) return true;
-
-            error = InvalidOperation.NotEnoughRoom;
-            return false;
+            return result;
         }
 
         private IItem Item(ICombatActor actor, int amount)
@@ -44,6 +40,18 @@ namespace NeoServer.Extensions.Spells.Commands
                 new Dictionary<ItemAttribute, IConvertible> { { ItemAttribute.Count, amount } });
 
             return item;
+        }
+
+        private bool CreateItem(ICombatActor actor, IItem item)
+        {
+            if (item is null) return false;
+
+            if (!item.IsPickupable && actor.Tile is { } tile && tile.AddItem(item).Succeeded) return true;
+
+            if (item.IsPickupable && actor is IPlayer player && player.Inventory.BackpackSlot is { } container &&
+                container.AddItem(item, true).Succeeded) return true;
+
+            return false;
         }
     }
 }

--- a/src/Game/NeoServer.Game.Common/Contracts/Creatures/IPlayer.cs
+++ b/src/Game/NeoServer.Game.Common/Contracts/Creatures/IPlayer.cs
@@ -113,6 +113,7 @@ public interface IPlayer : ICombatActor, ISociableCreature
     event ChangeOnlineStatus OnChangedOnlineStatus;
     event Exhaust OnExhausted;
 
+    bool CanSeeLookDetails { get; }
     uint ChooseToRemoveFromKnownSet(); //todo: looks like implementation detail
 
     /// <summary>

--- a/src/Game/NeoServer.Game.Common/Contracts/Creatures/IPlayer.cs
+++ b/src/Game/NeoServer.Game.Common/Contracts/Creatures/IPlayer.cs
@@ -113,7 +113,7 @@ public interface IPlayer : ICombatActor, ISociableCreature
     event ChangeOnlineStatus OnChangedOnlineStatus;
     event Exhaust OnExhausted;
 
-    bool CanSeeLookDetails { get; }
+    bool CanSeeInspectionDetails { get; }
     uint ChooseToRemoveFromKnownSet(); //todo: looks like implementation detail
 
     /// <summary>

--- a/src/Game/NeoServer.Game.Common/Contracts/Inspection/IInspectionTextBuilder.cs
+++ b/src/Game/NeoServer.Game.Common/Contracts/Inspection/IInspectionTextBuilder.cs
@@ -1,16 +1,17 @@
 ﻿using System;
+using NeoServer.Game.Common.Contracts.Creatures;
 using NeoServer.Game.Common.Contracts.Items;
 
 namespace NeoServer.Game.Common.Contracts.Inspection;
 
 public interface IInspectionTextBuilder
 {
-    string Build(IThing thing, bool isClose = false);
+    string Build(IThing thing, IPlayer player, bool isClose = false);
     bool IsApplicable(IThing thing);
     public static string GetArticle(string name)
     {
         if (string.IsNullOrWhiteSpace(name)) return "a";
-        
+
         Span<char> vowels = stackalloc char[5] { 'a', 'e', 'i', 'o', 'u' };
         return vowels.Contains(name.ToLower()[0]) ? "an" : "a";
     }

--- a/src/Game/NeoServer.Game.Common/Contracts/Items/IThing.cs
+++ b/src/Game/NeoServer.Game.Common/Contracts/Items/IThing.cs
@@ -11,7 +11,7 @@ public interface IThing
 
     public byte Amount => 1;
 
-    string GetLookText(IInspectionTextBuilder inspectionTextBuilder, bool isClose = false);
+    string GetLookText(IInspectionTextBuilder inspectionTextBuilder, IPlayer player, bool isClose = false);
 
     public bool IsCloseTo(IThing thing)
     {

--- a/src/Game/NeoServer.Game.Creatures/Model/Bases/Creature.cs
+++ b/src/Game/NeoServer.Game.Creatures/Model/Bases/Creature.cs
@@ -59,7 +59,7 @@ public abstract class Creature : IEquatable<Creature>, ICreature
     public uint MaxHealthPoints { get; protected set; }
     public string Name => CreatureType.Name;
 
-    public string GetLookText(IInspectionTextBuilder inspectionTextBuilder, bool isClose = false)
+    public string GetLookText(IInspectionTextBuilder inspectionTextBuilder, IPlayer player, bool isClose = false)
     {
         return $"You see {(isClose ? CloseInspectionText : InspectionText)}";
     }

--- a/src/Game/NeoServer.Game.Creatures/Model/Players/Player.cs
+++ b/src/Game/NeoServer.Game.Creatures/Model/Players/Player.cs
@@ -226,6 +226,7 @@ public class Player : CombatActor, IPlayer
     public bool Recovering { get; private set; }
     public override bool CanSeeInvisible => FlagIsEnabled(PlayerFlag.CanSeeInvisibility);
     public override bool CanBeSeen => FlagIsEnabled(PlayerFlag.CanBeSeen);
+    public virtual bool CanSeeLookDetails => false;
 
     public ushort GetSkillLevel(SkillType skillType)
     {
@@ -385,12 +386,12 @@ public class Player : CombatActor, IPlayer
         switch (ArmorRating)
         {
             case > 3:
-            {
-                var min = ArmorRating / 2 * (Vocation.Formula?.Armor ?? 1f);
-                var max = (ArmorRating / 2 * 2 - 1) * (Vocation.Formula?.Armor ?? 1f);
-                damage -= (ushort)GameRandom.Random.NextInRange(min, max);
-                break;
-            }
+                {
+                    var min = ArmorRating / 2 * (Vocation.Formula?.Armor ?? 1f);
+                    var max = (ArmorRating / 2 * 2 - 1) * (Vocation.Formula?.Armor ?? 1f);
+                    damage -= (ushort)GameRandom.Random.NextInRange(min, max);
+                    break;
+                }
             case > 0:
                 --damage;
                 break;
@@ -542,7 +543,7 @@ public class Player : CombatActor, IPlayer
 
     public void Use(IUsable item)
     {
-        if(!item.IsCloseTo(this)) return;
+        if (!item.IsCloseTo(this)) return;
 
         item.Use(this);
     }
@@ -555,7 +556,7 @@ public class Player : CombatActor, IPlayer
             return;
         }
 
-        if(!item.IsCloseTo(this)) return;
+        if (!item.IsCloseTo(this)) return;
 
         if (item is IEquipmentRequirement requirement && !requirement.CanBeUsed(this))
         {
@@ -594,7 +595,7 @@ public class Player : CombatActor, IPlayer
             return;
         }
 
-        if(!item.IsCloseTo(this)) return;
+        if (!item.IsCloseTo(this)) return;
 
         if (item is IEquipmentRequirement requirement && !requirement.CanBeUsed(this))
         {
@@ -617,8 +618,8 @@ public class Player : CombatActor, IPlayer
             return Result.NotPossible;
         }
 
-        if(!item.IsCloseTo(this)) return Result.NotPossible;
-        
+        if (!item.IsCloseTo(this)) return Result.NotPossible;
+
         if (item is IEquipmentRequirement requirement && !requirement.CanBeUsed(this))
         {
             OperationFailService.Display(CreatureId, requirement.ValidationError);
@@ -671,7 +672,7 @@ public class Player : CombatActor, IPlayer
     public Result<OperationResult<IItem>> PickItemFromGround(IItem item, ITile tile, byte amount = 1) =>
         PlayerHand.PickItemFromGround(item, tile, amount);
 
-    public Result<OperationResult<IItem>> MoveItem(IItem item,IHasItem source, IHasItem destination, byte amount, byte fromPosition,
+    public Result<OperationResult<IItem>> MoveItem(IItem item, IHasItem source, IHasItem destination, byte amount, byte fromPosition,
         byte? toPosition) =>
         PlayerHand.Move(item, source, destination, amount, fromPosition, toPosition);
 

--- a/src/Game/NeoServer.Game.Creatures/Model/Players/Player.cs
+++ b/src/Game/NeoServer.Game.Creatures/Model/Players/Player.cs
@@ -226,7 +226,7 @@ public class Player : CombatActor, IPlayer
     public bool Recovering { get; private set; }
     public override bool CanSeeInvisible => FlagIsEnabled(PlayerFlag.CanSeeInvisibility);
     public override bool CanBeSeen => FlagIsEnabled(PlayerFlag.CanBeSeen);
-    public virtual bool CanSeeLookDetails => false;
+    public virtual bool CanSeeInspectionDetails => false;
 
     public ushort GetSkillLevel(SkillType skillType)
     {

--- a/src/Game/NeoServer.Game.Items/Bases/BaseItem.cs
+++ b/src/Game/NeoServer.Game.Items/Bases/BaseItem.cs
@@ -16,11 +16,11 @@ public abstract class BaseItem : IItem
     public IItemType Metadata { get; protected set; }
     public Location Location { get; set; }
 
-    public virtual string GetLookText(IInspectionTextBuilder inspectionTextBuilder, bool isClose = false)
+    public virtual string GetLookText(IInspectionTextBuilder inspectionTextBuilder, IPlayer player, bool isClose = false)
     {
         return inspectionTextBuilder is null
             ? $"You see {Metadata.Article} {Metadata.Name}"
-            : inspectionTextBuilder.Build(this, isClose);
+            : inspectionTextBuilder.Build(this, player, isClose);
     }
     public byte Amount { get; set; } = 1;
 

--- a/src/Game/NeoServer.Game.Items/Inspection/InspectionTextBuilder.cs
+++ b/src/Game/NeoServer.Game.Items/Inspection/InspectionTextBuilder.cs
@@ -60,7 +60,7 @@ public class InspectionTextBuilder : IInspectionTextBuilder
     private static void AddItemName(IItem item, IPlayer player, StringBuilder inspectionText)
     {
         if (player.CanSeeLookDetails)
-            inspectionText.AppendLine($"[ItemId: {item.ServerId}]");
+            inspectionText.AppendLine($"Id: [{item.ServerId}] - Pos: {item.Location}");
 
         inspectionText.Append("You see ");
         inspectionText.Append(item is ICumulative cumulative

--- a/src/Game/NeoServer.Game.Items/Inspection/InspectionTextBuilder.cs
+++ b/src/Game/NeoServer.Game.Items/Inspection/InspectionTextBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using System.Globalization;
 using System.Text;
+using NeoServer.Game.Common.Contracts.Creatures;
 using NeoServer.Game.Common.Contracts.DataStores;
 using NeoServer.Game.Common.Contracts.Inspection;
 using NeoServer.Game.Common.Contracts.Items;
@@ -15,14 +16,14 @@ public class InspectionTextBuilder : IInspectionTextBuilder
     {
         _vocationStore = vocationStore;
     }
-    
-    public string Build(IThing thing, bool isClose = false)
+
+    public string Build(IThing thing, IPlayer player, bool isClose = false)
     {
         if (thing is not IItem item) return string.Empty;
 
         var inspectionText = new StringBuilder();
 
-        AddItemName(item, inspectionText);
+        AddItemName(item, player, inspectionText);
         AddEquipmentAttributes(item, inspectionText);
         inspectionText.AppendLine();
         AddRequirement(item, inspectionText);
@@ -36,7 +37,6 @@ public class InspectionTextBuilder : IInspectionTextBuilder
     {
         return thing is IItem;
     }
-
 
     private void AddRequirement(IItem item, StringBuilder inspectionText)
     {
@@ -57,13 +57,16 @@ public class InspectionTextBuilder : IInspectionTextBuilder
                 $"{(item is ICumulative ? "They weigh" : "It weighs")} {pickupable.Weight.ToString("F", CultureInfo.InvariantCulture)} oz.");
     }
 
-    private static void AddItemName(IItem item, StringBuilder inspectionText)
+    private static void AddItemName(IItem item, IPlayer player, StringBuilder inspectionText)
     {
-        inspectionText.Append("You see ");
+        if (player.CanSeeLookDetails)
+            inspectionText.AppendLine($"[ItemId: {item.ServerId}]");
 
+        inspectionText.Append("You see ");
         inspectionText.Append(item is ICumulative cumulative
             ? $"{cumulative.Amount} {item.Name}{(cumulative.Amount > 1 ? "s" : "")}"
             : $"{item.Metadata.Article} {item.Name}");
+
     }
 
     private static void AddEquipmentAttributes(IItem item, StringBuilder inspectionText)

--- a/src/Game/NeoServer.Game.Items/Inspection/InspectionTextBuilder.cs
+++ b/src/Game/NeoServer.Game.Items/Inspection/InspectionTextBuilder.cs
@@ -59,7 +59,7 @@ public class InspectionTextBuilder : IInspectionTextBuilder
 
     private static void AddItemName(IItem item, IPlayer player, StringBuilder inspectionText)
     {
-        if (player.CanSeeLookDetails)
+        if (player.CanSeeInspectionDetails)
             inspectionText.AppendLine($"Id: [{item.ServerId}] - Pos: {item.Location}");
 
         inspectionText.Append("You see ");

--- a/src/Game/NeoServer.Game.Items/Items/LiquidPool.cs
+++ b/src/Game/NeoServer.Game.Items/Items/LiquidPool.cs
@@ -18,11 +18,11 @@ public struct LiquidPool : ILiquid
     public LiquidColor LiquidColor { get; }
     public Location Location { get; set; }
 
-    public string GetLookText(IInspectionTextBuilder inspectionTextBuilder, bool isClose = false)
+    public string GetLookText(IInspectionTextBuilder inspectionTextBuilder, IPlayer player, bool isClose = false)
     {
         return inspectionTextBuilder is null
             ? $"You see {Metadata.Article} {Metadata.Name}"
-            : inspectionTextBuilder.Build(this, isClose);
+            : inspectionTextBuilder.Build(this, player, isClose);
     }
 
 

--- a/src/Game/NeoServer.Game.Items/Items/MagicField.cs
+++ b/src/Game/NeoServer.Game.Items/Items/MagicField.cs
@@ -24,11 +24,11 @@ public struct MagicField : IItem, IMagicField
 
     public Location Location { get; set; }
 
-    public string GetLookText(IInspectionTextBuilder inspectionTextBuilder, bool isClose = false)
+    public string GetLookText(IInspectionTextBuilder inspectionTextBuilder, IPlayer player, bool isClose = false)
     {
         return inspectionTextBuilder is null
             ? $"You see {Metadata.Article} {Metadata.Name}"
-            : inspectionTextBuilder.Build(this, isClose);
+            : inspectionTextBuilder.Build(this, player, isClose);
     }
 
     public IItemType Metadata { get; }

--- a/src/Game/NeoServer.Game.Items/Items/Sign.cs
+++ b/src/Game/NeoServer.Game.Items/Items/Sign.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using NeoServer.Game.Common.Contracts.Creatures;
 using NeoServer.Game.Common.Contracts.Inspection;
 using NeoServer.Game.Common.Contracts.Items;
 using NeoServer.Game.Common.Item;
@@ -20,9 +21,9 @@ public class Sign : BaseItem, ISign
 
     public string Text { get; }
 
-    public override string GetLookText(IInspectionTextBuilder inspectionTextBuilder, bool isClose = false)
+    public override string GetLookText(IInspectionTextBuilder inspectionTextBuilder, IPlayer player, bool isClose = false)
     {
-        var lookText = base.GetLookText(inspectionTextBuilder, isClose);
+        var lookText = base.GetLookText(inspectionTextBuilder, player, isClose);
 
         return string.IsNullOrWhiteSpace(Text) ? lookText : $"{lookText} You read: {Text}";
     }

--- a/src/Game/NeoServer.Game.Items/Items/TeleportItem.cs
+++ b/src/Game/NeoServer.Game.Items/Items/TeleportItem.cs
@@ -30,11 +30,11 @@ public struct TeleportItem : ITeleport, IItem
 
     public Location Location { get; set; }
 
-    public string GetLookText(IInspectionTextBuilder inspectionTextBuilder, bool isClose = false)
+    public string GetLookText(IInspectionTextBuilder inspectionTextBuilder, IPlayer player, bool isClose = false)
     {
         return inspectionTextBuilder is null
             ? $"You see {Metadata.Article} {Metadata.Name}."
-            : inspectionTextBuilder.Build(this, isClose);
+            : inspectionTextBuilder.Build(this, player, isClose);
     }
 
     public bool HasDestination => Destination != Location.Zero;

--- a/src/Game/NeoServer.Game.World/Models/Tiles/BaseTile.cs
+++ b/src/Game/NeoServer.Game.World/Models/Tiles/BaseTile.cs
@@ -108,7 +108,7 @@ public abstract class BaseTile : ITile
 
     public Location Location { get; set; }
     public string Name { get; }
-    public string GetLookText(IInspectionTextBuilder inspectionTextBuilder, bool isClose = false)
+    public string GetLookText(IInspectionTextBuilder inspectionTextBuilder, IPlayer player, bool isClose = false)
     {
         return string.Empty;
     }

--- a/src/NeoServer.Server.Standalone/Properties/launchSettings.json
+++ b/src/NeoServer.Server.Standalone/Properties/launchSettings.json
@@ -4,7 +4,8 @@
       "commandName": "Project",
       "environmentVariables": {
         "ENVIRONMENT": "Local"
-      }
+      },
+      "nativeDebugging": true
     }
   }
 }

--- a/src/Server/NeoServer.Server.Events/Player/PlayerLookedAtEventHandler.cs
+++ b/src/Server/NeoServer.Server.Events/Player/PlayerLookedAtEventHandler.cs
@@ -24,7 +24,7 @@ public class PlayerLookedAtEventHandler
 
         var inspectionTextBuilder = GetInspectionTextBuilder(thing);
 
-        var text = thing.GetLookText(inspectionTextBuilder, isClose);
+        var text = thing.GetLookText(inspectionTextBuilder, player, isClose);
 
         connection.OutgoingPackets.Enqueue(new TextMessagePacket(text, TextMessageOutgoingType.Description));
         connection.Send();


### PR DESCRIPTION
## O Que?

- Corrigido [bug da spell /i](https://trello.com/c/BM3yqIkm/48-adicionar-regra-para-quando-criar-itens-i-verificar-se-%C3%A9-um-item-que-pode-ser-jogado-dentro-da-bp-ou-se-ser%C3%A1-criado-no-cen%C3%A1rio-e) que adiciona qualquer tipo de item no inventario
- Adicionado ItemId no look dos itens quando player eh good

## Por que?

- [Look] : Ideia eh facilitar a identificação do item