### PR TITLE
Fix: Resolve player descent bug and improve test cases

### DIFF
--- a/src/Core/NeoServer.Domain/Creatures/Events/CreatureTeleportedEventHandler.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Events/CreatureTeleportedEventHandler.cs
@@ -26,7 +26,7 @@ public class CreatureTeleportedEventHandler(IMap map, ICreatureMovementService c
 
         if (map[location] is DynamicTile dynamicTile)
         {
-            creatureMovementService.MoveCreature(creature, dynamicTile.Location, forced: true);
+            creatureMovementService.MoveCreature(creature, dynamicTile.Location, forced: true, isTeleport: true);
         }
     }
 }

--- a/src/Core/NeoServer.Domain/Creatures/Services/CreatureMovementService.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Services/CreatureMovementService.cs
@@ -1,5 +1,6 @@
 using NeoServer.Domain.Common;
 using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.Services;
 using NeoServer.Domain.Common.Contracts.World;
 using NeoServer.Domain.Common.Contracts.World.Tiles;
 using NeoServer.Domain.Common.Location;
@@ -8,6 +9,7 @@ using NeoServer.Domain.Common.Services;
 using NeoServer.Domain.Common.Texts;
 using NeoServer.Domain.World.Events;
 using NeoServer.Domain.World.Map;
+using NeoServer.Domain.World.Models.Tiles;
 
 namespace NeoServer.Domain.Creatures.Services;
 
@@ -15,7 +17,7 @@ public interface ICreatureMovementService
 {
     bool MoveCreature(IWalkableCreature creature, Direction nextDirection);
     void MoveCreature(IWalkableCreature creature);
-    bool MoveCreature(ICreature creature, Location location, bool forced = false);
+    bool MoveCreature(ICreature creature, Location location, bool forced = false, bool isTeleport = false);
 }
 
 /// <summary>
