### PR TITLE
Fix Summon sleep mode behavior when far from master

### DIFF
--- a/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IMonster.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IMonster.cs
@@ -7,8 +7,6 @@ using NeoServer.Domain.Creatures;
 using NeoServer.Domain.Creatures.Monster;
 using NeoServer.Domain.Creatures.Monster.Combat;
 
-public delegate void MonsterChangeState(IMonster monster, MonsterState fromState, MonsterState toState);
-
 public interface IMonster : IWalkableMonster, ICombatActor
 {
     /// <summary>

--- a/src/Core/NeoServer.Domain/Creatures/Monster/Monster.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Monster/Monster.cs
@@ -77,7 +77,7 @@ public class Monster : WalkableMonster, IMonster
     public MonsterState State
     {
         get => _state;
-        private set
+        protected set
         {
             var oldState = _state;
             if (_state == value) return;
@@ -285,11 +285,11 @@ public class Monster : WalkableMonster, IMonster
         {
             if (Conditions.Count > 0)
             {
-                State = MonsterState.LookingForEnemy;
+                State = MonsterState.RandomlyWalking;
                 return;
             }
 
-            State = Cooldowns.Expired(CooldownType.Awaken) ? MonsterState.Sleeping : MonsterState.LookingForEnemy;
+            State = Cooldowns.Expired(CooldownType.Awaken) ? MonsterState.Sleeping : MonsterState.RandomlyWalking;
             return;
         }
 
@@ -302,7 +302,7 @@ public class Monster : WalkableMonster, IMonster
 
         if (!HasFollowPath)
         {
-            State = MonsterState.LookingForEnemy;
+            State = MonsterState.RandomlyWalking;
             return;
         }
 

--- a/src/Core/NeoServer.Domain/Creatures/Monster/MonsterState.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Monster/MonsterState.cs
@@ -8,6 +8,6 @@ public enum MonsterState
     Sleeping,
     InCombat,
     Escaping,
-    LookingForEnemy,
+    RandomlyWalking,
     Awake
 }

--- a/src/Core/NeoServer.Domain/Creatures/Monster/Services/MonsterStateService.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Monster/Services/MonsterStateService.cs
@@ -33,7 +33,7 @@ public class MonsterStateService(
             monster.StopFollowing();
         }
 
-        if (monster.State == MonsterState.LookingForEnemy)
+        if (monster.State == MonsterState.RandomlyWalking)
         {
             //Walk a random step
             monster.DoRandomStep();

--- a/src/Core/NeoServer.Domain/Creatures/Monster/Summon/Summon.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Monster/Summon/Summon.cs
@@ -46,6 +46,11 @@ public class Summon : Monster
 
         //Summon should not attack if the master has no target
         if (Master is ICombatActor { CurrentTarget: null }) return;
+        
+        if (!CanSee(creature.Location))
+        {
+            return;
+        }
 
         base.SetAsEnemy(creature);
     }
@@ -58,6 +63,11 @@ public class Summon : Monster
 
         //Summon should not attack if the master has no target
         if (Master is ICombatActor { CurrentTarget: null }) return Result.NotPossible;
+
+        if (!CanSee(target.Location))
+        {
+            return Result.NotPossible;
+        }
         
         return base.SetAttackTarget(target);
     }
@@ -81,6 +91,18 @@ public class Summon : Monster
                 Die();
                 return;
             }
+        }
+
+        if (!CanSee(Master.Location))
+        {
+            Targets.Clear();
+            State = MonsterState.RandomlyWalking;
+            return;
+        }
+
+        if (CanSee(Master.Location) && State is MonsterState.RandomlyWalking)
+        {
+            State = MonsterState.Awake;
         }
 
         if (Master is not IPlayer player)
@@ -151,12 +173,17 @@ public class Summon : Monster
         Die();
     }
 
