### PR TITLE
Ensure correct player follow stop behavior and spectator handling

### DIFF
--- a/src/ApplicationServer/NeoServer.Server.Commands/Player/PlayerFollowCommand.cs
+++ b/src/ApplicationServer/NeoServer.Server.Commands/Player/PlayerFollowCommand.cs
@@ -7,6 +7,12 @@ public class PlayerFollowCommand : ICommand
 {
     public void Execute(IPlayer player, ICreature target)
     {
+        if (target is null)
+        {
+            player.StopFollowing();
+            return;
+        }
+        
         player.StopAttack();
         player.Follow(target);
     }

--- a/src/ApplicationServer/NeoServer.Server.Events/Creature/CreatureChangedVisibilityEventHandler.cs
+++ b/src/ApplicationServer/NeoServer.Server.Events/Creature/CreatureChangedVisibilityEventHandler.cs
@@ -11,6 +11,6 @@ public class CreatureChangedVisibilityEventHandler(IMap map)
     {
         var creature = @event.Creature;
         foreach (var spectator in map.GetSpectators(creature.Location))
-            creature.OnSpectatorChangedVisibility(spectator);
+            spectator.OnSpectatorChangedVisibility(creature);
     }
 }

--- a/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IWalkableCreature.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IWalkableCreature.cs
@@ -23,7 +23,7 @@ public delegate void Moved(IWalkableCreature creature, Location.Structs.Location
 
 public interface IWalkableCreature : ICreature
 {
-    ICreature Following { get; }
+    ICreature FollowCreature { get; }
     bool HasNextStep { get; }
     bool IsFollowing { get; }
     ushort RawSpeed { get; }

--- a/src/Core/NeoServer.Domain/Creatures/Events/StoppedFollowEvent.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Events/StoppedFollowEvent.cs
@@ -1,0 +1,6 @@
+using NeoServer.Domain.Common;
+using NeoServer.Domain.Common.Contracts.Creatures;
+
+namespace NeoServer.Domain.Creatures.Events;
+
+public record StoppedFollowEvent(IWalkableCreature Creature) : IEvent;

--- a/src/Core/NeoServer.Domain/Creatures/Models/Bases/WalkableCreature.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Models/Bases/WalkableCreature.cs
@@ -1,10 +1,12 @@
 ﻿using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Common.Contracts.World;
 using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Common;
 using NeoServer.Domain.Common.Creatures;
 using NeoServer.Domain.Common.Helpers;
 using NeoServer.Domain.Common.Location;
 using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Creatures.Events;
 using NeoServer.Domain.Creatures.Player.Outfit;
 
 namespace NeoServer.Domain.Creatures.Models.Bases;
@@ -37,8 +39,8 @@ public abstract class WalkableCreature : Creature, IWalkableCreature
     public virtual ITileEnterRule TileEnterRule => PlayerEnterTileRule.Rule;
     public virtual ushort Speed { get; protected set; }
 
-    public ICreature Following { get; private set; }
-    public bool IsFollowing => Following is not null;
+    public ICreature FollowCreature { get; private set; }
+    public bool IsFollowing => FollowCreature is not null;
     public bool HasNextStep => _walkingQueue.Count > 0;
 
     public virtual void OnMoved(IDynamicTile fromTile, IDynamicTile toTile, ICylinderSpectator[] spectators)
@@ -103,10 +105,13 @@ public abstract class WalkableCreature : Creature, IWalkableCreature
     {
         if (!IsFollowing) return;
 
-        Following = null;
+        FollowCreature = null;
         HasFollowPath = false;
         _walkUpdateTicks = 0;
         _forceUpdateFollowPath = false;
+
+        EventAggregator.Invoke(new StoppedFollowEvent(this));
+        
         StopWalking();
     }
 
@@ -122,7 +127,7 @@ public abstract class WalkableCreature : Creature, IWalkableCreature
             {
                 _walkUpdateTicks = 0;
                 _forceUpdateFollowPath = false;
-                Follow(Following);
+                Follow(FollowCreature);
             }
         }
     }
@@ -151,12 +156,12 @@ public abstract class WalkableCreature : Creature, IWalkableCreature
 
         if (IsFollowing)
         {
-            Following = creature;
+            FollowCreature = creature;
             StartFollowing(creature);
             return;
         }
 
-        Following = creature;
+        FollowCreature = creature;
         _forceUpdateFollowPath = false;
 
         StartFollowing(creature);