@@ -27,7 +29,8 @@ public interface ICreatureMovementService
 public class CreatureMovementService(
     IMap map,
     CylinderOperation cylinderOperation,
-    CreatureMovementValidation movementValidation) : ICreatureMovementService
+    CreatureMovementValidation movementValidation,
+    IStaticToDynamicTileService staticToDynamicTileService) : ICreatureMovementService
 {
     /// <summary>
     ///     Attempts to move a creature to a specific location.
@@ -36,10 +39,11 @@ public class CreatureMovementService(
     /// <param name="creature">The creature to move.</param>
     /// <param name="location">The target location.</param>
     /// <param name="forced"></param>
+    /// <param name="isTeleport"></param>
     /// <returns>True if movement succeeded, false otherwise.</returns>
-    public bool MoveCreature(ICreature creature, Location location, bool forced = false)
+    public bool MoveCreature(ICreature creature, Location location, bool forced = false, bool isTeleport = false)
     {
-        if (TryMoveCreature(creature, location, forced: forced)) return true;
+        if (TryMoveCreature(creature, location, forced: forced, isTeleport: isTeleport)) return true;
 
         OperationFailService.Send(creature.CreatureId, TextConstants.NOT_POSSIBLE);
         return false;
@@ -76,7 +80,7 @@ public class CreatureMovementService(
         return TryMoveCreature(creature, validation.DestinationTile.Location);
     }
 
-    private bool TryMoveCreature(ICreature creature, Location toLocation, bool forced = false)
+    private bool TryMoveCreature(ICreature creature, Location toLocation, bool forced = false, bool isTeleport = false)
     {
         if (creature is not IWalkableCreature walkableCreature) return false;
 
@@ -88,6 +92,12 @@ public class CreatureMovementService(
         }
 
         var tileDestination = map[toLocation];
+
+        if (tileDestination is StaticTile staticTile)
+        {
+            staticToDynamicTileService.TransformIntoDynamicTile(staticTile);
+            tileDestination = map[toLocation];
+        }
 
         // Immutable tiles cannot be modified, so movement fails.
         if (tileDestination is not IDynamicTile toTile)
@@ -109,7 +119,7 @@ public class CreatureMovementService(
         // Handle teleports: if the destination tile has a teleport, execute it.
         if (toTile.HasTeleport(out var teleport) && teleport.HasDestination)
         {
-            teleport.Teleport(walkableCreature);
+            TryMoveCreature(creature, teleport.Destination, true, true);
             return true;
         }
 
@@ -118,8 +128,11 @@ public class CreatureMovementService(
 
         if (tileDestination is null || tileDestination.Location == toLocation) return true;
 
+        //when creatures are sent to another place from a teleport, they should not be moved again to another place.
+        if (isTeleport) return true;
+
         // If there's a redirect destination, recursively attempt to move there.
-        TryMoveCreature(creature, tileDestination.Location);
+        TryMoveCreature(creature, tileDestination.Location, forced: true);
 
         return true;
     }

--- a/src/Core/NeoServer.Domain/Items/Items/TeleportItem.cs
+++ b/src/Core/NeoServer.Domain/Items/Items/TeleportItem.cs
@@ -12,7 +12,7 @@ public class TeleportItem : BaseItem
     {
     }
 
-    private Location Destination =>
+    public Location Destination =>
         Attributes.TryGetValue(ItemAttribute.TeleportDestination, out var destination) &&
         destination is Location destLocation
             ? destLocation

--- a/src/Core/NeoServer.Domain/Items/Items/UsableItems/FloorChangerUsableItem.cs
+++ b/src/Core/NeoServer.Domain/Items/Items/UsableItems/FloorChangerUsableItem.cs
@@ -6,7 +6,6 @@ using NeoServer.Domain.Common.Location.Structs;
 
 namespace NeoServer.Domain.Items.Items.UsableItems;
 
-[Obsolete]
 public class FloorChangerUsableItem : UsableOnItem, IUsableOnItem
 {
     public FloorChangerUsableItem(IItemType type, Location location) : base(type, location)
@@ -15,7 +14,6 @@ public class FloorChangerUsableItem : UsableOnItem, IUsableOnItem
 
     public override bool AllowUseOnDistance => false;
 
-    [Obsolete]
     public virtual bool Use(ICreature usedBy, IItem onItem)
     {
         Console.WriteLine("FloorChangerUsableItem.Use is obsolete. Implement lua script instead");

--- a/tests/NeoServer.Domain.Tests/Creature/Monster/MonsterWalkTest.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Monster/MonsterWalkTest.cs
@@ -1,4 +1,6 @@
-﻿using NeoServer.Domain.Common.Contracts.World.Tiles;
+﻿using Moq;
+using NeoServer.Domain.Common.Contracts.Services;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
 using NeoServer.Domain.Common.Creatures;
 using NeoServer.Domain.Common.Item;
 using NeoServer.Domain.Common.Location;
@@ -56,8 +58,10 @@ public class MonsterWalkTest
         var gameServer = GameServerTestBuilder.Build(map);
         var cancellationToken = ServerTestHelper.StartThreads(gameServer);
 
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
         var creatureMovementService =
-            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map));
+            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map),
+                staticToDynamicTileServiceMock.Object);
 
         sut.OnStartedWalking += new CreatureStartedWalkingEventHandler(gameServer, creatureMovementService).Execute;
 
@@ -109,8 +113,10 @@ public class MonsterWalkTest
 
         var gameServer = GameServerTestBuilder.Build(map);
         var cancellationToken = ServerTestHelper.StartThreads(gameServer);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
         var creatureMovementService =
-            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map));
+            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map),
+                staticToDynamicTileServiceMock.Object);
 
         sut.OnStartedWalking += new CreatureStartedWalkingEventHandler(gameServer, creatureMovementService).Execute;
 

--- a/tests/NeoServer.Domain.Tests/Creature/Summon/SummonTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Summon/SummonTests.cs
@@ -48,8 +48,10 @@ public class SummonTests
         (map[104, 105, 7] as DynamicTile)?.AddCreature(summon);
         (map[106, 105, 7] as DynamicTile)?.AddCreature(playerB);
 
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
         var creatureMovementService =
-            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map));
+            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map),
+                staticToDynamicTileServiceMock.Object);
 
         // Act
         // Move master to a position that triggers floor change to floor 6
@@ -104,8 +106,10 @@ public class SummonTests
 
         (map[105, 105, 7] as DynamicTile)?.AddCreature(master);
         (map[104, 105, 7] as DynamicTile)?.AddCreature(summon);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
         var creatureMovementService =
-            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map));
+            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map),
+                staticToDynamicTileServiceMock.Object);
 
         // Act
         // Move master 2 floors up (from 7 to 5)
@@ -128,8 +132,10 @@ public class SummonTests
 
         (map[105, 105, 7] as DynamicTile)?.AddCreature(master);
         (map[104, 105, 7] as DynamicTile)?.AddCreature(summon);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
         var creatureMovementService =
-            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map));
+            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map),
+                staticToDynamicTileServiceMock.Object);
 
         // Act
         // Move master 2 floors down (from 7 to 9)

