### PR TITLE
Fix visibility logic for hidden creatures

### DIFF
--- a/src/ApplicationServer/NeoServer.Server.Events/Creature/CreatureChangedVisibilityEventHandler.cs
+++ b/src/ApplicationServer/NeoServer.Server.Events/Creature/CreatureChangedVisibilityEventHandler.cs
@@ -11,6 +11,8 @@ public class CreatureChangedVisibilityEventHandler(IMap map)
     {
         var creature = @event.Creature;
         foreach (var spectator in map.GetSpectators(creature.Location))
+        {
             spectator.OnSpectatorChangedVisibility(creature);
+        }
     }
 }

--- a/src/Core/NeoServer.Domain/Combat/Attacks/AreaCalculationService.cs
+++ b/src/Core/NeoServer.Domain/Combat/Attacks/AreaCalculationService.cs
@@ -35,8 +35,8 @@ public class AreaCalculationService(IMap map)
 
             if (tile is not IDynamicTile targetTile) continue;
 
-            var targetCreatures = targetTile.Creatures?.ToArray();
-            if (targetCreatures is null or { Length: 0 }) continue;
+            var targetCreatures = targetTile.Creatures;
+            if (targetCreatures is null or { Count: 0 }) continue;
 
             affectedCreatures.AddRange(targetCreatures);
         }