@@ -240,13 +245,13 @@ public abstract class WalkableCreature : Creature, IWalkableCreature
 
     public override void OnSpectatorMoved(ICreature spectator)
     {
-        if (Equals(spectator, Following)) //followed creature moved
+        if (Equals(spectator, FollowCreature)) //followed creature moved
         {
             // If we have no more steps in our walk queue, immediately recalculate the follow path
             if (!HasNextStep && HasFollowPath)
             {
                 _forceUpdateFollowPath = false;
-                Follow(Following);
+                Follow(FollowCreature);
             }
             else
             {
@@ -284,6 +289,7 @@ public abstract class WalkableCreature : Creature, IWalkableCreature
         if (!result.Found)
         {
             HasFollowPath = false;
+            StopWalking();
             return;
         }
 

--- a/src/Core/NeoServer.Domain/Creatures/Monster/Summon/Summon.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Monster/Summon/Summon.cs
@@ -33,7 +33,7 @@ public class Summon : Monster
         {
             var fpp = base.PathSearchParams;
             fpp.MinTargetDist = 1;
-            fpp.MaxTargetDist = Equals(Following, Master) ? 2 : TargetDistance;
+            fpp.MaxTargetDist = Equals(FollowCreature, Master) ? 2 : TargetDistance;
             fpp.FullPathSearch = true;
             fpp.KeepDistance = false;
             fpp.ClearSight = true;

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -518,7 +518,7 @@ public class Player : CombatActor, IPlayer
     public override void OnSpectatorChangedVisibility(ICreature spectator)
     {
         // If the spectator is an invisible monster that the player is following, stop following it.
-        if (spectator is IMonster && spectator.CreatureId == FollowCreature.CreatureId && spectator.IsInvisible)
+        if (spectator is IMonster && Equals(spectator, FollowCreature) && spectator.IsInvisible)
         {
             StopFollowing();
         }

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -497,6 +497,7 @@ public class Player : CombatActor, IPlayer
 
     public override void OnSpectatorChangedVisibility(ICreature spectator)
     {
+        // If the spectator is an invisible monster that the player is following, stop following it.
         if (spectator is IMonster && spectator.CreatureId == Following.CreatureId && spectator.IsInvisible)
         {
             StopFollowing();
@@ -1448,6 +1449,7 @@ public class Player : CombatActor, IPlayer
         var showError = CurrentTarget is not ICombatActor { IsDead: true };
 
         StopAttack();
+        StopFollowing();
 
         if (showError) OperationFailService.Send(this, InvalidOperation.TargetLost);
     }

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -492,13 +492,33 @@ public class Player : CombatActor, IPlayer
         if (spectator is not ICombatActor target) return;
         if (target.Equals(CurrentTarget)) HandleTargetLost();
 
+        // If the spectator is the creature being followed and the player can no longer see it, stop following.
+        if (Equals(spectator, FollowCreature) && !CanSee(spectator.Location))
+        {
+            StopFollowing();
+        }
+
         base.OnSpectatorMoved(spectator);
+    }
+
+    public override void OnSpectatorLoggedOut(ICreature spectator)
+    {
+        if (spectator is not ICombatActor target) return;
+        if (target.Equals(CurrentTarget)) HandleTargetLost();
+
+        // If the spectator is the creature being followed, stop following.
+        if (Equals(spectator, FollowCreature))
+        {
+            StopFollowing();
+        }
+        
+        base.OnSpectatorLoggedOut(spectator);
     }
 
     public override void OnSpectatorChangedVisibility(ICreature spectator)
     {
         // If the spectator is an invisible monster that the player is following, stop following it.
-        if (spectator is IMonster && spectator.CreatureId == Following.CreatureId && spectator.IsInvisible)
+        if (spectator is IMonster && spectator.CreatureId == FollowCreature.CreatureId && spectator.IsInvisible)
         {
             StopFollowing();
         }
@@ -509,6 +529,12 @@ public class Player : CombatActor, IPlayer
     public override void OnSpectatorDies(ICombatActor spectator)
     {
         if (spectator.Equals(CurrentTarget)) HandleTargetLost();
+        
+        // If the spectator is the creature being followed, stop following.
+        if (Equals(spectator, FollowCreature))
+        {
+            StopFollowing();
+        }
 
         base.OnSpectatorDies(spectator);
     }
@@ -569,13 +595,16 @@ public class Player : CombatActor, IPlayer
         var oldChaseMode = ChaseMode;
         ChaseMode = mode;
 
-        if (ChaseMode == ChaseMode.Follow && CurrentTarget is not null)
+        if (CurrentTarget is not null)
         {
-            Follow(CurrentTarget as IWalkableCreature, PathSearchParams);
-            return;
+            if (ChaseMode == ChaseMode.Follow && CurrentTarget is not null)
+            {
+                Follow(CurrentTarget as IWalkableCreature, PathSearchParams);
+                return;
+            }
+            
+            StopFollowing();
         }
-
-        StopFollowing();
 
         OnChangedChaseMode?.Invoke(this, oldChaseMode, mode);
     }
@@ -1745,6 +1774,7 @@ public class Player : CombatActor, IPlayer
     public override void Think(int interval)
     {
         HandleTargetLost();
+        base.Think(interval);
         EventAggregator.Invoke(new PlayerThinkEvent(this, interval));
     }
 

--- a/src/Database/NeoServer.Data/Seeds/PlayerModelSeed.cs
+++ b/src/Database/NeoServer.Data/Seeds/PlayerModelSeed.cs
@@ -11,7 +11,7 @@ internal static class PlayerModelSeed
     {
         builder.HasData(
             CreatePlayerEntity(1, "GOD", 11, 6, 1000, 4440, 4440, 1750, 1750, 1020, 1022, 7, 2520, 75),
-            CreatePlayerEntity(2, "Sorcerer Sample", 1, 1, 500, 2645, 2645, 14850, 14850, 1020, 1022, 7, 2520, 130, 69,
+            CreatePlayerEntity(2, "Sorcerer Sample", 1, 1, 8, 2645, 2645, 14850, 14850, 1020, 1022, 7, 2520, 130, 69,
                 95, 78, 58),
             CreatePlayerEntity(3, "Knight Sample", 4, 1, 500, 4440, 4440, 1750, 1750, 1020, 1022, 7, 2520, 131, 69, 95,
                 78, 58),
@@ -35,7 +35,7 @@ internal static class PlayerModelSeed
             AccountId = accountId,
             TownId = 1,
             Name = name,
-            ChaseMode = ChaseMode.Follow,
+            ChaseMode = ChaseMode.Stand,
             Capacity = CalculateCapacity(vocation),
             Level = level,
             Health = health,

--- a/src/Database/NeoServer.Data/Seeds/PlayerModelSeed.cs
+++ b/src/Database/NeoServer.Data/Seeds/PlayerModelSeed.cs
@@ -11,7 +11,7 @@ internal static class PlayerModelSeed
     {
         builder.HasData(
             CreatePlayerEntity(1, "GOD", 11, 6, 1000, 4440, 4440, 1750, 1750, 1020, 1022, 7, 2520, 75),
-            CreatePlayerEntity(2, "Sorcerer Sample", 1, 1, 8, 2645, 2645, 14850, 14850, 1020, 1022, 7, 2520, 130, 69,
+            CreatePlayerEntity(2, "Sorcerer Sample", 1, 1, 500, 2645, 2645, 14850, 14850, 1020, 1022, 7, 2520, 130, 69,
                 95, 78, 58),
             CreatePlayerEntity(3, "Knight Sample", 4, 1, 500, 4440, 4440, 1750, 1750, 1020, 1022, 7, 2520, 131, 69, 95,
                 78, 58),

--- a/src/NetworkingServer/NeoServer.Networking.Handlers/Player/PlayerFollowHandler.cs
+++ b/src/NetworkingServer/NeoServer.Networking.Handlers/Player/PlayerFollowHandler.cs
@@ -12,7 +12,7 @@ public class PlayerFollowHandler(IGameServer game, PlayerFollowCommand playerFol
         var targetId = message.GetUInt32();
 
         if (!game.CreatureManager.TryGetPlayer(connection.CreatureId, out var player)) return;
-        if (!game.CreatureManager.TryGetCreature(targetId, out var target)) return;
+        game.CreatureManager.TryGetCreature(targetId, out var target);
         
         game.Scheduler.AddEvent(new SchedulerEvent(200, () =>
         {

--- a/src/NetworkingServer/NeoServer.Networking/EventHandlers/Creature/StoppedFollowEventHandler.cs
+++ b/src/NetworkingServer/NeoServer.Networking/EventHandlers/Creature/StoppedFollowEventHandler.cs
@@ -1,0 +1,25 @@
+using NeoServer.Domain.Common;
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Creatures.Events;
+using NeoServer.Networking.Packets.Outgoing.Player;
+using NeoServer.Server.Common.Contracts;
+
+namespace NeoServer.Networking.EventHandlers.Creature;
+
+public class StoppedFollowEventHandler(IGameServer game) : INetworkingEventHandler<StoppedFollowEvent>
+{
+    public void Handle(StoppedFollowEvent @event)
+    {
+        if (@event.Creature is not IPlayer player) return;
+        if (!game.CreatureManager.GetPlayerConnection(player.CreatureId, out var connection)) return;
+        
+        // If the player is attacking, do not cancel the target when stopped follow.
+        if (player.Attacking)
+        {
+            return;
+        }
+
+        connection.OutgoingPackets.Enqueue(new CancelTargetPacket());
+        connection.Send();
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Creature/Players/PlayerFollowTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Players/PlayerFollowTests.cs
@@ -100,4 +100,118 @@ public class PlayerFollowTests
         sut.HasNextStep.Should().BeFalse();
         monitor.Should().Raise(nameof(sut.OnStoppedWalking));
     }
+
+    [Fact]
+    public void Player_stops_following_when_followed_creature_dies()
+    {
+        //arrange
+
+        var map = MapTestDataBuilder.Build(100, 110, 100, 110, 7, 7);
+
+        var sut = PlayerTestDataBuilder.Build(hp: 200);
+        var enemy = MonsterTestDataBuilder.Build(100);
+        using var monitor = sut.Monitor();
+
+        var fpp = new FindPathParams(true, true, true, false, 12, 0, 12);
+
+        (map[100, 100, 7] as DynamicTile)?.AddCreature(sut);
+        (map[100, 107, 7] as DynamicTile)?.AddCreature(enemy);
+
+        sut.Follow(enemy, fpp);
+
+        //act
+        sut.OnSpectatorDies(enemy);
+
+        //assert
+        sut.IsFollowing.Should().BeFalse();
+        sut.FollowCreature.Should().BeNull();
+        monitor.Should().Raise(nameof(sut.OnStoppedWalking));
+    }
+
+    [Fact]
+    public void Player_stops_following_when_followed_creature_becomes_invisible()
+    {
+        //arrange
+
+        var map = MapTestDataBuilder.Build(100, 110, 100, 110, 7, 7);
+
+        var sut = PlayerTestDataBuilder.Build(hp: 200);
+        var enemy = MonsterTestDataBuilder.Build(100);
+        using var monitor = sut.Monitor();
+
+        var fpp = new FindPathParams(true, true, true, false, 12, 0, 12);
+
+        (map[100, 100, 7] as DynamicTile)?.AddCreature(sut);
+        (map[100, 107, 7] as DynamicTile)?.AddCreature(enemy);
+
+        sut.Follow(enemy, fpp);
+        
+        enemy.TurnInvisible();
+
+        //act
+        sut.OnSpectatorChangedVisibility(enemy);
+
+        //assert
+        sut.IsFollowing.Should().BeFalse();
+        sut.FollowCreature.Should().BeNull();
+        monitor.Should().Raise(nameof(sut.OnStoppedWalking));
+    }
+
+    [Fact]
+    public void Player_stops_following_when_followed_player_logs_out()
+    {
+        //arrange
+
+        var map = MapTestDataBuilder.Build(100, 110, 100, 110, 7, 7);
+
+        var sut = PlayerTestDataBuilder.Build(hp: 200);
+        var otherPlayer = PlayerTestDataBuilder.Build(hp: 200);
+        using var monitor = sut.Monitor();
+
+        var fpp = new FindPathParams(true, true, true, false, 12, 0, 12);
+
+        (map[100, 100, 7] as DynamicTile)?.AddCreature(sut);
+        (map[100, 107, 7] as DynamicTile)?.AddCreature(otherPlayer);
+
+        sut.Follow(otherPlayer, fpp);
+
+        sut.Logout();
+
+        //act
+        sut.OnSpectatorLoggedOut(otherPlayer);
+
+        //assert
+        sut.IsFollowing.Should().BeFalse();
+        sut.FollowCreature.Should().BeNull();
+        monitor.Should().Raise(nameof(sut.OnStoppedWalking));
+    }
+
+    [Fact]
+    public void Player_stops_following_when_followed_creature_moves_away()
+    {
+        //arrange
+
+        var map = MapTestDataBuilder.Build(100, 120, 100, 120, 7, 7);
+
+        var sut = PlayerTestDataBuilder.Build(hp: 200);
+        var enemy = MonsterTestDataBuilder.Build(100);
+        using var monitor = sut.Monitor();
+
+        var fpp = new FindPathParams(true, true, true, false, 12, 0, 12);
+
+        (map[100, 100, 7] as DynamicTile)?.AddCreature(sut);
+        (map[100, 107, 7] as DynamicTile)?.AddCreature(enemy);
+
+        sut.Follow(enemy, fpp);
+
+        //act - move enemy far away (beyond player's view)
+        (map[100, 107, 7] as DynamicTile)?.RemoveCreature(enemy, out _);
+        (map[100, 120, 7] as DynamicTile)?.AddCreature(enemy);
+        sut.OnSpectatorMoved(enemy);
+
+        //assert
+        sut.IsFollowing.Should().BeFalse();
+        sut.FollowCreature.Should().BeNull();
+        monitor.Should().Raise(nameof(sut.OnStoppedWalking));
+    }
 }

--- a/tests/NeoServer.Domain.Tests/Creature/Players/PlayerFollowTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Players/PlayerFollowTests.cs
@@ -35,7 +35,7 @@ public class PlayerFollowTests
 
         //assert
         sut.IsFollowing.Should().BeFalse();
-        sut.Following.Should().BeNull();
+        sut.FollowCreature.Should().BeNull();
         sut.HasNextStep.Should().BeFalse();
         monitor.Should().Raise(nameof(sut.OnStoppedWalking));
     }
@@ -64,7 +64,7 @@ public class PlayerFollowTests
 
         //assert
         sut.IsFollowing.Should().BeFalse();
-        sut.Following.Should().BeNull();
+        sut.FollowCreature.Should().BeNull();
         sut.HasNextStep.Should().BeFalse();
         monitor.Should().NotRaise(nameof(sut.OnStoppedWalking));
     }
@@ -96,7 +96,7 @@ public class PlayerFollowTests
 
         //assert
         sut.IsFollowing.Should().BeFalse();
-        sut.Following.Should().BeNull();
+        sut.FollowCreature.Should().BeNull();
         sut.HasNextStep.Should().BeFalse();
         monitor.Should().Raise(nameof(sut.OnStoppedWalking));
     }

--- a/tests/NeoServer.Domain.Tests/Creature/WalkableCreature/PlayerTest.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/WalkableCreature/PlayerTest.cs
@@ -115,7 +115,7 @@ public class PlayerTest
         sut.Follow(creature.Object);
 
         Assert.True(sut.IsFollowing);
-        Assert.Equal(creature.Object, sut.Following);
+        Assert.Equal(creature.Object, sut.FollowCreature);
         Assert.True(followEventEmitted);
         Assert.True(walkEventEmitted);
         Assert.Equal(Direction.North, sut.GetNextStep());
@@ -149,7 +149,7 @@ public class PlayerTest
 
         //assert
         Assert.False(sut.IsFollowing);
-        Assert.Null(sut.Following);
+        Assert.Null(sut.FollowCreature);
         Assert.True(stoppedWalkEventEmitted);
         Assert.Equal(Direction.None, sut.GetNextStep());
     }
@@ -216,7 +216,7 @@ public class PlayerTest
         //assert
         Assert.False(sut.HasNextStep);
         Assert.False(sut.IsFollowing);
-        Assert.Null(sut.Following);
+        Assert.Null(sut.FollowCreature);
         Assert.False(sut.Attacking);
         Assert.True(stoppedWalkEventEmitted);
         Assert.Equal(Direction.None, sut.GetNextStep());
@@ -249,7 +249,7 @@ public class PlayerTest
 
         Assert.False(sut.HasNextStep);
         Assert.False(sut.IsFollowing);
-        Assert.Null(sut.Following);
+        Assert.Null(sut.FollowCreature);
         Assert.False(sut.Attacking);
         Assert.True(stoppedWalkEventEmitted);
         Assert.Equal(Direction.None, sut.GetNextStep());
@@ -282,7 +282,7 @@ public class PlayerTest
 
         Assert.False(player.HasNextStep);
         Assert.False(player.IsFollowing);
-        Assert.Null(player.Following);
+        Assert.Null(player.FollowCreature);
         Assert.False(player.Attacking);
         Assert.True(stoppedAttackEventEmitted);
         Assert.Equal(Direction.None, player.GetNextStep());


### PR DESCRIPTION
### Description
This update refines the logic for player follow behavior and fixes issues with spectator visibility handling. It includes bug fixes, property renaming for clarity, and systematic event handling for follow stop scenarios.

fix #931

### Key Changes
- Added unit tests to validate various scenarios where player follow should stop.
- Fixed `OnSpectatorChangedVisibility` call and adjusted visibility comparison logic.
- Renamed `Following` property to `FollowCreature` for improved clarity.
- Introduced `StoppedFollowEvent` to standardize follow stop handling.
- Adjusted default `ChaseMode` to `Stand` and updated `PlayerModelSeed` default values.
- Removed redundant checks and improved logic for ensuring players stop following under invalid conditions.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [x] Code refactoring
- [ ] Merge Down

### Test Case
- Verified that players stop following targets when they die, become invisible, log out, or move out of range.
- Ensured correct spectator visibility handling and accurate follow stop scenarios.