--- a/tests/NeoServer.Domain.Tests/Helpers/Services/ItemTransformServiceTestBuilder.cs
+++ b/tests/NeoServer.Domain.Tests/Helpers/Services/ItemTransformServiceTestBuilder.cs
@@ -1,4 +1,6 @@
+using Moq;
 using NeoServer.Domain.Common.Contracts.DataStores;
+using NeoServer.Domain.Common.Contracts.Services;
 using NeoServer.Domain.Common.Contracts.World;
 using NeoServer.Domain.Creatures.Services;
 using NeoServer.Domain.Items.Services.ItemTransform;
@@ -12,8 +14,10 @@ public static class ItemTransformServiceTestBuilder
 {
     public static ItemTransformService Build(IMap map, IItemTypeStore itemTypeStore)
     {
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
+
         var creatureMovementService =
-            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map));
+            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map), staticToDynamicTileServiceMock.Object);
         var mapService = new MapService(map, creatureMovementService);
         var itemFactory = ItemFactoryTestBuilder.Build();
         return new ItemTransformService(itemFactory, map, mapService, itemTypeStore, null);

--- a/tests/NeoServer.Domain.Tests/Items/Items/FloorChangerUsableItemTests.cs
+++ b/tests/NeoServer.Domain.Tests/Items/Items/FloorChangerUsableItemTests.cs
@@ -41,16 +41,16 @@ public class FloorChangerUsableItemTests
         var aboveTile = new DynamicTile(new Coordinate(100, 100, 6), TileFlag.None, ground, null, null);
 
         var map = MapTestDataBuilder.Build(tile, aboveTile);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
         var creatureMovementService =
-            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map));
+            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map),
+                staticToDynamicTileServiceMock.Object);
 
         backpack.AddItem(floorChangerItem);
         var player = PlayerTestDataBuilder.Build(inventoryMap: new Dictionary<Slot, (IItem Item, ushort Id)>
         {
             [Slot.Backpack] = new(backpack, 1)
         });
-
-        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
         
         player.OnTeleported += new CreatureTeleportedEventHandler(map, creatureMovementService, staticToDynamicTileServiceMock.Object).Execute;
 
@@ -81,16 +81,16 @@ public class FloorChangerUsableItemTests
         var aboveTile = new DynamicTile(new Coordinate(101, 100, 6), TileFlag.None, ground, null, null);
 
         var map = MapTestDataBuilder.Build(tile, aboveTile);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
         var creatureMovementService =
-            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map));
+            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map),
+                staticToDynamicTileServiceMock.Object);
 
         backpack.AddItem(floorChangerItem);
         var player = PlayerTestDataBuilder.Build(inventoryMap: new Dictionary<Slot, (IItem Item, ushort Id)>
         {
             [Slot.Backpack] = new(backpack, 1)
         });
-        
-        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
 
         player.OnTeleported += new CreatureTeleportedEventHandler(map, creatureMovementService, staticToDynamicTileServiceMock.Object).Execute;
 

--- a/tests/NeoServer.Domain.Tests/Server/DecayableItemManagerTestBuilder.cs
+++ b/tests/NeoServer.Domain.Tests/Server/DecayableItemManagerTestBuilder.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using NeoServer.Domain.Common.Contracts.DataStores;
+using NeoServer.Domain.Common.Contracts.Services;
 using NeoServer.Domain.Common.Contracts.World;
 using NeoServer.Domain.Creatures.Services;
 using NeoServer.Domain.Items.Services;
@@ -16,8 +17,10 @@ public class DecayableItemManagerTestBuilder
 {
     public static DecayableItemManager Build(IMap map, IItemTypeStore itemTypeStore)
     {
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
         var creatureMovementService =
-            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map));
+            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map),
+                staticToDynamicTileServiceMock.Object);
 
         var mapService = new MapService(map, creatureMovementService);
         var itemFactory = ItemFactoryTestBuilder.Build();

--- a/tests/NeoServer.Domain.Tests/Systems/SafeTrade/TradeCancellationTests.cs
+++ b/tests/NeoServer.Domain.Tests/Systems/SafeTrade/TradeCancellationTests.cs
@@ -1,8 +1,10 @@
-﻿using NeoServer.Data.InMemory.DataStores;
+﻿using Moq;
+using NeoServer.Data.InMemory.DataStores;
 using NeoServer.Domain.Combat.Player;
 using NeoServer.Domain.Common.Combat.Structs;
 using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Common.Contracts.Items.Types;
