### PR TITLE
fix: reset cursor in network message

### DIFF
--- a/src/NetworkingServer/NeoServer.Networking.Packets/Messages/NetworkMessage.cs
+++ b/src/NetworkingServer/NeoServer.Networking.Packets/Messages/NetworkMessage.cs
@@ -28,6 +28,12 @@ public class NetworkMessage : ReadOnlyNetworkMessage, INetworkMessage
         _cursor = length;
     }
 
+    public override void Reset()
+    {
+        base.Reset();
+        _cursor = 0;
+    }
+
     /// <summary>
     ///     Inserts a location point on the buffer
     /// </summary>

--- a/src/NetworkingServer/NeoServer.Networking.Packets/Messages/ReadOnlyNetworkMessage.cs
+++ b/src/NetworkingServer/NeoServer.Networking.Packets/Messages/ReadOnlyNetworkMessage.cs
@@ -116,7 +116,7 @@ public class ReadOnlyNetworkMessage : IReadOnlyNetworkMessage
         BytesRead = 0;
     }
 
-    public void Reset()
+    public virtual void Reset()
     {
         Buffer = new byte[16394];
         BytesRead = 0;


### PR DESCRIPTION
Error after some messages reset:
![image](https://github.com/caioavidal/OpenCoreMMO/assets/17263249/b551f596-0990-4d3b-b3ca-fa82a5501e2c)

Correction:
![image](https://github.com/caioavidal/OpenCoreMMO/assets/17263249/45839802-4e81-4849-82a3-84b8ca5b1ca5)
