### PR TITLE
fix: make monster visible upon receiving damage and add related tests

### DIFF
--- a/src/Core/NeoServer.Domain/Creatures/Models/Bases/CombatActor.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Models/Bases/CombatActor.cs
@@ -288,6 +288,8 @@ public abstract class CombatActor(ICreatureType type, IMapTool mapTool, Outfit o
 
     public virtual void TurnVisible()
     {
+        if (!IsInvisible) return;
+        
         IsInvisible = false;
         EventAggregator.Invoke(new CreatureChangedVisibilityEvent(this));
     }

--- a/src/Core/NeoServer.Domain/Creatures/Monster/Monster.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Monster/Monster.cs
@@ -567,6 +567,10 @@ public class Monster : WalkableMonster, IMonster
     public override void OnDamage(IThing enemy, CombatDamageList damages)
     {
         ReduceHealth(damages.TotalDamage.HealthDamage);
+        if (damages.TotalDamage.HealthDamage > 0)
+        {
+          TurnVisible();
+        }
     }
 
     internal void ChangeAttackTarget(ICreature creature)

--- a/tests/NeoServer.Domain.Tests/Creature/Monster/MonsterCombatTest.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Monster/MonsterCombatTest.cs
@@ -668,6 +668,60 @@ public class MonsterCombatTest
         sut.Attacking.Should().BeTrue();
     }
 
+    [Fact]
+    public void Monster_becomes_visible_when_receives_damage()
+    {
+        // Given
+        var map = MapTestDataBuilder.Build(100, 105, 100, 105, 7, 7);
+
+        var player = PlayerTestDataBuilder.Build();
+        player.SetNewLocation(new Location(101, 102, 7));
+
+        var monster = MonsterTestDataBuilder.Build();
+        monster.SetNewLocation(new Location(102, 102, 7));
+        monster.TurnInvisible(); // Monster starts invisible
+
+        map.PlaceCreature(player);
+        map.PlaceCreature(monster);
+
+        // Verify monster is initially invisible
+        monster.IsInvisible.Should().BeTrue();
+
+        // When
+        var damage = new CombatDamage(10, DamageType.Physical);
+        monster.TakeDamage(player, new CombatDamageList(damage));
+
+        // Then
+        monster.IsInvisible.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Monster_remains_invisible_when_receives_zero_damage()
+    {
+        // Given
+        var map = MapTestDataBuilder.Build(100, 105, 100, 105, 7, 7);
+
+        var player = PlayerTestDataBuilder.Build();
+        player.SetNewLocation(new Location(101, 102, 7));
+
+        var monster = MonsterTestDataBuilder.Build();
+        monster.SetNewLocation(new Location(102, 102, 7));
+        monster.TurnInvisible(); // Monster starts invisible
+
+        map.PlaceCreature(player);
+        map.PlaceCreature(monster);
+
+        // Verify monster is initially invisible
+        monster.IsInvisible.Should().BeTrue();
+
+        // When
+        var damage = new CombatDamage(0, DamageType.Physical);
+        monster.TakeDamage(player, new CombatDamageList(damage));
+
+        // Then
+        monster.IsInvisible.Should().BeTrue();
+    }
+
     private static MonsterStateService BuildMonsterStateService(
         ISummonService summonService,
         IMap map,


### PR DESCRIPTION
### Description
Fix #928 Make monster visible upon receiving damage and add related tests

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
Was created unit tests.
