### PR TITLE
Fix Summon not triggering defense mode

### DIFF
--- a/src/ApplicationServer/NeoServer.Server.Routines/Creatures/GameCreatureRoutine.cs
+++ b/src/ApplicationServer/NeoServer.Server.Routines/Creatures/GameCreatureRoutine.cs
@@ -68,7 +68,7 @@ public class GameCreatureRoutine(
     {
         if (creature is not IMonster monster) return;
 
-        CreatureDefenseRoutine.Execute(monster, game);
+        MonsterDefenseRoutine.Execute(monster, game);
         monsterStateRoutine.Execute(monster);
         MonsterYellRoutine.Execute(monster);
     }

--- a/src/ApplicationServer/NeoServer.Server.Routines/Creatures/Monster/MonsterDefenseRoutine.cs
+++ b/src/ApplicationServer/NeoServer.Server.Routines/Creatures/Monster/MonsterDefenseRoutine.cs
@@ -1,15 +1,15 @@
 ﻿using NeoServer.Server.Common.Contracts;
 using NeoServer.Server.Tasks;
 
-namespace NeoServer.Server.Routines.Creatures;
+namespace NeoServer.Server.Routines.Creatures.Monster;
 
-public static class CreatureDefenseRoutine
+public static class MonsterDefenseRoutine
 {
     public static void Execute(IMonster monster, IGameServer game)
     {
         if (monster.IsDead) return;
 
-        if (!monster.IsInCombat || monster.Defending) return;
+        if (monster.IsSleeping || monster.Defending) return;
 
         var interval = monster.Defend();
 

--- a/src/Core/NeoServer.Domain/Creatures/Monster/Actions/MonsterYell.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Monster/Actions/MonsterYell.cs
@@ -11,7 +11,7 @@ internal static class MonsterYell
 
         if (metadata.Voices is null) return;
         if (metadata.VoiceConfig is null) return;
-        if (!metadata.Voices.Any()) return;
+        if (metadata.Voices.Length == 0) return;
 
         if (!monster.Cooldowns.Expired(CooldownType.Yell)) return;
         monster.Cooldowns.Start(CooldownType.Yell, monster.Metadata.VoiceConfig.Interval);

--- a/src/Core/NeoServer.Domain/Creatures/Monster/Monster.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Monster/Monster.cs
@@ -82,7 +82,7 @@ public class Monster : WalkableMonster, IMonster
             var oldState = _state;
             if (_state == value) return;
             _state = value;
-            
+
             EventAggregator.Invoke(new MonsterStateChangedEvent(this, oldState, value));
         }
     }
@@ -343,10 +343,10 @@ public class Monster : WalkableMonster, IMonster
 
     public ushort Defend()
     {
-        if (IsDead || !Defenses.Any())
+        if (IsSleeping || Defenses.Length == 0)
         {
             StopDefending();
-            return default;
+            return 0;
         }
 
         Defending = true;

--- a/src/Core/NeoServer.Domain/Items/Items/Containers/LootContainer.cs
+++ b/src/Core/NeoServer.Domain/Items/Items/Containers/LootContainer.cs
@@ -56,7 +56,7 @@ public class LootContainer : Container.Container, ILootContainer
     private string GetStringContent(LootItem[] items)
     {
         if (Loot is null) return null;
-        if (!items.Any()) return null;
+        if (items.Length == 0) return null;
 
         var stringBuilder = new StringBuilder();
 

--- a/src/Core/NeoServer.Domain/SafeTrade/Validations/TradeRequestValidation.cs
+++ b/src/Core/NeoServer.Domain/SafeTrade/Validations/TradeRequestValidation.cs
@@ -151,7 +151,7 @@ internal class TradeRequestValidation
 
     private static bool TradeHasNoItems(IPlayer player, IItem[] items)
     {
-        if (items is null || !items.Any())
+        if (items is null || items.Length == 0)
         {
             OperationFailService.Send(player.CreatureId, "You must select an item to trade.");
             return true;

--- a/src/Extensions/NeoServer.Scripts.LuaJIT/Scripts.cs
+++ b/src/Extensions/NeoServer.Scripts.LuaJIT/Scripts.cs
@@ -113,7 +113,7 @@ public class Scripts : IScripts
 
         dir = Path.Combine(dir, coreFolder, "events", "scripts", "scheduler");
 
-        if (!Directory.Exists(dir) || !Directory.GetDirectories(dir).Any())
+        if (!Directory.Exists(dir) || Directory.GetDirectories(dir).Length == 0)
         {
             _logger.Warning(
                 "{LoadEventSchedulerScriptsName} - Can not load folder \'scheduler\' on {CoreFolder}/events/scripts\'",
@@ -156,7 +156,7 @@ public class Scripts : IScripts
 
         var searchOption = SearchOption.AllDirectories;
 
-        if (!Directory.GetDirectories(loadPath).Any())
+        if (Directory.GetDirectories(loadPath).Length == 0)
             searchOption = SearchOption.TopDirectoryOnly;
 
         foreach (var filePath in Directory.GetFiles(loadPath, "*.lua", searchOption))


### PR DESCRIPTION
### Description
Fixed an issue where the "Summon" would not properly execute defense mode when it was not in an attack state.

### Key Changes
- Resolved a bug causing "Summon" to skip defense mode activation when not in attack mode.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
Ensure "Summon" correctly activates defense mode when not in attack.