### PR TITLE
Add support for `OriginalOutfit` and improve spectator handling

### DIFF
--- a/src/Core/NeoServer.Domain/Common/Contracts/Creatures/ICreature.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Creatures/ICreature.cs
@@ -137,6 +137,8 @@ public interface ICreature : IMovableThing
     /// </summary>
     IList<Summon> Summons { get; }
 
+    Outfit OriginalOutfit { get; set; }
+
     /// <summary>
     ///     Fires when creature says something
     /// </summary>

--- a/src/Core/NeoServer.Domain/Creatures/Models/Bases/Creature.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Models/Bases/Creature.cs
@@ -74,6 +74,7 @@ public abstract class Creature : IEquatable<Creature>, ICreature
     public IThing Corpse { get; set; }
     public virtual BloodType BloodType => BloodType.Blood;
     public abstract Outfit Outfit { get; protected set; }
+    public Outfit OriginalOutfit { get; set; }
     public Outfit LastOutfit { get; private set; }
     public Direction Direction { get; protected set; }
     public IList<Summon> Summons { get; protected set; } = new List<Summon>();
@@ -105,6 +106,7 @@ public abstract class Creature : IEquatable<Creature>, ICreature
     {
         LastOutfit = null;
         Outfit.Change(outfit.LookType, outfit.Head, outfit.Body, outfit.Legs, outfit.Feet, outfit.Addon);
+        OriginalOutfit = Outfit.Clone();
 
         OnChangedOutfit?.Invoke(this, Outfit);
     }

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -100,6 +100,7 @@ public class Player : CombatActor, IPlayer
         SoulPoints = soulPoints;
         StaminaMinutes = staminaMinutes;
         Outfit = outfit;
+        OriginalOutfit = outfit.Clone();
         Speed = speed == 0 ? RawSpeed : speed;
         Inventory = new Inventory.Inventory(this, new Dictionary<Slot, (IItem Item, ushort Id)>());
 
@@ -825,7 +826,7 @@ public class Player : CombatActor, IPlayer
         foreach (var summon in summonsCopy) summon.OnMasterLogout();
 
         EventAggregator.Invoke(new PlayerLoggedOutEvent(this));
-
+        
         return true;
     }
 

--- a/src/Database/NeoServer.Data/Repositories/Player/PlayerRepository.cs
+++ b/src/Database/NeoServer.Data/Repositories/Player/PlayerRepository.cs
@@ -123,12 +123,12 @@ public class PlayerRepository(DbContextOptions<NeoContext> contextOptions, ILogg
         playerEntity.MaxSoul = player.MaxSoulPoints;
         playerEntity.StaminaMinutes = player.StaminaMinutes;
 
-        playerEntity.LookAddons = player.Outfit.Addon;
-        playerEntity.LookBody = player.Outfit.Body;
-        playerEntity.LookFeet = player.Outfit.Feet;
-        playerEntity.LookHead = player.Outfit.Head;
-        playerEntity.LookLegs = player.Outfit.Legs;
-        playerEntity.LookType = player.Outfit.LookType;
+        playerEntity.LookAddons = player.OriginalOutfit?.Addon ?? player.Outfit.Addon;
+        playerEntity.LookBody = player.OriginalOutfit?.Body ?? player.Outfit.Body;
+        playerEntity.LookFeet = player.OriginalOutfit?.Feet ?? player.Outfit.Feet;
+        playerEntity.LookHead = player.OriginalOutfit?.Head ?? player.Outfit.Head;
+        playerEntity.LookLegs = player.OriginalOutfit?.Legs ?? player.Outfit.Legs;
+        playerEntity.LookType = player.OriginalOutfit?.LookType ?? player.Outfit.LookType;
         playerEntity.PosX = player.Location.X;
         playerEntity.PosY = player.Location.Y;
         playerEntity.PosZ = player.Location.Z;

--- a/src/NetworkingServer/NeoServer.Networking/EventHandlers/World/Tiles/ThingRemovedFromTileEventHandler.cs
+++ b/src/NetworkingServer/NeoServer.Networking/EventHandlers/World/Tiles/ThingRemovedFromTileEventHandler.cs
@@ -30,12 +30,12 @@ public class ThingRemovedFromTileEventHandler(IGameServer game, IScriptManager s
 
         foreach (var spectator in cylinder.TileSpectators)
         {
-            var creature = spectator.Spectator;
+            var spectatorCreature = spectator.Spectator;
 
-            if (creature is not IPlayer player) continue;
-            if (!creature.CanSee(thing.Location)) continue;
+            if (spectatorCreature is not IPlayer player) continue;
+            if (!spectatorCreature.CanSee(thing.Location)) continue;
 
-            if (!game.CreatureManager.GetPlayerConnection(creature.CreatureId, out var connection)) continue;
+            if (!game.CreatureManager.GetPlayerConnection(spectatorCreature.CreatureId, out var connection)) continue;
 
             if (player.IsDead && !Equals(thing, player)) continue;
 
@@ -43,13 +43,20 @@ public class ThingRemovedFromTileEventHandler(IGameServer game, IScriptManager s
 
             // if the player is not dead, show a puff effect
             if (thing is IPlayer { IsDead: false } or IMonster { IsSummon: true })
+            {
                 connection.OutgoingPackets.Enqueue(new MagicEffectPacket(tile.Location, EffectT.Puff));
+            }
 
             // if the monster was killed by another monster, show a puff effect
             if (thing is Monster { KilledByAnotherMonster: true })
+            {
                 connection.OutgoingPackets.Enqueue(new MagicEffectPacket(tile.Location, EffectT.Puff));
+            }
 
-            connection.OutgoingPackets.Enqueue(new RemoveTileThingPacket(tile, stackPosition));
+            if (thing is ICreature creatureThing && spectatorCreature.CanSee(creatureThing))
+            {
+                connection.OutgoingPackets.Enqueue(new RemoveTileThingPacket(tile, stackPosition));
+            }
 
             connection.Send();
         }


### PR DESCRIPTION
### Description
This pull request introduces support for the `OriginalOutfit` property to enhance outfit preservation for players and improves tile spectator handling and packet dispatch logic to ensure consistency and clarity.
fix #929

### Key Changes
- Added `OriginalOutfit` property to `Creature` and `Player` classes to preserve and utilize the original outfit.
- Updated `PlayerRepository` to incorporate `OriginalOutfit` functionality.
- Ensured `OriginalOutfit` is cloned when applying a new outfit.
- Refined tile spectator handling by renaming variables for clarity and adding conditional checks to prevent unnecessary packet dispatches.
- Improved consistency in visibility and stack position checks.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
Preserve and validate that the `OriginalOutfit` property is handled correctly across outfit changes, and ensure spectator visibility behaves as expected when interacting with tiles.