### PR TITLE
Refine PvP combat logic and add summon attack tests

### DIFF
--- a/src/Core/NeoServer.Domain/Combat/Attacks/AttackService.cs
+++ b/src/Core/NeoServer.Domain/Combat/Attacks/AttackService.cs
@@ -11,6 +11,7 @@ using NeoServer.Domain.Common.Item;
 using NeoServer.Domain.Common.Results;
 using NeoServer.Domain.Common.Services;
 using NeoServer.Domain.Creatures.Models.Bases;
+using NeoServer.Domain.Creatures.Monster.Summon;
 using NeoServer.Domain.Creatures.Player.Modes;
 using Serilog;
 
@@ -75,7 +76,15 @@ public class AttackService(
         var pvpCombatValidationResult = ValidatePvpCombat(attackInput);
         if (pvpCombatValidationResult.Failed) return CombatResult.Fail(pvpCombatValidationResult);
 
-        playerSkullService.UpdateSkullOnAttack(attackInput.Aggressor as IPlayer, attackInput.Target as IPlayer);
+        // Update skull for direct player attacks or attacks on player summons
+        var targetPlayer = attackInput.Target switch
+        {
+            IPlayer player => player,
+            Summon { Master: IPlayer master } => master,
+            _ => null
+        };
+        
+        playerSkullService.UpdateSkullOnAttack(attackInput.Aggressor as IPlayer, targetPlayer);
 
         if (!DistanceAttackValidator.IsValid(attackInput))
             return CombatResult.Fail(Result.Fail(InvalidOperation.TooFar));
@@ -126,12 +135,27 @@ public class AttackService(
     private Result ValidatePvpCombat(AttackInput attackInput)
     {
         if (Equals(attackInput.Aggressor, attackInput.Target)) return Result.Success;
-        if (attackInput.Aggressor is not IPlayer playerAggressor ||
-            attackInput.Target is not IPlayer playerTarget)
-            //not pvp combat
+        
+        if (attackInput.Aggressor is not IPlayer playerAggressor)
             return Result.Success;
 
-        var targetHasSkull = playerTarget?.GetSkull(playerAggressor) is not Skull.None;
+        // Check if attacking own summon - allow regardless of secure mode
+        if (attackInput.Target is Summon { Master: IPlayer summonMaster } && 
+            playerAggressor.Equals(summonMaster))
+            return Result.Success;
+
+        // Get the target player - either direct attack or attack on player's summon
+        var playerTarget = attackInput.Target switch
+        {
+            IPlayer player => player,
+            Summon { Master: IPlayer master } => master,
+            _ => null
+        };
+
+        // If no player is involved as target, it's not pvp combat
+        if (playerTarget is null) return Result.Success;
+
+        var targetHasSkull = playerTarget.GetSkull(playerAggressor) is not Skull.None;
 
         var tryingToAttackWithPvpDisabled = !targetHasSkull && playerAggressor.SecureMode is PvpSecureMode.PvPDisabled;
 
@@ -139,10 +163,14 @@ public class AttackService(
         {
             playerAggressor.StopAttack(true);
 
-            OperationFailService.Send(playerAggressor,
-                InvalidOperation.AdjustCombatSettingsToAttackPlayer);
+            // Use different message for summon attacks vs direct player attacks
+            var operation = attackInput.Target is Summon 
+                ? InvalidOperation.AdjustCombatSettingsToAttackCreature 
+                : InvalidOperation.AdjustCombatSettingsToAttackPlayer;
 
-            return Result.Fail(InvalidOperation.AdjustCombatSettingsToAttackPlayer);
+            OperationFailService.Send(playerAggressor, operation);
+
+            return Result.Fail(operation);
         }
 
         return Result.Success;

--- a/src/Core/NeoServer.Domain/Combat/Validations/AttackValidation.cs
+++ b/src/Core/NeoServer.Domain/Combat/Validations/AttackValidation.cs
@@ -66,6 +66,12 @@ public class AttackValidation(IMapTool mapTool, IMap map, PvPConfiguration pvpCo
                                           master.Equals(summonMaster) && !combatConfiguration.CanAttackOwnSummon:
                         return Result.Fail(InvalidOperation.YouMayNotAttackThisCreature);
                     
+                    //Player cannot attack another player's summon if protection level applies
+                    case IPlayer playerAggressor when monsterTarget is Summon { Master: IPlayer summonMaster } &&
+                                                   !playerAggressor.Equals(summonMaster) &&
+                                                   IsProtected(playerAggressor, summonMaster):
+                        return Result.Fail(InvalidOperation.YouMayNotAttackThisCreature);
+                    
                     //Player cannot attack a monster
                     case IPlayer playerAggressor
                         when playerAggressor.Group.FlagIsEnabled(PlayerFlag.CannotAttackMonster):

--- a/src/Core/NeoServer.Domain/Common/InvalidOperation.cs
+++ b/src/Core/NeoServer.Domain/Common/InvalidOperation.cs
@@ -41,6 +41,7 @@ public enum InvalidOperation
     NotEnoughMagicLevel,
     PremiumTimeIsRequired,
     AdjustCombatSettingsToAttackPlayer,
+    AdjustCombatSettingsToAttackCreature,
     SpellNeedsWeapon,
     SpellRequiresPremium,
     CanOnlyUseOnCreatures,

--- a/src/NetworkingServer/NeoServer.Networking.Packets/Outgoing/TextMessageOutgoingParser.cs
+++ b/src/NetworkingServer/NeoServer.Networking.Packets/Outgoing/TextMessageOutgoingParser.cs
@@ -26,6 +26,7 @@ public static class TextMessageOutgoingParser
             InvalidOperation.NotPermittedInProtectionZone => TextConstants.NOT_PERMITTED_IN_PROTECTION_ZONE,
             InvalidOperation.PlayerLocationInvalid => "Player location is invalid.",
             InvalidOperation.AdjustCombatSettingsToAttackPlayer => "Adjust your combat settings to attack this person.",
+            InvalidOperation.AdjustCombatSettingsToAttackCreature => "Adjust your combat settings to attack this creature.",
             InvalidOperation.SpellNeedsWeapon => "You need to equip a weapon to use this spell.",
             InvalidOperation.PremiumTimeIsRequired => "Premium time is required.",
             InvalidOperation.SpellRequiresPremium => "Premium time is required to use this spell.",

--- a/tests/NeoServer.Domain.Tests/Creature/SkullTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/SkullTests.cs
@@ -1,0 +1,45 @@
+using NeoServer.Domain.Combat;
+using NeoServer.Domain.Common;
+using NeoServer.Domain.Common.Combat.Enums;
+using NeoServer.Domain.Common.Combat.Structs;
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Combat.Attacks;
+using NeoServer.Domain.Combat.Player;
+using NeoServer.Domain.Creatures.Player.Modes;
+using NeoServer.Domain.Tests.Helpers;
+using NeoServer.Domain.Tests.Helpers.Map;
+using NeoServer.Domain.Tests.Helpers.Player;
+using NeoServer.Domain.Tests.Helpers.Services;
+using NeoServer.Domain.World.Models.Tiles;
+
+namespace NeoServer.Domain.Tests.Creature;
+
+public class SkullTests
+{
+    [Fact]
+    [Trait("Category", "Skull")]
+    public void Player_gets_white_skull_when_attacking_summon_of_another_player()
+    {
+        // Arrange
+        var map = MapTestDataBuilder.Build(100, 110, 100, 110, 7, 7);
+        var attackService = AttackServiceTestBuilder.Build(map, PvpType.OpenPvP);
+
+        var aggressor = PlayerTestDataBuilder.Build(id: 1, name: "Aggressor");
+        aggressor.ChangeSecureMode(PvpSecureMode.PvPEnabled);
+        (map[100, 100, 7] as DynamicTile)?.AddCreature(aggressor);
+
+        var summonMaster = PlayerTestDataBuilder.Build(id: 2, name: "SummonMaster");
+
+        var summon = MonsterTestDataBuilder.BuildSummon(summonMaster);
+        (map[100, 101, 7] as DynamicTile)?.AddCreature(summon);
+
+        var attackInput = new AttackInput(aggressor, summon, PlayerCombatParameterBuilder.Build(aggressor, summon));
+
+        // Act
+        attackService.Execute(attackInput);
+
+        // Assert
+        aggressor.Skull.Should().Be(Skull.White);
+        summonMaster.Skull.Should().Be(Skull.None);
+    }
+}


### PR DESCRIPTION
### Description
This pull request refines the PvP combat logic to properly handle cases of players attacking another player's summon. It also adjusts validation messages relating to secure mode. Additionally, a unit test is added for the scenario where a player receives a white skull when attacking another player's summon.

### Key Changes
- Refined PvP combat logic to address summon attacks.
- Updated secure mode validation messages for clarity.
- Added a unit test for white skull mechanics involving summon attacks.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
- Verified that the unit test for white skull mechanics involving summon attacks passes.
- Conducted additional PvP scenarios to ensure the refined combat logic functions as expected.