### PR TITLE
Fix mana shield health reduction when mana is depleted

### DIFF
--- a/src/Core/NeoServer.Domain/Common/Combat/Structs/CombatDamageList.cs
+++ b/src/Core/NeoServer.Domain/Common/Combat/Structs/CombatDamageList.cs
@@ -1,81 +1,101 @@
+using System.Collections;
 using System.Collections.Immutable;
 using NeoServer.Domain.Common.Item;
 
 namespace NeoServer.Domain.Common.Combat.Structs;
 
-public readonly struct CombatDamageList
+public class CombatDamageList : IEnumerable<CombatDamage>
 {
-    private readonly CombatDamage _singleDamage;
-    private readonly ImmutableArray<CombatDamage> _multipleDamages;
+    private readonly Dictionary<DamageType, CombatDamage> _damages = new(3);
+
+    public CombatDamageList()
+    {
+    }
 
     public CombatDamageList(CombatDamage damage)
     {
-        _singleDamage = damage;
-        _multipleDamages = default;
         Unjustified = damage.Unjustified;
+        AddDamage(damage);
     }
 
-    public CombatDamageList(ImmutableArray<CombatDamage> damages)
+    public CombatDamageList(CombatDamage[] damages)
     {
-        _singleDamage = null;
-        _multipleDamages = damages;
-
         foreach (var damage in damages)
         {
+            AddDamage(damage);
+
             if (damage is { Unjustified: true })
             {
                 Unjustified = true;
-                break;
             }
         }
     }
 
-    public bool IsSingle => _multipleDamages.IsDefaultOrEmpty;
-    public int Count => IsSingle ? 1 : _multipleDamages.Length;
+    public void AddDamage(CombatDamage damage)
+    {
+        if (_damages.TryGetValue(damage.Type, out var existingDamage))
+        {
+            existingDamage.IncreaseDamage(damage.Damage);
+        }
+        else
+        {
+            _damages[damage.Type] = damage;
+        }
+
+        if (damage.Type is DamageType.ManaDrain)
+        {
+            return;
+        }
+    }
+
+    public void ReduceHealthDamage(int damage)
+    {
+        foreach (var damageRecord in _damages.Values)
+        {
+            if (damageRecord.Type is not DamageType.ManaDrain)
+            {
+                damageRecord.IncreaseDamage(-damage);
+            }
+        }
+    }
+
+    public int Count => _damages.Count;
 
     public bool Unjustified { get; }
 
-    public void SetDamagesAsManaDrain()
-    {
-        _singleDamage?.ChangeDamageType(DamageType.ManaDrain);
+    public Damage TotalDamage {
 
-        if (_multipleDamages != null)
-        {
-            foreach (var multipleDamage in _multipleDamages)
-            {
-                multipleDamage.ChangeDamageType(DamageType.ManaDrain);
-            }
-        }
-    }
-
-    public Damage TotalDamage
-    {
         get
         {
-            ushort health = 0, mana = 0;
-
-            foreach (var damage in this)
+            var manaDamage = 0;
+            var healthDamage = 0;
+            
+            foreach (var damage in _damages.Values)
             {
-                if (damage == null)
-                    continue;
-
                 if (damage.Type is DamageType.ManaDrain)
-                    mana += damage.Damage;
-                else
-                    health += damage.Damage;
+                {
+                    manaDamage += damage.Damage;
+                    continue;
+                }
+                
+                healthDamage += damage.Damage;
             }
-
-            return new Damage(health, mana);
+            
+            return new Damage((ushort)Math.Max(0, healthDamage), (ushort)Math.Max(0, manaDamage)); 
         }
     }
 
-    public CombatDamage Damage
+public CombatDamage RegularDamage
     {
         get
         {
             foreach (var damage in this)
+            {
                 if (damage is { IsElementalDamage: false, Damage: > 0 })
+                {
                     return damage;
+                }
+            }
 
             return new CombatDamage();
         }
@@ -93,30 +113,13 @@ public readonly struct CombatDamageList
         }
     }
 
-    // Enumerator struct — no allocation
-    public Enumerator GetEnumerator()
+    public IEnumerator<CombatDamage> GetEnumerator()
     {
-        return new Enumerator(this);
+        return _damages.Values.GetEnumerator();
     }
 
-    public ref struct Enumerator(CombatDamageList list)
+    IEnumerator IEnumerable.GetEnumerator()
     {
-        private int _index = -1;
-
-        public CombatDamage Current
-        {
-            get
-            {
-                if (list.IsSingle)
-                    return list._singleDamage;
-                return list._multipleDamages[_index];
-            }
-        }
-
-        public bool MoveNext()
-        {
-            _index++;
-            return list._multipleDamages.IsDefaultOrEmpty ? _index == 0 : _index < list._multipleDamages.Length;
-        }
+        return GetEnumerator();
     }
 }