--- a/src/Core/NeoServer.Domain/Combat/Validations/AttackValidation.cs
+++ b/src/Core/NeoServer.Domain/Combat/Validations/AttackValidation.cs
@@ -119,10 +119,15 @@ public class AttackValidation(
         if (!attackInput.HasTarget) return Result.Success;
 
         if (!aggressor.CanSee(target.Location) || !aggressor.Location.SameFloorAs(target.Location))
+        {
             return Result.Fail(InvalidOperation.TargetLost);
+        }
 
-        if (target is ICreature creatureTarget && !aggressor.CanSeeInvisible && !aggressor.CanSee(creatureTarget))
+        // Extra check for area attacks to ensure visibility of creatures
+        if (!attackInput.Parameters.IsAttackInArea && target is ICreature creatureTarget && !aggressor.CanSee(creatureTarget))
+        {
             return Result.Fail(InvalidOperation.TargetLost);
+        }
 
         switch (target)
         {

--- a/src/Core/NeoServer.Domain/Common/Contracts/Creatures/ICreature.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Creatures/ICreature.cs
@@ -133,11 +133,6 @@ public interface ICreature : IMovableThing
     IDynamicTile Tile { get; }
 
     /// <summary>
-    ///     Checks if creature can be seen by others
-    /// </summary>
-    bool CanBeSeen { get; }
-
-    /// <summary>
     ///     Summons of creature
     /// </summary>
     IList<Summon> Summons { get; }

--- a/src/Core/NeoServer.Domain/Creatures/Models/Bases/CombatActor.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Models/Bases/CombatActor.cs
@@ -276,6 +276,8 @@ public abstract class CombatActor(ICreatureType type, IMapTool mapTool, Outfit o
 
     public virtual void TurnInvisible()
     {
+        if (IsInvisible) return;
+        
         IsInvisible = true;
         EventAggregator.Invoke(new CreatureChangedVisibilityEvent(this));
     }

--- a/src/Core/NeoServer.Domain/Creatures/Models/Bases/Creature.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Models/Bases/Creature.cs
@@ -73,7 +73,6 @@ public abstract class Creature : IEquatable<Creature>, ICreature
     public ushort CorpseType => CreatureType.Look[LookType.Corpse];
     public IThing Corpse { get; set; }
     public virtual BloodType BloodType => BloodType.Blood;
-    public abstract bool CanBeSeen { get; }
     public abstract Outfit Outfit { get; protected set; }
     public Outfit LastOutfit { get; private set; }
     public Direction Direction { get; protected set; }

--- a/src/Core/NeoServer.Domain/Creatures/Monster/Monster.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Monster/Monster.cs
@@ -236,8 +236,7 @@ public class Monster : WalkableMonster, IMonster
     public bool IsSleeping => State == MonsterState.Sleeping;
     public bool Defending { get; private set; }
     public virtual bool IsSummon => false;
-    public override bool CanSeeInvisible => IsImmune(Immunity.Invisibility); //todo: add invisibility flag
-    public override bool CanBeSeen => false;
+    public override bool CanSeeInvisible => IsImmune(Immunity.Invisibility); 
 
     public override BloodType BloodType => Metadata.Race switch
     {

--- a/src/Core/NeoServer.Domain/Creatures/Npcs/Npc.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Npcs/Npc.cs
@@ -43,9 +43,7 @@ public class Npc : WalkableCreature, INpc
     public INpcType Metadata { get; }
 
     public override bool CanSeeInvisible => false;
-
-    public override bool CanBeSeen => true;
-
+    
     public void Advertise()
     {
         if (!Metadata.Marketings?.Any() ?? true) return;

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -368,7 +368,6 @@ public class Player : CombatActor, IPlayer
     public override bool UsingDistanceWeapon => Inventory.Weapon is IDistanceWeapon;
     public bool Recovering => HasCondition(ConditionType.Regeneration);
     public override bool CanSeeInvisible => Group.FlagIsEnabled(PlayerFlag.CanSenseInvisibility);
-    public override bool CanBeSeen => Group.FlagIsEnabled(PlayerFlag.IgnoreYellCheck);
     public virtual bool CanSeeInspectionDetails => Group.Access;
 
     public override ushort MaximumElementalAttackPower =>
@@ -546,13 +545,15 @@ public class Player : CombatActor, IPlayer
         // if the other creature is not invisible, we can see it
         if (!otherCreature.IsInvisible) return true;
 
-        //  players can always see other players if they are not invisible
-        if (otherCreature is IPlayer && otherCreature.CanBeSeen) return true;
+        //  players can always see other players
+        if (otherCreature is IPlayer && !otherCreature.CanSeeInvisible) return true;
 
         // if we can see invisible creatures, we can see it
         if (CanSeeInvisible) return true;
+
+        if (otherCreature.IsInvisible) return false;
         
-        return CanSee(otherCreature.Location) && otherCreature.CanBeSeen;
+        return CanSee(otherCreature.Location);
     }
 
     public override bool CanSee(Location pos)

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -543,12 +543,16 @@ public class Player : CombatActor, IPlayer
     {
         if (otherCreature is null) return false;
 
-        if (!otherCreature.IsInvisible ||
-            (otherCreature is IPlayer && otherCreature.CanBeSeen) ||
-            CanSeeInvisible)
-            return true;
+        // if the other creature is not invisible, we can see it
+        if (!otherCreature.IsInvisible) return true;
 
-        return CanSee(otherCreature.Location);
+        //  players can always see other players if they are not invisible
+        if (otherCreature is IPlayer && otherCreature.CanBeSeen) return true;
+
+        // if we can see invisible creatures, we can see it
+        if (CanSeeInvisible) return true;
+        
+        return CanSee(otherCreature.Location) && otherCreature.CanBeSeen;
     }
 
     public override bool CanSee(Location pos)

--- a/src/NetworkingServer/NeoServer.Networking/EventHandlers/Creature/CreatureChangedVisibilityEventHandler.cs
+++ b/src/NetworkingServer/NeoServer.Networking/EventHandlers/Creature/CreatureChangedVisibilityEventHandler.cs
@@ -1,4 +1,5 @@
-﻿using NeoServer.Domain.Common;
+﻿using System;
+using NeoServer.Domain.Common;
 using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Common.Contracts.World;
 using NeoServer.Domain.Creatures.Events;
@@ -26,11 +27,16 @@ public class CreatureChangedVisibilityEventHandler(IMap map, IGameServer game)
 
             if (!spectator.CanSee(creature.Location)) continue;
 
-            if (creature.IsInvisible)
+            if (spectator.CanSeeInvisible) continue;
+            
+            Console.WriteLine(creature.Location);
+
+            if (creature.IsInvisible && !spectator.CanSee(creature))
             {
                 connection.OutgoingPackets.Enqueue(new RemoveTileThingPacket(creature.Tile, stackPosition));
             }
-            else
+            
+            if(!creature.IsInvisible && spectator.CanSee(creature))
             {
                 connection.OutgoingPackets.Enqueue(new AddAtStackPositionPacket(creature, stackPosition));
                 connection.OutgoingPackets.Enqueue(new AddCreaturePacket((IPlayer)spectator,

--- a/src/NetworkingServer/NeoServer.Networking/EventHandlers/World/CreatureMovedEventHandler.cs
+++ b/src/NetworkingServer/NeoServer.Networking/EventHandlers/World/CreatureMovedEventHandler.cs
@@ -31,20 +31,16 @@ public class CreatureMovedEventHandler(IGameServer game) : INetworkingEventHandl
         var fromTile = cylinder.FromTile;
         if (toTile.IsNull()) return;
         if (fromTile.IsNull()) return;
-
-        var toDirection = fromTile.Location.DirectionTo(toTile.Location, true);
-
-        MoveCreature(toDirection, creature, cylinder);
+        
+        MoveCreature(creature, cylinder);
     }
 
-    private void MoveCreature(Direction toDirection, IWalkableCreature creature, ICylinder cylinder)
+    private void MoveCreature(IWalkableCreature creature, ICylinder cylinder)
     {
         var fromLocation = cylinder.FromTile.Location;
         var toLocation = cylinder.ToTile.Location;
         var fromTile = cylinder.FromTile;
-
-        if (creature is IMonster && creature.IsInvisible) return;
-
+        
         foreach (var cylinderSpectator in cylinder.TileSpectators)
         {
             var spectator = cylinderSpectator.Spectator;

--- a/tests/NeoServer.Domain.Tests/Creature/Creature/PlayerTest.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Creature/PlayerTest.cs
@@ -160,11 +160,15 @@ public class PlayerTest
     }
 
     [Fact]
-    public void Player_sees_invisible_player_when_invisible_player()
+    public void Player_sees_invisible_players()
     {
         // Arrange
-        var playerA = PlayerTestDataBuilder.Build(hp: 100);
-        var playerB = PlayerTestDataBuilder.Build(hp: 100);
+        var map = MapTestDataBuilder.Build(100, 101, 100, 101, 7, 7);
+        var playerA = PlayerTestDataBuilder.Build(hp: 100, map: map);
+        var playerB = PlayerTestDataBuilder.Build(hp: 100, map: map);
+        
+        (map[100, 100, 7] as DynamicTile)?.AddCreature(playerA);
+        (map[100, 101, 7] as DynamicTile)?.AddCreature(playerB);
 
         playerB.TurnInvisible();
 
@@ -174,7 +178,29 @@ public class PlayerTest
         // Assert
         result.Should().BeTrue();
         playerB.IsInvisible.Should().BeTrue();
-        playerB.CanBeSeen.Should().BeTrue();
+    }
+    
+    [Fact]
+    public void Player_cannot_see_invisible_player_that_are_immune_to_invisibility()
+    {
+        // Arrange
+        var map = MapTestDataBuilder.Build(100, 101, 100, 101, 7, 7);
+        var playerA = PlayerTestDataBuilder.Build(hp: 100, map: map);
+        
+        var playerB = PlayerTestDataBuilder.Build(hp: 100, map: map);
+        playerB.Group.EnableFlag(PlayerFlag.CanSenseInvisibility);
+        
+        (map[100, 100, 7] as DynamicTile)?.AddCreature(playerA);
+        (map[100, 101, 7] as DynamicTile)?.AddCreature(playerB);
+
+        playerB.TurnInvisible();
+
+        // Act
+        var result = playerA.CanSee(playerB);
+
+        // Assert
+        result.Should().BeFalse();
+        playerB.IsInvisible.Should().BeTrue();
     }
 
     [Fact]
@@ -186,7 +212,7 @@ public class PlayerTest
         var monsterA = MonsterTestDataBuilder.Build(map: map);
 
         (map[100, 100, 7] as DynamicTile)?.AddCreature(playerA);
-        (map[100, 101, 7] as DynamicTile)?.AddCreature(monsterA); // Far enough that location isn't visible
+        (map[100, 101, 7] as DynamicTile)?.AddCreature(monsterA);
 
         monsterA.TurnInvisible();
 
@@ -268,18 +294,6 @@ public class PlayerTest
         Assert.Null(messageEmitted);
         Assert.Equal(SpeechType.None, speechTypeEmitted);
         Assert.Null(to);
-    }
-
-    [Fact]
-    public void CanBeSeen_Returns_True_Or_False_Depending_On_Flag_State()
-    {
-        var sut = PlayerTestDataBuilder.Build(hp: 100);
-
-        sut.Group.EnableFlag(PlayerFlag.IgnoreYellCheck);
-        Assert.True(sut.CanBeSeen);
-
-        sut.Group.DisableFlag(PlayerFlag.IgnoreYellCheck);
-        Assert.False(sut.CanBeSeen);
     }
 
     [Fact]

--- a/tests/NeoServer.Domain.Tests/Creature/Creature/PlayerTest.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Creature/PlayerTest.cs
@@ -11,9 +11,11 @@ using NeoServer.Domain.Common.Location.Structs;
 using NeoServer.Domain.Creatures.Player;
 using NeoServer.Domain.Creatures.Player.Outfit;
 using NeoServer.Domain.Services;
+using NeoServer.Domain.Tests.Helpers;
 using NeoServer.Domain.Tests.Helpers.Map;
 using NeoServer.Domain.Tests.Helpers.Player;
 using NeoServer.Domain.World.Models;
+using NeoServer.Domain.World.Models.Tiles;
 
 namespace NeoServer.Domain.Tests.Creature.Creature;
 
@@ -155,6 +157,46 @@ public class PlayerTest
         var result = sut.CanSee(creature.Object);
 
         Assert.True(result);
+    }
+
+    [Fact]
+    public void Player_sees_invisible_player_when_invisible_player()
+    {
+        // Arrange
+        var playerA = PlayerTestDataBuilder.Build(hp: 100);
+        var playerB = PlayerTestDataBuilder.Build(hp: 100);
+
+        playerB.TurnInvisible();
+
+        // Act
+        var result = playerA.CanSee(playerB);
+
+        // Assert
+        result.Should().BeTrue();
+        playerB.IsInvisible.Should().BeTrue();
+        playerB.CanBeSeen.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Player_does_not_see_monster_when_monster_is_invisible_and_player_cannot_see_invisible()
+    {
+        // Arrange
+        var map = MapTestDataBuilder.Build(100, 101, 100, 101, 7, 7);
+        var playerA = PlayerTestDataBuilder.Build(hp: 100, map: map);
+        var monsterA = MonsterTestDataBuilder.Build(map: map);
+
+        (map[100, 100, 7] as DynamicTile)?.AddCreature(playerA);
+        (map[100, 101, 7] as DynamicTile)?.AddCreature(monsterA); // Far enough that location isn't visible
+
+        monsterA.TurnInvisible();
+
+        // Act
+        var result = playerA.CanSee(monsterA);
+
+        // Assert
+        result.Should().BeFalse();
+        playerA.CanSeeInvisible.Should().BeFalse();
+        monsterA.IsInvisible.Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
### Description
This pull request updates the visibility logic for handling interactions with invisible creatures and players.
fix #944
### Key Changes
- Improved `CanSee` logic to handle edge cases with invisible players and monsters.
- Added tests to verify visibility interactions.
- Updated movement and visibility event handling to align with revised rules.
- Prevented redundant visibility state changes in `TurnInvisible`.

### Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
Tests were added to verify interactions where players encounter invisible creatures under different scenarios.