### PR TITLE
fix: Player direction being set to none

### DIFF
--- a/src/Core/NeoServer.Domain/Creatures/Models/Bases/Creature.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Models/Bases/Creature.cs
@@ -264,8 +264,9 @@ public abstract class Creature : IEquatable<Creature>, ICreature
 
     protected void SetDirection(Direction direction)
     {
+        if(direction == Direction.None) return;
         // LastDirection should only remember actual directions, so we're ignoring 'none'.
-        LastDirection = Direction == Direction.None ? LastDirection : Direction;
+        LastDirection =  Direction;
         Direction = direction;
     }
 

--- a/tests/NeoServer.Domain.Tests/Creature/Players/PlayerTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Players/PlayerTests.cs
@@ -5,11 +5,13 @@ using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Common.Contracts.World;
 using NeoServer.Domain.Common.Creatures;
 using NeoServer.Domain.Common.Item;
+using NeoServer.Domain.Common.Location;
 using NeoServer.Domain.Common.Location.Structs;
 using NeoServer.Domain.Creatures.Player;
 using NeoServer.Domain.Creatures.Player.Modes;
 using NeoServer.Domain.Creatures.Player.Outfit;
 using NeoServer.Domain.Creatures.Player.Vocation;
+using NeoServer.Domain.Tests.Helpers.Map;
 using NeoServer.Domain.Tests.Helpers.Player;
 
 namespace NeoServer.Domain.Tests.Creature.Players;
@@ -193,5 +195,22 @@ public class PlayerTests
 
         var actual = sut.KnowsCreatureWithId(knownCreature);
         actual.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Player_direction_cannot_be_set_to_none()
+    {
+        //arrange
+        var sut = PlayerTestDataBuilder.Build();
+        sut.TurnTo(Direction.North);
+        
+        var fromTile = MapTestDataBuilder.CreateTile(new Location(100,100,7));
+        var toTile = MapTestDataBuilder.CreateTile(new Location(100,100,8));
+        
+        //act
+        sut.OnMoved(fromTile, toTile, []);
+        
+        //assert
+        sut.Direction.Should().Be(Direction.North);
     }
 }


### PR DESCRIPTION
### Description
Fixed an issue where player direction could be incorrectly set to `Direction.None`, which was causing problems in creature movement logic. The fix ensures that `Direction.None` is ignored when setting the direction, preserving the last valid direction.

### Key Changes
- Modified `SetDirection` method in `Creature.cs` to return early if `direction == Direction.None`
- Updated `LastDirection` assignment logic to always use the current `Direction` before changing it
- Added a unit test in `PlayerTests.cs` to verify that player direction cannot be set to none during movement

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
Added test `Player_direction_cannot_be_set_to_none()` which verifies that when a player moves between tiles, their direction remains the last valid direction (North in the test case) and is not set to `Direction.None`.