-    private void OnMasterTargetChange(ICombatActor actor, uint oldTargetId, uint newTargetId)
+    private void OnMasterTargetChange(ICombatActor master, uint oldTargetId, uint newTargetId)
     {
         Targets.Clear();
 
-        SetAsEnemy(actor.CurrentTarget);
-        ChangeAttackTarget(actor.CurrentTarget);
+        if (!CanSee(master.CurrentTarget?.Location ?? Location.Zero))
+        {
+            return;
+        }
+
+        SetAsEnemy(master.CurrentTarget);
+        ChangeAttackTarget(master.CurrentTarget);
     }
 
     private void OnMasterStoppedAttack(ICombatActor actor)

--- a/tests/NeoServer.Domain.Tests/Creature/Monster/MonsterCombatTest.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Monster/MonsterCombatTest.cs
@@ -108,7 +108,7 @@ public class MonsterCombatTest
         monsterStateService.UpdateState(monster);
 
         //assert
-        monster.State.Should().Be(MonsterState.LookingForEnemy);
+        monster.State.Should().Be(MonsterState.RandomlyWalking);
         monster.CurrentTarget.Should().BeNull();
         monster.IsFollowing.Should().BeFalse();
         monster.Attacking.Should().BeFalse();
@@ -233,7 +233,7 @@ public class MonsterCombatTest
         monsterStateService.UpdateState(monster);
 
         //assert
-        monster.State.Should().Be(MonsterState.LookingForEnemy);
+        monster.State.Should().Be(MonsterState.RandomlyWalking);
         monster.CurrentTarget.Should().BeNull();
         monster.IsFollowing.Should().BeFalse();
         monster.Attacking.Should().BeFalse();
@@ -413,7 +413,7 @@ public class MonsterCombatTest
         monsterStateService.UpdateState(monster);
 
         //assert - Monster enters an idle state even with status effects (current behavior)
-        monster.State.Should().Be(MonsterState.LookingForEnemy); // Current behavior: enters idle state
+        monster.State.Should().Be(MonsterState.RandomlyWalking); // Current behavior: enters idle state
         monster.CurrentTarget.Should().BeNull();
         monster.IsFollowing.Should().BeFalse();
         monster.Attacking.Should().BeFalse();
@@ -591,7 +591,7 @@ public class MonsterCombatTest
 
         // Initial state: SUT might be targeting player yet
         monsterStateService.UpdateState(sut);
-        sut.State.Should().Be(MonsterState.LookingForEnemy);
+        sut.State.Should().Be(MonsterState.RandomlyWalking);
         sut.CurrentTarget.Should()
             .Be(player); // Assume targeting the player initially although not having follow path to him
 

--- a/tests/NeoServer.Domain.Tests/Creature/Monster/MonsterStateTest.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Monster/MonsterStateTest.cs
@@ -48,7 +48,7 @@ public class MonsterStateTest
         monster.UpdateState();
 
         //assert
-        monster.State.Should().Be(MonsterState.LookingForEnemy);
+        monster.State.Should().Be(MonsterState.RandomlyWalking);
     }
 
     [Fact]
@@ -129,7 +129,7 @@ public class MonsterStateTest
         monster.UpdateState();
 
         //assert
-        monster.State.Should().Be(MonsterState.LookingForEnemy);
+        monster.State.Should().Be(MonsterState.RandomlyWalking);
     }
 
     [Fact]

--- a/tests/NeoServer.Domain.Tests/Creature/Summon/SummonTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Summon/SummonTests.cs
@@ -289,4 +289,58 @@ public class SummonTests
         summon.CurrentTarget.Should().NotBe(master, "Summon should never target its master");
         summon.Attacking.Should().BeFalse("Summon should not be attacking when trying to attack master");
     }
