### PR TITLE
Fix area spell damage affecting protected zones

### DIFF
--- a/src/Core/NeoServer.Domain/World/Factories/TileFactory.cs
+++ b/src/Core/NeoServer.Domain/World/Factories/TileFactory.cs
@@ -76,7 +76,7 @@ public class TileFactory : ITileFactory
             !hasMoveableItem &&
             !hasTransformableItem && !hasHeight)
         {
-            var staticTile = new StaticTile(new Coordinate(), items);
+            var staticTile = new StaticTile(new Coordinate(), (uint)flag, items);
             _tileCache.TryAdd(hash, staticTile);
             return staticTile;
         }

--- a/src/Core/NeoServer.Domain/World/Models/Tiles/StaticTile.cs
+++ b/src/Core/NeoServer.Domain/World/Models/Tiles/StaticTile.cs
@@ -11,9 +11,10 @@ public class StaticTile : BaseTile, IStaticTile
 {
     private IItem _topDownItemOnStack;
 
-    public StaticTile(Coordinate coordinate, params IItem[] items) : this(
+    public StaticTile(Coordinate coordinate, uint flag = 0, params IItem[] items) : this(
         new Location((ushort)coordinate.X, (ushort)coordinate.Y, (byte)coordinate.Z), items)
     {
+        Flags |= flag;
     }
 
     public StaticTile(Location location, params IItem[] items)

--- a/tests/NeoServer.Domain.Tests/World/TileTest.cs
+++ b/tests/NeoServer.Domain.Tests/World/TileTest.cs
@@ -492,7 +492,7 @@ public class TileTest
         var topItem = ItemTestDataBuilder.CreateTopItem(1, 1);
         var downItem = ItemTestDataBuilder.CreateRegularItem(2);
 
-        var tile = new StaticTile(new Coordinate(100, 100, 7), topItem, downItem);
+        var tile = new StaticTile(new Coordinate(100, 100, 7), 0, topItem, downItem);
 
         // Act & Assert
         // Index 0 should return first top item (no ground)
@@ -513,7 +513,7 @@ public class TileTest
         var topItem = ItemTestDataBuilder.CreateTopItem(1, 1);
         var downItem = ItemTestDataBuilder.CreateRegularItem(2);
 
-        var tile = new StaticTile(new Coordinate(100, 100, 7), ground, topItem, downItem);
+        var tile = new StaticTile(new Coordinate(100, 100, 7), 0, ground, topItem, downItem);
 
         // Act & Assert
         // Index 0 should return ground
@@ -535,7 +535,7 @@ public class TileTest
         // Arrange
         var topItem = ItemTestDataBuilder.CreateTopItem(1, 1);
 
-        var tile = new StaticTile(new Coordinate(100, 100, 7), topItem);
+        var tile = new StaticTile(new Coordinate(100, 100, 7), 0, topItem);
 
         // Act & Assert
         tile.GetItemByIndex(-1).Should().BeNull();
@@ -547,7 +547,7 @@ public class TileTest
         // Arrange
         var topItem = ItemTestDataBuilder.CreateTopItem(1, 1);
 
-        var tile = new StaticTile(new Coordinate(100, 100, 7), topItem);
+        var tile = new StaticTile(new Coordinate(100, 100, 7), 0, topItem);
 
         // Act & Assert
         tile.GetItemByIndex(1).Should().BeNull();
@@ -562,7 +562,7 @@ public class TileTest
         var downItem = ItemTestDataBuilder.CreateRegularItem(2);
 
         // Pass items in random order: topItem, ground, downItem
-        var tile = new StaticTile(new Coordinate(100, 100, 7), topItem, ground, downItem);
+        var tile = new StaticTile(new Coordinate(100, 100, 7), 0, topItem, ground, downItem);
 
         // Act & Assert
         // Even though passed in random order, AllItems should be ordered: ground, topItem, downItem


### PR DESCRIPTION
### Description
Fixed an issue where area spell damage was unintentionally impacting protected zones.
fix #896

### Key Changes
- Resolved bug causing area spells to deal damage within protected zones.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
- Verify area spells no longer damage entities in protected zones.