### PR TITLE
Prevent logout near hostile monsters and adjust logout blocking

### DIFF
--- a/src/ApplicationServer/NeoServer.Server.Routines/Creatures/Player/PlayerStatusRoutine.cs
+++ b/src/ApplicationServer/NeoServer.Server.Routines/Creatures/Player/PlayerStatusRoutine.cs
@@ -2,10 +2,11 @@ using System;
 using NeoServer.Domain.Common;
 using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Server.Common.Contracts;
 
 namespace NeoServer.Server.Routines.Creatures.Player;
 
-public class PlayerStatusRoutine(GameConfiguration gameConfiguration) : IRoutine
+public class PlayerStatusRoutine(GameConfiguration gameConfiguration, IGameServer gameServer) : IRoutine
 {
     public void Execute(IPlayer player)
     {
@@ -20,7 +21,33 @@ public class PlayerStatusRoutine(GameConfiguration gameConfiguration) : IRoutine
         var passedTicks = DateTime.UtcNow.Ticks - logoutBlockCondition.StartedAt;
         var milliseconds = new TimeSpan(passedTicks).TotalMilliseconds;
 
-        if (milliseconds >= gameConfiguration.LogoutBlockDuration) player.RemoveLogoutBlock();
+        if (milliseconds >= gameConfiguration.LogoutBlockDuration)
+        {
+            // Check if there are hostile monsters nearby before removing logout block
+            if (HasHostileMonstersNearby(player))
+            {
+                // Reset the logout block condition to extend its duration
+                logoutBlockCondition.Start(player);
+                return;
+            }
+
+            player.RemoveLogoutBlock();
+        }
+    }
+
+    private bool HasHostileMonstersNearby(IPlayer player)
+    {
+        var spectators = gameServer.Map.GetSpectators(player.Location);
+
+        foreach (var spectator in spectators)
+        {
+            if (spectator is IMonster monster && monster.IsHostileTo(player))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     private void RemoveProtectionZoneBlockIfExpired(IPlayer player)


### PR DESCRIPTION
### Description
Added a fix to prevent players from logging out when hostile monsters are nearby. Extended the logout block duration dynamically if necessary.

### Key Changes
- Implemented a check to detect hostile monsters in proximity.
- Adjusted logout block duration based on nearby hostile threats.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
Add test cases for scenarios involving logout attempts while hostile monsters are close by. Ensure logout block duration properly adjusts as required.