### PR TITLE
Fix summon state logic for master's random walking state

### DIFF
--- a/src/Core/NeoServer.Domain/Creatures/Monster/Summon/Summon.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Monster/Summon/Summon.cs
@@ -105,18 +105,18 @@ public class Summon : Monster
             return;
         }
 
+        if (Master is IMonster { State: MonsterState.RandomlyWalking })
+        {
+            State = MonsterState.Awake;
+            return;
+        }
+
         if (CanSee(Master.Location) && State is MonsterState.RandomlyWalking)
         {
             State = MonsterState.Awake;
         }
 
-        if (Master is not IPlayer player)
-        {
-            base.UpdateState();
-            return;
-        }
-
-        if (player.CurrentTarget is not null)
+        if (Master is IPlayer { CurrentTarget: not null } player)
         {
             ChangeAttackTarget(player.CurrentTarget);
             return;


### PR DESCRIPTION
### Description
Updated the summon state logic to correctly handle scenarios where the master is in a random walking state.
fix #919

### Key Changes
- Fixed an issue in the summon state logic that did not account for the master’s random walking state.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
Test summoning logic while the master is in a random walking state. Validate that the summon behavior operates as expected.