### PR TITLE
Refactor and fix player flag handling with updates to logic

### DIFF
--- a/data/extensions/Spells/Commands/BanPlayerCommand.cs
+++ b/data/extensions/Spells/Commands/BanPlayerCommand.cs
@@ -2,6 +2,7 @@
 using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Common.Contracts.Items;
 using NeoServer.Domain.Common.Results;
+using NeoServer.Domain.Creatures.Player;
 using NeoServer.Domain.Spells.Entities;
 using NeoServer.Server.Commands.Player;
 using NeoServer.Server.Common.Contracts;
@@ -26,6 +27,9 @@ public class BanPlayerCommand : CommandSpell
             return Result.NotApplicable;
 
         if (player is null || player.CreatureId == caster.CreatureId)
+            return Result.NotApplicable;
+
+        if (player.Group.FlagIsEnabled(PlayerFlag.CannotBeBanned))
             return Result.NotApplicable;
 
         var reason = Params[1]?.ToString() ?? BANISH_REASON;

--- a/data/extensions/Spells/Commands/InfoCommand.cs
+++ b/data/extensions/Spells/Commands/InfoCommand.cs
@@ -40,7 +40,7 @@ public class InfoCommand : CommandSpell
              AccountId: {targetPlayer.AccountId}
              Position: {targetPlayer.Location.X}, {targetPlayer.Location.Y}, {targetPlayer.Location.Z}
              Capacity: {targetPlayer.TotalCapacity}
-             PremiumTime: {targetPlayer.PremiumTime}
+             PremiumTime: {targetPlayer.PremiumDays}
              Level: {targetPlayer.Level}
              Skills:
              {targetPlayer.Skills.Where(item => item.Key != SkillType.Level).Select(Item => "   * " + Item.Key + ": " + Item.Value.Level + "\n").Aggregate((a, b) => a + b)}

--- a/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IPlayer.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IPlayer.cs
@@ -127,8 +127,8 @@ public interface IPlayer : ICombatActor, ISociableCreature, IBankable
     IPlayerParty PlayerParty { get; set; }
     string GenderPronoun { get; }
     Gender Gender { get; set; }
-    int PremiumTime { get; }
-    bool HasPremiumTime => PremiumTime > 0;
+    int PremiumDays { get; }
+    bool HasPremiumTime { get; }
     IDictionary<SkillType, ISkill> Skills { get; }
     IDictionary<uint, int> Storages { get; }
 

--- a/src/Core/NeoServer.Domain/Creatures/Models/Bases/CombatActor.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Models/Bases/CombatActor.cs
@@ -266,7 +266,7 @@ public abstract class CombatActor : WalkableCreature, ICombatActor
         return Result.Success;
     }
 
