### PR TITLE
Fix monster targeting a player's summon but not attacking

### DIFF
--- a/src/Core/NeoServer.Domain/Combat/Validations/AttackValidation.cs
+++ b/src/Core/NeoServer.Domain/Combat/Validations/AttackValidation.cs
@@ -1,3 +1,4 @@
+using System.Runtime.Versioning;
 using NeoServer.Domain.Common;
 using NeoServer.Domain.Common.Combat.Enums;
 using NeoServer.Domain.Common.Combat.Structs;
@@ -21,16 +22,11 @@ public class AttackValidation(IMapTool mapTool, IMap map, PvPConfiguration pvpCo
 
         if (Guard.IsNull(aggressor))
             return Result.NotPossible;
-
+        
         switch (target)
         {
             case IPlayer targetPlayer:
             {
-                if (targetPlayer.Group.FlagIsEnabled(PlayerFlag.CannotBeAttacked) && targetPlayer != aggressor)
-                    return Result.Fail(InvalidOperation.YouMayNotAttackThisPlayer);
-
-                if (targetPlayer.Tile.NoPvpZone) return Result.Fail(InvalidOperation.NotPermittedInNoPvpZone);
-
                 switch (aggressor)
                 {
                     //Player cannot attack a player
@@ -70,7 +66,7 @@ public class AttackValidation(IMapTool mapTool, IMap map, PvPConfiguration pvpCo
                         return Result.Fail(InvalidOperation.NotPermittedInNoPvpZone);
                     //Monster cannot attack another monster or summons monster
                     case IMonster monsterAggressor
-                        when monsterTarget is ISummon { Master: IMonster } || monsterAggressor is not ISummon:
+                        when monsterTarget is ISummon { Master: IMonster }:
                         return Result.Fail(InvalidOperation.YouMayNotAttackThisCreature);
                 }
 

--- a/tests/NeoServer.Domain.Tests/Helpers/MonsterTestDataBuilder.cs
+++ b/tests/NeoServer.Domain.Tests/Helpers/MonsterTestDataBuilder.cs
@@ -46,8 +46,7 @@ public static class MonsterTestDataBuilder
             ]
         };
 
-        monsterType.Flags.AddOrUpdate(CreatureFlagAttribute.Hostile, isHostile ? (ushort)1 : (ushort)0);
-
+        monsterType.Flags[CreatureFlagAttribute.Hostile] = (ushort)(isHostile ? 1 : 0);
         return new Monster(monsterType, mapTool, spawnPoint);
     }
 

--- a/tests/NeoServer.Domain.Tests/Systems/Combat/SummonCombatTest.cs
+++ b/tests/NeoServer.Domain.Tests/Systems/Combat/SummonCombatTest.cs
@@ -1,0 +1,35 @@
+using NeoServer.Domain.Tests.Helpers;
+using NeoServer.Domain.Tests.Helpers.Map;
+using NeoServer.Domain.Tests.Helpers.Player;
+using NeoServer.Domain.Tests.Helpers.Services;
+using NeoServer.Domain.World.Models.Tiles;
+
+namespace NeoServer.Domain.Tests.Systems.Combat;
+
+public class SummonCombatTest
+{
+    [Fact]
+    public void Player_summon_is_injured_when_attacked_by_a_monster()
+    {
+        //arrange
+
+        var map = MapTestDataBuilder.Build(100, 102, 100, 102, 7, 7);
+
+        var monster = MonsterTestDataBuilder.Build(9000);
+
+        var master = PlayerTestDataBuilder.Build();
+        var summon = MonsterTestDataBuilder.BuildSummon(master, 4000, 5000);
+
+        (map[100, 100, 7] as DynamicTile)?.AddCreature(monster);
+        (map[101, 100, 7] as DynamicTile)?.AddCreature(master);
+        (map[100, 101, 7] as DynamicTile)?.AddCreature(summon);
+
+        var monsterCombatService = MonsterCombatServiceTestBuilder.Build(map);
+
+        //act
+        monsterCombatService.Attack(monster, summon);
+
+        //assert
+        summon.HealthPoints.Should().BeLessThan(summon.MaxHealthPoints);
+    }
+}


### PR DESCRIPTION
### Description
Fix Monster is targeting a player's summon but not attacking

Fix issue #756

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down