+using NeoServer.Domain.Common.Contracts.Services;
 using NeoServer.Domain.Common.Contracts.World;
 using NeoServer.Domain.Common.Item;
 using NeoServer.Domain.Common.Location;
@@ -66,9 +68,10 @@ public class TradeCancellationTests
         tradeSystem.Request(player, secondPlayer, item);
 
         player.WalkTo(new Location(104, 100, 7));
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
         var creatureMovementService =
-            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map));
-
+            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map),
+                staticToDynamicTileServiceMock.Object);
 
         //player will walk 2 steps
         creatureMovementService.MoveCreature(player);
@@ -143,9 +146,10 @@ public class TradeCancellationTests
 
         var item = ItemTestDataBuilder.CreateWeaponItem(1);
         ((DynamicTile)map[100, 100, 7]).AddItem(item);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
         var creatureMovementService =
-            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map));
-
+            new CreatureMovementService(map, new CylinderOperation(map), new CreatureMovementValidation(map),
+                staticToDynamicTileServiceMock.Object);
 
         //act
         tradeSystem.Request(player, secondPlayer, item);

--- a/tests/NeoServer.Domain.Tests/World/MapMoveCreatureTest.cs
+++ b/tests/NeoServer.Domain.Tests/World/MapMoveCreatureTest.cs
@@ -25,9 +25,11 @@ public class MapMoveCreatureTest
         var player = PlayerTestDataBuilder.Build();
         player.SetNewLocation(new Location(50, 50, 7));
         sut.PlaceCreature(player);
+        
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
 
         var creatureMovementService =
-            new CreatureMovementService(sut, new CylinderOperation(sut), new CreatureMovementValidation(sut));
+            new CreatureMovementService(sut, new CylinderOperation(sut), new CreatureMovementValidation(sut), staticToDynamicTileServiceMock.Object);
 
         var result = creatureMovementService.MoveCreature(player, new Location(51, 50, 7));
 
@@ -36,16 +38,18 @@ public class MapMoveCreatureTest
     }
 
     [Fact]
-    public void TryMoveCreature_when_Teleport_Should_Move_Creature()
+    public void TryMoveCreature_When_Teleport_Should_Move_Creature()
     {
         var sut = MapTestDataBuilder.Build(1, 101, 1, 101, 6, 9);
         var player = PlayerTestDataBuilder.Build();
 
         player.SetNewLocation(new Location(50, 50, 7));
         sut.PlaceCreature(player);
+        
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
 
         var creatureMovementService =
-            new CreatureMovementService(sut, new CylinderOperation(sut), new CreatureMovementValidation(sut));
+            new CreatureMovementService(sut, new CylinderOperation(sut), new CreatureMovementValidation(sut), staticToDynamicTileServiceMock.Object);
 
         var result = creatureMovementService.MoveCreature(player, new Location(53, 50, 7));
 
@@ -73,8 +77,10 @@ public class MapMoveCreatureTest
             //no destination
         };
 
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
+
         var creatureMovementService =
-            new CreatureMovementService(sut, new CylinderOperation(sut), new CreatureMovementValidation(sut));
+            new CreatureMovementService(sut, new CylinderOperation(sut), new CreatureMovementValidation(sut), staticToDynamicTileServiceMock.Object);
 
         ((IDynamicTile)sut[teleportLocation]).AddItem(new TeleportItem(new ItemType(), teleportLocation));
 
@@ -108,9 +114,11 @@ public class MapMoveCreatureTest
             {
                 [teleportLocation] = [teleport]
             });
-
+        
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
+        
         var creatureMovementService =
-            new CreatureMovementService(sut, new CylinderOperation(sut), new CreatureMovementValidation(sut));
+            new CreatureMovementService(sut, new CylinderOperation(sut), new CreatureMovementValidation(sut), staticToDynamicTileServiceMock.Object);
 
         var pathFinder = new PathFinder(sut);
 
@@ -118,8 +126,6 @@ public class MapMoveCreatureTest
         player.SetCurrentTile((IDynamicTile)sut[100, 100, 7]);
         sut.PlaceCreature(player);
         
-        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
-
         player.OnStartedWalking += c => creatureMovementService.MoveCreature(c);
         player.OnTeleported += (a, b) => new CreatureTeleportedEventHandler(sut, creatureMovementService, staticToDynamicTileServiceMock.Object).Execute(a, b);
 