-    public void Heal(ushort increasing, ICreature healedBy)
+    public virtual void Heal(ushort increasing, ICreature healedBy)
     {
         if (increasing <= 0) return;
 

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -857,6 +857,8 @@ public class Player : CombatActor, IPlayer
 
     public void IncreaseMana(uint increasing)
     {
+        if (Group.FlagIsEnabled(PlayerFlag.NotGainMana)) return;
+
         if (increasing <= 0) return;
 
         if (Mana == MaxMana) return;

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -147,7 +147,7 @@ public class Player : CombatActor, IPlayer
 
     public List<RegenerationBonus> RegenerationBonusList { get; private set; } = new();
 
-    public override ushort RawSpeed => (ushort)(220 + 2 * (Level - 1));
+    public override ushort RawSpeed => Group.FlagIsEnabled(PlayerFlag.SetMaxSpeed) ? ushort.MaxValue : (ushort)(220 + 2 * (Level - 1));
 
     public float DamageFactor => FightMode switch
     {

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -867,6 +867,13 @@ public class Player : CombatActor, IPlayer
         OnStatusChanged?.Invoke(this);
     }
 
+    public override void Heal(ushort increasing, ICreature healedBy)
+    {
+        if (Group.FlagIsEnabled(PlayerFlag.NotGainHealth)) return;
+
+        base.Heal(increasing, healedBy);
+    }
+
     public void Recover()
     {
         if (!Recovering) return;

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -86,7 +86,6 @@ public class Player : CombatActor, IPlayer
         Id = id;
         CharacterName = characterName;
         ChaseMode = chaseMode;
-        TotalCapacity = capacity;
         Skills = skills;
         Storages = storages;
         Vocation = vocation;
@@ -102,6 +101,8 @@ public class Player : CombatActor, IPlayer
         Outfit = outfit;
         Speed = speed == 0 ? RawSpeed : speed;
         Inventory = new Inventory.Inventory(this, new Dictionary<Slot, (IItem Item, ushort Id)>());
+
+        TotalCapacity = Group.FlagIsEnabled(PlayerFlag.HasInfiniteCapacity) ? uint.MaxValue : capacity;;
 
         Vip = new Vip(this);
         Channels = new PlayerChannel(this);
@@ -398,7 +399,7 @@ public class Player : CombatActor, IPlayer
 
     public override ushort ArmorRating => Inventory.TotalArmor;
     public PvpSecureMode SecureMode { get; private set; }
-    public float FreeCapacity => TotalCapacity - Inventory.TotalWeight;
+    public float FreeCapacity => Group.FlagIsEnabled(PlayerFlag.HasInfiniteCapacity) ? float.MaxValue : TotalCapacity - Inventory.TotalWeight;
     public override bool UsingDistanceWeapon => Inventory.Weapon is IDistanceWeapon;
     public bool Recovering => HasCondition(ConditionType.Regeneration);
     public override bool CanSeeInvisible => Group.FlagIsEnabled(PlayerFlag.CanSenseInvisibility);
@@ -1342,6 +1343,9 @@ public class Player : CombatActor, IPlayer
 
     public override void AddCondition(ICondition condition)
     {
+        if (Group.FlagIsEnabled(PlayerFlag.CannotBeAttacked) && condition.Type.ToDamageType() != DamageType.None)
+            return;
+
         switch (condition.Type)
         {
             case ConditionType.Drunk when Inventory.HasEquippedItemWithImmunity(Immunity.Drunkenness):
@@ -1447,7 +1451,8 @@ public class Player : CombatActor, IPlayer
             var levelDiff = toLevel - fromLevel;
             MaxHealthPoints += (uint)(levelDiff * Vocation.GainHp);
             MaxMana += (ushort)(levelDiff * Vocation.GainMana);
-            TotalCapacity += (uint)(levelDiff * Vocation.GainCap);
+            if (!Group.FlagIsEnabled(PlayerFlag.HasInfiniteCapacity))
+                TotalCapacity += (uint)(levelDiff * Vocation.GainCap);
             ResetHealthPoints();
             ResetMana();
             ChangeSpeedLevel(RawSpeed);
@@ -1463,7 +1468,8 @@ public class Player : CombatActor, IPlayer
             var levelDiff = toLevel - fromLevel;
             MaxHealthPoints += (uint)(levelDiff * Vocation.GainHp);
             MaxMana += (ushort)(levelDiff * Vocation.GainMana);
-            TotalCapacity += (uint)(levelDiff * Vocation.GainCap);
+            if (!Group.FlagIsEnabled(PlayerFlag.HasInfiniteCapacity))
+                TotalCapacity += (uint)(levelDiff * Vocation.GainCap);
             ResetHealthPoints();
             ResetMana();
             ChangeSpeedLevel(RawSpeed);

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -102,7 +102,7 @@ public class Player : CombatActor, IPlayer
         Speed = speed == 0 ? RawSpeed : speed;
         Inventory = new Inventory.Inventory(this, new Dictionary<Slot, (IItem Item, ushort Id)>());
 
-        TotalCapacity = Group.FlagIsEnabled(PlayerFlag.HasInfiniteCapacity) ? uint.MaxValue : capacity;;
+        TotalCapacity = Group.FlagIsEnabled(PlayerFlag.HasInfiniteCapacity) ? uint.MaxValue : capacity;
 
         Vip = new Vip(this);
         Channels = new PlayerChannel(this);

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -167,8 +167,8 @@ public class Player : CombatActor, IPlayer
     public string GenderPronoun => Gender == Gender.Male ? "He" : "She";
 
     public Gender Gender { get; set; }
-    public int PremiumTime { get; init; }
-    public bool HasPremiumTime => PremiumTime > 0;
+    public int PremiumDays { get; init; }
+    public bool HasPremiumTime => PremiumDays > 0 || Group.FlagIsEnabled(PlayerFlag.IsAlwaysPremium);
     public ITown Town { get; set; }
     public IVip Vip { get; }
     public override IOutfit Outfit { get; protected set; }
@@ -1227,7 +1227,7 @@ public class Player : CombatActor, IPlayer
     public bool CanUseOutfit(IOutfit outfit)
     {
         if (string.IsNullOrEmpty(outfit.Name)) return false;
-        if (outfit.Premium && !(PremiumTime > 0)) return false;
+        if (outfit.Premium && !HasPremiumTime) return false;
 
         return outfit.Unlocked;
     }
@@ -1319,7 +1319,7 @@ public class Player : CombatActor, IPlayer
         if (!spell.VocationIds?.Contains(((IPlayer)this).VocationType) ?? false)
             return Result.Fail(InvalidOperation.VocationCannotUseSpell);
 
-        if (spell.NeedsPremium && PremiumTime <= 0) return Result.Fail(InvalidOperation.PremiumTimeIsRequired);
+        if (spell.NeedsPremium && !HasPremiumTime) return Result.Fail(InvalidOperation.PremiumTimeIsRequired);
 
         if (spell.IsAggressive && (spell.Range < 1 || (spell.Range > 0 && CurrentTarget is null)) &&
             Skull is Skull.Black)

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -262,6 +262,8 @@ public class Player : CombatActor, IPlayer
     {
         if (experience == 0) return;
 
+        if (Group.FlagIsEnabled(PlayerFlag.NotGainExperience)) return;
+
         if (!IgnoreStamina)
         {
             experience = ApplyStaminaEffectOnExperienceGain(experience);

--- a/src/Core/NeoServer.Domain/Items/Services/ItemRequirementService.cs
+++ b/src/Core/NeoServer.Domain/Items/Services/ItemRequirementService.cs
@@ -20,7 +20,7 @@ public class ItemRequirementService : IItemRequirementService
         if ((player.Skills[SkillType.Magic]?.Level ?? 0) < requirement.MinMagicLevel)
             return Result.Fail(InvalidOperation.NotEnoughMagicLevel);
 
-        if (player.PremiumTime <= 0 && requirement.RequirePremiumTime)
+        if (!player.HasPremiumTime && requirement.RequirePremiumTime)
             return Result.Fail(InvalidOperation.PremiumTimeIsRequired);
 
         return Result.Success;
@@ -30,7 +30,7 @@ public class ItemRequirementService : IItemRequirementService
     {
         if (player.Level < requirement.MinLevel) return Result.Fail(InvalidOperation.NotEnoughLevel);
 
-        if (player.PremiumTime <= 0 && requirement.RequirePremiumTime)
+        if (!player.HasPremiumTime && requirement.RequirePremiumTime)
             return Result.Fail(InvalidOperation.PremiumTimeIsRequired);
 
         var hasRequiredVocation = PlayerHasRequiredVocation(player, requirement);

--- a/src/Loaders/NeoServer.Loaders/Players/PlayerLoader.cs
+++ b/src/Loaders/NeoServer.Loaders/Players/PlayerLoader.cs
@@ -120,7 +120,7 @@ public class PlayerLoader : IPlayerLoader
             MapTool,
             town)
         {
-            PremiumTime = premiumTimeDays,
+            PremiumDays = premiumTimeDays,
             AccountId = (uint)playerEntity.AccountId,
             WorldId = playerEntity.WorldId,
             Guild = GuildStore.Get((ushort)(playerEntity.GuildMember?.GuildId ?? 0)),

--- a/src/Loaders/NeoServer.Loaders/TileRule/TileRuleLoader.cs
+++ b/src/Loaders/NeoServer.Loaders/TileRule/TileRuleLoader.cs
@@ -79,7 +79,7 @@ public class TileRuleLoader : IStartupLoader
 
         if (player.Level >= tileRule.MinLevel &&
             player.Level <= tileRule.MaxLevel &&
-            (!tileRule.RequiresPremium || (tileRule.RequiresPremium && player.PremiumTime > 0))) return true;
+            (!tileRule.RequiresPremium || (tileRule.RequiresPremium && player.HasPremiumTime))) return true;
 
         if (string.IsNullOrWhiteSpace(tileRule.Message)) return false;
 

--- a/src/NetworkingServer/NeoServer.Networking.Packets/Outgoing/Player/PlayerOutFitWindowPacket.cs
+++ b/src/NetworkingServer/NeoServer.Networking.Packets/Outgoing/Player/PlayerOutFitWindowPacket.cs
@@ -34,7 +34,7 @@ public class PlayerOutFitWindowPacket : OutgoingPacket
             message.AddByte(player.Outfit.Addon);
         }
 
-        var outfits = _outfits.Where(x => (!x.RequiresPremium || (player.PremiumTime > 0 && x.RequiresPremium)) &&
+        var outfits = _outfits.Where(x => (!x.RequiresPremium || (player.HasPremiumTime && x.RequiresPremium)) &&
                                           x.Enabled).ToList();
 
         message.AddByte((byte)outfits.Count);
@@ -43,7 +43,7 @@ public class PlayerOutFitWindowPacket : OutgoingPacket
 
         foreach (var outfit in outfits)
         {
-            if (player.PremiumTime <= 0 && outfit.RequiresPremium) continue;
+            if (!player.HasPremiumTime && outfit.RequiresPremium) continue;
 
             playerAddons.TryGetValue(outfit.LookType, out var addonLevel);
 

--- a/tests/NeoServer.Domain.Tests/Helpers/Player/PlayerTestDataBuilder.cs
+++ b/tests/NeoServer.Domain.Tests/Helpers/Player/PlayerTestDataBuilder.cs
@@ -133,7 +133,7 @@ public static class PlayerTestDataBuilder
         )
         {
             Guild = guild,
-            PremiumTime = premiumTime,
+            PremiumDays = premiumTime,
             LastLogOut = DateTime.UtcNow
         };
 


### PR DESCRIPTION
### Description
This pull request addresses several issues related to player flag handling, improves logic for flag interaction, prevents invalid conditions, and includes a small refactoring of terminology.

### Key Changes
- Fixed handling of the `SetMaxSpeed` flag to correctly set players' speed to the maximum.
- Renamed `PremiumTime` to `PremiumDays` and updated associated logic and references.
- Prevented players with `NotGainHealth`, `NotGainMana`, or `NotGainExperience` flags from gaining health, mana, or experience respectively.
- Ensured players with the `CannotBeBanned` flag cannot be banned.
- Handled the infinite capacity flag and prevented the application of invalid conditions for players.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which