### PR TITLE
feat: add docker-compose to up database and portal admin

### DIFF
--- a/src/docker-compose.Mongo.yaml
+++ b/src/docker-compose.Mongo.yaml
@@ -1,0 +1,18 @@
+version: "3.9"
+services:
+  db:
+    image: mongo:4.4
+    ports:
+      - "27017:27017"
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: root
+      MONGO_INITDB_ROOT_PASSWORD: root  
+  painel-admin:
+    image: mongo-express
+    restart: always
+    ports:
+      - "8081:8081"
+    environment:
+      ME_CONFIG_MONGODB_ADMINUSERNAME: root
+      ME_CONFIG_MONGODB_ADMINPASSWORD: root
+      ME_CONFIG_MONGODB_URL: mongodb://root:root@mongo:27017/

--- a/src/docker-compose.Mongo.yaml
+++ b/src/docker-compose.Mongo.yaml
@@ -6,7 +6,8 @@ services:
       - "27017:27017"
     environment:
       MONGO_INITDB_ROOT_USERNAME: root
-      MONGO_INITDB_ROOT_PASSWORD: root  
+      MONGO_INITDB_ROOT_PASSWORD: root
+
   painel-admin:
     image: mongo-express
     restart: always

--- a/src/docker-compose.Mysql.yaml
+++ b/src/docker-compose.Mysql.yaml
@@ -1,0 +1,17 @@
+version: "3.9"
+services:
+  db:
+    image: mysql:latest
+    ports:
+      - "3306:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_DATABASE: neo
+  painel-admin:
+    image: phpmyadmin:latest
+    restart: always
+    ports:
+      - "80:8080"
+    environment:
+      PMA_PASSWORD: root
+      PMA_USER: root

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3.9"
+services:
+  db:
+    networks:
+      - internal
+  painel-admin:
+    networks:
+      - internal
+
+networks:
+  internal:
+    name: internal
+    driver: bridge

--- a/src/docker-compose.yaml
+++ b/src/docker-compose.yaml
@@ -3,6 +3,7 @@ services:
   db:
     networks:
       - internal
+
   painel-admin:
     networks:
       - internal


### PR DESCRIPTION
Goal: add docker-compose to up database and portal admin with specific infrastructure.

How run:  **docker-compose -f docker-compose.yaml -f docker-compose.Mongo.yaml  up -d**

![image](https://user-images.githubusercontent.com/17841549/178765018-b4ed81aa-3ff6-4be3-9cf4-4a6df3528126.png)

![image](https://user-images.githubusercontent.com/17841549/178765148-615a565a-cdf0-4912-a267-c2250e4703b0.png)