--- a/tests/NeoServer.Domain.Tests/World/TileHeightTests.cs
+++ b/tests/NeoServer.Domain.Tests/World/TileHeightTests.cs
@@ -1,5 +1,6 @@
 ﻿using Moq;
 using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Contracts.Services;
 using NeoServer.Domain.Common.Item;
 using NeoServer.Domain.Common.Location;
 using NeoServer.Domain.Common.Location.Structs;
@@ -107,7 +108,9 @@ public class TileHeightTests
         tile1StFloor.AddCreature(player);
 
         var validation = new CreatureMovementValidation(map);
-        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
+        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation,
+            staticToDynamicTileServiceMock.Object);
 
         //act
         player.WalkTo(Direction.East);
@@ -140,7 +143,9 @@ public class TileHeightTests
         tile1StFloor.AddCreature(player);
 
         var validation = new CreatureMovementValidation(map);
-        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
+        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation,
+            staticToDynamicTileServiceMock.Object);
 
         //act
         player.WalkTo(Direction.East);
@@ -184,7 +189,9 @@ public class TileHeightTests
 
         tile2StFloor.AddCreature(player);
         var validation = new CreatureMovementValidation(map);
-        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
+        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation,
+            staticToDynamicTileServiceMock.Object);
 
         //act
         player.WalkTo(Direction.West);
@@ -217,7 +224,9 @@ public class TileHeightTests
 
         tile2StFloor.AddCreature(player);
         var validation = new CreatureMovementValidation(map);
-        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
+        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation,
+            staticToDynamicTileServiceMock.Object);
 
         //act
         player.WalkTo(Direction.West);

--- a/tests/NeoServer.Domain.Tests/World/TileTest.cs
+++ b/tests/NeoServer.Domain.Tests/World/TileTest.cs
@@ -255,7 +255,10 @@ public class TileTest
         player.SetNewLocation(new Location(102, 100, 7));
 
         var validation = new CreatureMovementValidation(map);
-        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
+
+        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation,
+            staticToDynamicTileServiceMock.Object);
         var mapService = new MapService(map, creatureMovementService);
 
         var item = ItemTestDataBuilder.CreateWeaponItem(1);
@@ -319,9 +322,12 @@ public class TileTest
 
         var itemMovementService =
             new ItemMovementService(new WalkToMechanism(GameServerTestBuilder.Build(map).Scheduler), mailService);
+        
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
 
         var validation = new CreatureMovementValidation(map);
-        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation);
+        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation,
+            staticToDynamicTileServiceMock.Object);
         var mapService = new MapService(map, creatureMovementService);
 
         mapService.ReplaceGround(destinationTile.Location, hole);
@@ -350,7 +356,9 @@ public class TileTest
         player.SetNewLocation(new Location(102, 100, 7));
 
         var validation = new CreatureMovementValidation(map);
-        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
+        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation,
+            staticToDynamicTileServiceMock.Object);
         var mapService = new MapService(map, creatureMovementService);
 
         var item = ItemTestDataBuilder.CreateWeaponItem(1);
@@ -401,7 +409,9 @@ public class TileTest
         var player = PlayerTestDataBuilder.Build();
 
         var validation = new CreatureMovementValidation(map);
-        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
+        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation,
+            staticToDynamicTileServiceMock.Object);
         var mapService = new MapService(map, creatureMovementService);
 
         player.SetNewLocation(new Location(102, 100, 7));
@@ -437,7 +447,9 @@ public class TileTest
         var map = MapTestDataBuilder.Build(100, 105, 100, 105, 7, 8);
 
         var validation = new CreatureMovementValidation(map);
-        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation);
+        var staticToDynamicTileServiceMock = new Mock<IStaticToDynamicTileService>();
+        var creatureMovementService = new CreatureMovementService(map, new CylinderOperation(map), validation,
+            staticToDynamicTileServiceMock.Object);
         var mapService = new MapService(map, creatureMovementService);
 
         var player = PlayerTestDataBuilder.Build();


### PR DESCRIPTION
### Description
- Injected `IStaticToDynamicTileService` mock in `CreatureMovementService` test cases to improve unit test reliability.
- Fixed a bug where the player would not descend if the hole led to an unwalkable tile.
- fix #924

### Key Changes
- Added `IStaticToDynamicTileService` mock to relevant test cases.
- Updated player movement logic to handle descent to unwalkable tiles correctly.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
- Verified that `CreatureMovementService` test cases now consider `IStaticToDynamicTileService`.
- Tested and confirmed that the player properly descends even when the hole leads to an unwalkable tile.