### PR TITLE
Fix player duplicate login freezing characters

### DIFF
--- a/src/ApplicationServer/NeoServer.Server.Commands/Player/PlayerLogInCommand.cs
+++ b/src/ApplicationServer/NeoServer.Server.Commands/Player/PlayerLogInCommand.cs
@@ -67,14 +67,16 @@ public class PlayerLogInCommand(
             return (false,
                 $"Your IP address {existBan.Ip} has been banished until {existBan.ExpiresAt:MM/dd/yyyy}.\nReason: {existBan.Reason}");
 
-        var playerOnline = await accountRepository.GetOnlinePlayer(request.Account);
-        if (playerOnline is not null)
+        var playersOnline = await accountRepository.GetOnlinePlayers(request.Account);
+
+        foreach (var playerOnline in playersOnline)
         {
             game.CreatureManager.TryGetLoggedPlayer((uint)playerOnline.Id, out var existingPlayer);
             if (existingPlayer?.Name == request.CharacterName)
             {
                 game.CreatureManager.GetPlayerConnection(existingPlayer.CreatureId, out var existingConnection);
                 existingConnection?.Disconnect();
+                logger.Warning("Player {PlayerName} logged out because of another login attempt", existingPlayer.Name);
             }
             else if (!playerOnline.Account.AllowManyOnline)
             {
@@ -118,7 +120,7 @@ public class PlayerLogInCommand(
 
         if (!playerAlreadyLoggedIn)
         {
-            guildLoader.Load(playerRecord.GuildMember?.Guild);
+            await guildLoader.LoadAsync(playerRecord.GuildMember?.Guild);
 
             var playerLocation = playerLocationResolver.GetPlayerLocation(playerRecord);
             if (playerLocation == Location.Zero) return (false, "Player location invalid");

--- a/src/ApplicationServer/NeoServer.Server.Events/Server/ServerOpenedEventHandler.cs
+++ b/src/ApplicationServer/NeoServer.Server.Events/Server/ServerOpenedEventHandler.cs
@@ -1,18 +1,20 @@
-﻿using NeoServer.Data.Interfaces;
+﻿using System;
+using NeoServer.Data.Interfaces;
+using Serilog;
 
 namespace NeoServer.Server.Events.Server;
 
-public class ServerOpenedEventHandler
+public class ServerOpenedEventHandler(IPlayerRepository playerRepository, ILogger logger)
 {
-    private readonly IPlayerRepository _playerRepository;
-
-    public ServerOpenedEventHandler(IPlayerRepository playerRepository)
+    public async void Execute()
     {
-        _playerRepository = playerRepository;
-    }
-
-    public void Execute()
-    {
-        _playerRepository.UpdateAllPlayersToOffline();
+        try
+        {
+            await playerRepository.UpdateAllPlayersToOfflineAsync();
+        }
+        catch (Exception e)
+        {
+            logger.Error(e, "Error while updating all players to offline");
+        }
     }
 }

--- a/src/Database/NeoServer.Data/Interfaces/IAccountRepository.cs
+++ b/src/Database/NeoServer.Data/Interfaces/IAccountRepository.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
 using NeoServer.Data.Entities;
 
 namespace NeoServer.Data.Interfaces;
@@ -12,6 +13,6 @@ public interface IAccountRepository : IBaseRepositoryNeo<AccountEntity>
     Task<PlayerEntity> GetPlayer(string accountName, string password, string charName, bool includeDeathList = false,
         bool includeKillsLastMonth = false);
 
-    Task<PlayerEntity> GetOnlinePlayer(string accountName);
+    Task<IList<PlayerEntity>> GetOnlinePlayers(string accountName);
     Task<int> Ban(uint accountId, string reason, uint bannedByAccountId);
 }

--- a/src/Database/NeoServer.Data/Interfaces/IPlayerRepository.cs
+++ b/src/Database/NeoServer.Data/Interfaces/IPlayerRepository.cs
@@ -8,7 +8,7 @@ namespace NeoServer.Data.Interfaces;
 
 public interface IPlayerRepository : IBaseRepositoryNeo<PlayerEntity>
 {
-    Task UpdateAllPlayersToOffline();
+    Task UpdateAllPlayersToOfflineAsync();
     Task<List<PlayerOutfitAddonEntity>> GetOutfitAddons(int playerId);
     Task UpdatePlayers(IEnumerable<IPlayer> players);
     Task UpdatePlayerOnlineStatus(uint playerId, bool status);

--- a/src/Database/NeoServer.Data/Repositories/AccountRepository.cs
+++ b/src/Database/NeoServer.Data/Repositories/AccountRepository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -70,14 +71,15 @@ public class AccountRepository(DbContextOptions<NeoContext> contextOptions, ILog
         return result;
     }
 
-    public async Task<PlayerEntity> GetOnlinePlayer(string accountName)
+    public async Task<IList<PlayerEntity>> GetOnlinePlayers(string accountName)
     {
         await using var context = NewDbContext;
 
         return await context.Players
             .Include(x => x.Account)
             .Where(x => x.Account.EmailAddress.Equals(accountName) && x.Online)
-            .FirstOrDefaultAsync();
+            .AsNoTracking()
+            .ToListAsync();
     }
 
     #endregion

--- a/src/Database/NeoServer.Data/Repositories/Player/PlayerRepository.cs
+++ b/src/Database/NeoServer.Data/Repositories/Player/PlayerRepository.cs
@@ -18,9 +18,9 @@ public class PlayerRepository(DbContextOptions<NeoContext> contextOptions, ILogg
     : BaseRepository<PlayerEntity>(contextOptions,
         logger), IPlayerRepository, Domain.Repositories.IPlayerRepository
 {
-    public async Task UpdateAllPlayersToOffline()
+    public async Task UpdateAllPlayersToOfflineAsync()
     {
-        const string sql = "UPDATE Player SET Online = 0";
+        const string sql = "UPDATE Player SET Online = false";
 
         await using var context = NewDbContext;
 


### PR DESCRIPTION
### Description
Resolved an issue where players logging in multiple times simultaneously caused character freezing.
fix #882

### Key Changes
- Added logic to properly handle duplicate login attempts.
- Prevented character freezing by managing improper session overlaps.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
Conduct tests to ensure proper handling of simultaneous duplicate login attempts without freezing the character.