--- a/src/Core/NeoServer.Domain/Common/Item/DamageType.cs
+++ b/src/Core/NeoServer.Domain/Common/Item/DamageType.cs
@@ -2,7 +2,7 @@
 
 public enum DamageType : byte
 {
-    None = default,
+    None = 0,
     Ice,
     Fire,
     Physical,

--- a/src/Core/NeoServer.Domain/Creatures/Models/Bases/CombatActor.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Models/Bases/CombatActor.cs
@@ -416,6 +416,7 @@ public abstract class CombatActor(ICreatureType type, IMapTool mapTool, Outfit o
 
     protected void ReduceHealth(ushort damage)
     {
+        if (damage == 0) return;
         HealthPoints = damage > HealthPoints ? 0 : HealthPoints - damage;
     }
 

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -1663,14 +1663,17 @@ public class Player : CombatActor, IPlayer
         if (totalDamage.ManaDamage > 0)
         {
             DecreaseMana(totalDamage.ManaDamage);
-            return;
         }
 
-        if (IsManaShieldEnabled)
+        if (IsManaShieldEnabled && Mana > 0)
         {
-            DecreaseMana(totalDamage.HealthDamage);
-            damages.SetDamagesAsManaDrain();
-            return;
+            var totalHealthDamage = Math.Min(totalDamage.HealthDamage, (int)Mana);
+            damages.ReduceHealthDamage(totalHealthDamage);
+          
+            DecreaseMana((uint)totalHealthDamage);
+            damages.AddDamage(new CombatDamage((ushort)totalHealthDamage, DamageType.ManaDrain));
+            
+            totalDamage = damages.TotalDamage;
         }
 
         ReduceHealth(totalDamage.HealthDamage);

--- a/src/Extensions/NeoServer.Scripts.LuaJIT/CreatureEvent.cs
+++ b/src/Extensions/NeoServer.Scripts.LuaJIT/CreatureEvent.cs
@@ -316,8 +316,8 @@ public class CreatureEvent(LuaScriptInterface scriptInterface, ILogger logger, I
         LuaScriptInterface.SetMetatable(luaState, -1, "Creature");
 
         //Primary damage
-        Lua.PushNumber(luaState, (byte)combatDamageList.Damage.Type);
-        Lua.PushNumber(luaState, combatDamageList.Damage.Damage);
+        Lua.PushNumber(luaState, (byte)combatDamageList.RegularDamage.Type);
+        Lua.PushNumber(luaState, combatDamageList.RegularDamage.Damage);
 
         //Secondary damage
         Lua.PushNumber(luaState, (byte)combatDamageList.ElementalDamage.Type);

--- a/src/Extensions/NeoServer.Scripts.LuaJIT/Events/Creatures/CreatureInjuredEventHandler.cs
+++ b/src/Extensions/NeoServer.Scripts.LuaJIT/Events/Creatures/CreatureInjuredEventHandler.cs
@@ -14,7 +14,7 @@ public class CreatureInjuredEventHandler(ICreatureEvents creatureEvents)
     {
         foreach (var creatureEvent in creatureEvents.GetCreatureEvents(
                      @event.Victim.CreatureId,
-                     @event.DamageList.Damage.Type == DamageType.ManaDrain
+                     @event.DamageList.RegularDamage.Type == DamageType.ManaDrain
                          ? CreatureEventType.CREATURE_EVENT_MANACHANGE
                          : CreatureEventType.CREATURE_EVENT_HEALTHCHANGE))
             creatureEvent.ExecuteOnDamageReceivedChange(@event.Victim, @event.Enemy as ICreature, @event.DamageList);

--- a/tests/NeoServer.Domain.Tests/Creature/Players/PlayerTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Players/PlayerTests.cs
@@ -79,6 +79,71 @@ public class PlayerTests
     }
 
     [Fact]
+    public void OnDamage_With_ManaShield_Enabled_When_Damage_Less_Than_Mana_Reduce_Only_Mana()
+    {
+        var sut = PlayerTestDataBuilder.Build(hp: 100, mana: 100) as Player;
+        var enemy = PlayerTestDataBuilder.Build() as Player;
+        sut.EnableManaShield();
+        
+        sut.OnDamage(enemy, new CombatDamageList(new CombatDamage(50, DamageType.Melee)));
+
+        Assert.Equal((uint)50, sut.Mana);
+        Assert.Equal((uint)100, sut.HealthPoints);
+    }
+
+    [Fact]
+    public void OnDamage_With_ManaShield_Enabled_When_Damage_Greater_Than_Mana_Reduce_Mana_And_Health()
+    {
+        var sut = PlayerTestDataBuilder.Build(hp: 100, mana: 100) as Player;
+        var enemy = PlayerTestDataBuilder.Build() as Player;
+        sut.EnableManaShield();
+        
+        sut.OnDamage(enemy, new CombatDamageList(new CombatDamage(150, DamageType.Melee)));
+
+        Assert.Equal((uint)0, sut.Mana);
+        Assert.Equal((uint)50, sut.HealthPoints);
+    }
+
+    [Fact]
+    public void OnDamage_With_ManaShield_Enabled_When_Damage_Equal_To_Mana_Reduce_Only_Mana()
+    {
+        var sut = PlayerTestDataBuilder.Build(hp: 100, mana: 100) as Player;
+        var enemy = PlayerTestDataBuilder.Build() as Player;
+        sut.EnableManaShield();
+        
+        sut.OnDamage(enemy, new CombatDamageList(new CombatDamage(100, DamageType.Melee)));
+
+        Assert.Equal((uint)0, sut.Mana);
+        Assert.Equal((uint)100, sut.HealthPoints);
+    }
+
+    [Fact]
+    public void OnDamage_With_ManaShield_Enabled_When_Receiving_Melee_And_ManaDrain_Reduce_Mana()
+    {
+        var sut = PlayerTestDataBuilder.Build(hp: 100, mana: 100) as Player;
+        var enemy = PlayerTestDataBuilder.Build() as Player;
+        sut.EnableManaShield();
+        
+        sut.OnDamage(enemy, new CombatDamageList([new CombatDamage(50, DamageType.Melee), new CombatDamage(50, DamageType.ManaDrain)]));
+
+        Assert.Equal((uint)0, sut.Mana);
+        Assert.Equal((uint)100, sut.HealthPoints);
+    }
+
+    [Fact]
+    public void OnDamage_With_ManaShield_Enabled_And_Zero_Mana_When_Receiving_Melee_And_ManaDrain_Reduce_Health()
+    {
+        var sut = PlayerTestDataBuilder.Build(hp: 100, mana: 0) as Player;
+        var enemy = PlayerTestDataBuilder.Build() as Player;
+        sut.EnableManaShield();
+        
+        sut.OnDamage(enemy, new CombatDamageList([new CombatDamage(50, DamageType.Melee), new CombatDamage(50, DamageType.ManaDrain)]));
+
+        Assert.Equal((uint)0, sut.Mana);
+        Assert.Equal((uint)50, sut.HealthPoints);
+    }
+
+    [Fact]
     public void FlagIsEnabled_Enabled_ReturnsTrue()
     {
         var sut = PlayerTestDataBuilder.Build();


### PR DESCRIPTION
### Description
Fixes an issue where the mana shield mechanic failed to reduce health correctly once mana was depleted.
fix #934

### Key Changes
- Added unit tests for mana shield scenarios, testing damage splitting between health and mana.
- Refactored `CombatDamageList` to enable damage aggregation by type and improve health damage reduction logic.
- Updated the `Player` class to handle mana shield behavior using the updated `CombatDamageList`.
- Fixed Lua integration to use `RegularDamage`