+
+    [Fact]
+    [Trait("Category", "Summon")]
+    public void Summon_looking_for_enemy_does_not_attack_floor7_creatures_when_master_has_target_on_floor8()
+    {
+        // Arrange
+        var map = MapTestDataBuilder.Build(100, 110, 100, 110, 7, 8);
+
+        // Master will be on floor 8
+        var master = PlayerTestDataBuilder.Build();
+        master.SetNewLocation(new Location(105, 105, 8));
+
+        // Summon and other creatures on floor 7
+        var summon = MonsterTestDataBuilder.BuildSummon(master);
+        summon.SetNewLocation(new Location(104, 105, 7));
+
+        var monsterX = PlayerTestDataBuilder.Build(2, "MonsterX");
+        monsterX.SetNewLocation(new Location(106, 105, 7));
+
+        var playerY = PlayerTestDataBuilder.Build(3, "PlayerY");
+        playerY.SetNewLocation(new Location(107, 105, 7));
+
+        // Place creatures on the map
+        map.PlaceCreature(master);
+        map.PlaceCreature(summon);
+        map.PlaceCreature(monsterX);
+        map.PlaceCreature(playerY);
+
+        // Give the master a target on floor 8 (different creature)
+        var targetOnZ8 = PlayerTestDataBuilder.Build(4, "TargetZ8");
+        targetOnZ8.SetNewLocation(new Location(108, 108, 8));
+        map.PlaceCreature(targetOnZ8);
+        master.SetAttackTarget(targetOnZ8);
+
+        // Prepare services used to update monster/summon state
+        var summonServiceMock = new Mock<ISummonService>();
+        var targetDetectorService = new TargetDetectorService(map);
+        var pathFinder = new PathFinder(map);
+        var monsterTargetingService = new MonsterTargetingService(new MonsterTargetSearch(new MapTool(map, pathFinder)));
+        var monsterStateService = new MonsterStateService(summonServiceMock.Object, targetDetectorService, monsterTargetingService);
+
+        // Act
+        monsterStateService.UpdateState(summon);
+
+        // Assert
+        // Summon should not be attacking or have an auto-attack target just because master's target is on another floor
+        summon.State.Should().Be(MonsterState.RandomlyWalking);
+        summon.Attacking.Should().BeFalse();
+        summon.AutoAttackTargetId.Should().Be(0);
+
+        // Summon should not acquire targets that are on floor 7 (nearby creatures) when master is on floor 8
+        summon.Targets.HasTarget(monsterX).Should().BeFalse("Summon must not target nearby floor-7 monster when its master is on a different floor");
+        summon.Targets.HasTarget(playerY).Should().BeFalse("Summon must not target nearby floor-7 player when its master is on a different floor");
+    }
 }

--- a/tests/NeoServer.Domain.Tests/Creatures/Monster/SummonDeathHandlingTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creatures/Monster/SummonDeathHandlingTests.cs
@@ -2,6 +2,7 @@ using Moq;
 using NeoServer.Domain.Common.Combat.Structs;
 using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Common.Item;
+using NeoServer.Domain.Common.Location.Structs;
 using NeoServer.Domain.Creatures.Monster.Summon;
 using NeoServer.Domain.Creatures.Services;
 using NeoServer.Domain.Tests.Helpers;
@@ -171,8 +172,11 @@ public class SummonDeathHandlingTests
     {
         // Arrange
         var master = PlayerTestDataBuilder.Build();
+        master.SetNewLocation(new Location(100, 100, 7));
         var summon = MonsterTestDataBuilder.BuildSummon(master);
+        summon.SetNewLocation(new Location(100, 101, 7));
         var enemy = PlayerTestDataBuilder.Build();
+        summon.SetNewLocation(new Location(100, 102, 7));
 
         // Act
         master.SetAttackTarget(enemy); // This should trigger OnMasterTargetChange
@@ -218,9 +222,12 @@ public class SummonDeathHandlingTests
     {
         // Arrange
         var master = PlayerTestDataBuilder.Build();
+        master.SetNewLocation(new Location(100, 100, 7));
         var summon = MonsterTestDataBuilder.BuildSummon(master);
+        summon.SetNewLocation(new Location(100, 101, 7));
         var enemy = PlayerTestDataBuilder.Build();
-
+        summon.SetNewLocation(new Location(100, 102, 7));
+        
         // Act
         master.SetAttackTarget(enemy);
 


### PR DESCRIPTION
### Description
Fixed an issue where Summon was incorrectly entering sleep mode when far from its master.

### Key Changes
- Resolved incorrect sleep mode activation for Summon.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
- Verify that Summon remains operational and does not enter sleep mode when far from its master under valid conditions.