### PR TITLE
Add MinVersion to support protocol 10.97 and 10.98

### DIFF
--- a/src/ApplicationServer/NeoServer.Server/Configurations/ServerConfiguration.cs
+++ b/src/ApplicationServer/NeoServer.Server/Configurations/ServerConfiguration.cs
@@ -14,6 +14,7 @@ public enum DatabaseType
 [SuppressMessage("ReSharper", "InconsistentNaming")]
 public record ServerConfiguration(
     int Version,
+    int MinVersion,
     string OTBM,
     string OTB,
     string Data,

--- a/src/NetworkingServer/NeoServer.Networking.Handlers/ClientVersion/ClientProtocolVersion.cs
+++ b/src/NetworkingServer/NeoServer.Networking.Handlers/ClientVersion/ClientProtocolVersion.cs
@@ -16,7 +16,7 @@ public class ClientProtocolVersion
 
     public bool IsSupported(uint version)
     {
-        if (version == _serverConfiguration.Version) return true;
+        if (version >= _serverConfiguration.MinVersion && version <= _serverConfiguration.Version) return true;
 
         _logger.Warning("Client protocol version {Version} is not supported", version);
         return false;

--- a/src/NetworkingServer/NeoServer.Networking.Handlers/LogIn/PlayerLogInHandler.cs
+++ b/src/NetworkingServer/NeoServer.Networking.Handlers/LogIn/PlayerLogInHandler.cs
@@ -159,7 +159,7 @@ public class PlayerLogInHandler : PacketHandler
             return false;
         }
 
-        if (_serverConfiguration.Version != packet.Version)
+        if (packet.Version < _serverConfiguration.MinVersion || packet.Version > _serverConfiguration.Version)
         {
             Disconnect(connection, $"Only clients with protocol {_serverConfiguration.Version} allowed!");
             return false;

--- a/src/Standalone/IoC/Modules/ConfigurationInjection.cs
+++ b/src/Standalone/IoC/Modules/ConfigurationInjection.cs
@@ -29,7 +29,7 @@ public static class ConfigurationInjection
         IConfigurationRoot configuration)
     {
         ServerConfiguration serverConfiguration =
-            new(0, null, null, null, string.Empty, string.Empty, string.Empty, 7171, 7172, false,
+            new(0,0, null, null, null, string.Empty, string.Empty, string.Empty, 7171, 7172, false,
                 new SaveConfiguration(3600));
         GameConfiguration gameConfiguration = new();
         LogConfiguration logConfiguration = new(null);
@@ -61,6 +61,7 @@ public static class ConfigurationInjection
 
         serverConfiguration = new ServerConfiguration(
             serverConfiguration.Version,
+            serverConfiguration.MinVersion,
             serverConfiguration.OTBM,
             serverConfiguration.OTB,
             serverConfiguration.Data,

--- a/src/Standalone/appsettings.json
+++ b/src/Standalone/appsettings.json
@@ -1,8 +1,9 @@
 {
   "server": {
     "version": 1098,
+    "minVersion": 1097,
     "otb": "items.otb",
-    "otbm": "example.otbm",
+    "otbm": "small.otbm",
     "data": "data",
     "extensions": "extensions",
     "serverName": "OpenCore",


### PR DESCRIPTION
### Description
Add MinVersion to support protocol 10.97 and 10.98
close #807 

### Key Changes
Original client sends 10.97 protocol on both client 10.97 and 10.98

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down
