### PR TITLE
Fix spell casting in protection zones

### DIFF
--- a/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IMonster.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IMonster.cs
@@ -52,7 +52,6 @@ public interface IMonster : IWalkableMonster, ICombatActor
     bool IsHostile { get; }
     MonsterTargetList Targets { get; set; }
     bool IsPushable { get; }
-    event MonsterChangeState OnChangedState;
 
     void Reborn();
 

--- a/src/Core/NeoServer.Domain/Creatures/Monster/Monster.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Monster/Monster.cs
@@ -451,12 +451,6 @@ public class Monster : WalkableMonster, IMonster
         if (this is not Summon.Summon) Targets.Add(creature as ICombatActor);
     }
 
-    #region Events
-
-    public event MonsterChangeState OnChangedState;
-
-    #endregion
-
     private void PushCreatures(IDynamicTile destinationTile)
     {
         // find all the creatures that can be pushed

--- a/src/Core/NeoServer.Domain/Spells/SpellCastValidation.cs
+++ b/src/Core/NeoServer.Domain/Spells/SpellCastValidation.cs
@@ -23,6 +23,11 @@ public class SpellCastValidation(IMapTool mapTool)
         var result = spell.CanCast(caster, target);
         if (result.Failed) return result;
 
+        if (caster.Tile.ProtectionZone && (spell.PrimaryGroup.Name == "attack" || spell.SecondaryGroup.Name == "Attack"))
+        {
+            return Result.Fail(InvalidOperation.NotPermittedInProtectionZone);
+        }
+
         if (spell.Range.HasValue && target is not null && !mapTool.CanThrowObjectTo(caster.Location, target.Location,
                 SightLine.CheckSightLineAndFloor, spell.Range.Value, spell.Range.Value))
             return Result.Fail(InvalidOperation.DestinationOutOfReach);

--- a/src/Core/NeoServer.Domain/Spells/SpellCastValidation.cs
+++ b/src/Core/NeoServer.Domain/Spells/SpellCastValidation.cs
@@ -23,7 +23,7 @@ public class SpellCastValidation(IMapTool mapTool)
         var result = spell.CanCast(caster, target);
         if (result.Failed) return result;
 
-        if (caster.Tile.ProtectionZone && (spell.PrimaryGroup.Name == "attack" || spell.SecondaryGroup.Name == "Attack"))
+        if ((caster.Tile?.ProtectionZone ?? false) && (spell.PrimaryGroup.Name == "attack" || spell.SecondaryGroup.Name == "Attack"))
         {
             return Result.Fail(InvalidOperation.NotPermittedInProtectionZone);
         }


### PR DESCRIPTION
### Description
Fixed an issue where spell casting was incorrectly allowed in protection zones.

### Key Changes
- Added logic to prevent spell casting in protection zones.
fix #897

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
Verify that spells cannot be cast when the player is inside a protection zone.