### PR TITLE
Fixed window size when changed

### DIFF
--- a/src/NetworkingServer/NeoServer.Networking.Packets/Outgoing/Map/MapPartialDescriptionPacket.cs
+++ b/src/NetworkingServer/NeoServer.Networking.Packets/Outgoing/Map/MapPartialDescriptionPacket.cs
@@ -87,22 +87,22 @@ public class MapPartialDescriptionPacket : OutgoingPacket
             case Direction.East:
                 newLocation.X = (ushort)(toLocation.X + MapViewPort.MaxClientViewPortX + 1);
                 newLocation.Y = (ushort)(toLocation.Y - MapViewPort.MaxClientViewPortY);
-                height = 14;
+                height = MapConstants.DEFAULT_MAP_WINDOW_SIZE_Y;
                 break;
             case Direction.West:
                 newLocation.X = (ushort)(toLocation.X - MapViewPort.MaxClientViewPortX);
                 newLocation.Y = (ushort)(toLocation.Y - MapViewPort.MaxClientViewPortY);
-                height = 14;
+                height = MapConstants.DEFAULT_MAP_WINDOW_SIZE_Y;
                 break;
             case Direction.North:
                 newLocation.X = (ushort)(fromLocation.X - MapViewPort.MaxClientViewPortX);
                 newLocation.Y = (ushort)(toLocation.Y - MapViewPort.MaxClientViewPortY);
-                width = 18;
+                width = MapConstants.DEFAULT_MAP_WINDOW_SIZE_X;
                 break;
             case Direction.South:
                 newLocation.X = (ushort)(fromLocation.X - MapViewPort.MaxClientViewPortX);
                 newLocation.Y = (ushort)(toLocation.Y + MapViewPort.MaxClientViewPortY + 1);
-                width = 18;
+                width = MapConstants.DEFAULT_MAP_WINDOW_SIZE_X;
                 break;
         }
 


### PR DESCRIPTION
Problem: When window size is changed to send more packets the partitial description (usually when you walk in a direction) is not updated to correct value.
Resolution: Use the same reference as when you send fullmap