### PR TITLE
Add condition suppression handlers for players

### DIFF
--- a/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IInventory.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IInventory.cs
@@ -47,11 +47,8 @@ public interface IInventory : IHasItem
     Result<OperationResultList<IItem>> AddItem(IItem item, Slot slot = Slot.None);
 
     bool UpdateItem(IItem item, IItemType newType);
-
     void Protect(CombatDamage damage);
-
-    bool HasEquippedItemWithImmunity(Immunity immunity);
-
+    
     #region Events
 
     event AddItemToSlot OnItemAddedToSlot;

--- a/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IPlayer.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IPlayer.cs
@@ -136,6 +136,9 @@ public interface IPlayer : ICombatActor, ISociableCreature, IBankable
 
     bool CanSeeInspectionDetails { get; }
     bool IsManaShieldEnabled { get; }
+    void AddConditionSuppression(ConditionType conditionType);
+    void RemoveConditionSuppression(ConditionType conditionType);
+    int GetConditionSuppressionCount(ConditionType conditionType);
 
     /// <summary>
     ///     Indicates Skull showed on creature

--- a/src/Core/NeoServer.Domain/Creatures/Player/Inventory/Inventory.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Inventory/Inventory.cs
@@ -103,17 +103,6 @@ public class Inventory : IInventory
         return PossibleAmountToAddCalculation.Calculate(this, item, toPosition);
     }
 
-    public bool HasEquippedItemWithImmunity(Immunity immunity)
-    {
-        foreach (var (item, _) in InventoryMap.Items)
-            if (immunity is Immunity.Drunkenness &&
-                item.Metadata.Attributes.TryGetAttribute(ItemTypeAttribute.SuppressDrunk, out byte suppressDrunk) &&
-                suppressDrunk == 1)
-                return true;
-
-        return false;
-    }
-
     private void AddItemsToInventory(IDictionary<Slot, (IItem Item, ushort Id)> items)
     {
         foreach (var (slot, (item, _)) in items) TryAddItemToSlot(slot, item);

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -49,6 +49,7 @@ public class Player : CombatActor, IPlayer
     private const int KNOWN_CREATURE_LIMIT = 250; //todo: for version 8.60
 
 
+    private readonly Dictionary<ConditionType, int> _conditionSuppressions = new();
     private byte _soulPoints;
 
     public Player(
@@ -1044,6 +1045,35 @@ public class Player : CombatActor, IPlayer
 
     public bool IsManaShieldEnabled => HasCondition(ConditionType.ManaShield);
 
+    public void AddConditionSuppression(ConditionType conditionType)
+    {
+        if (_conditionSuppressions.TryGetValue(conditionType, out var suppressionCount))
+        {
+            _conditionSuppressions[conditionType] = suppressionCount + 1;
+            return;
+        }
+
+        _conditionSuppressions[conditionType] = 1;
+    }
+
+    public void RemoveConditionSuppression(ConditionType conditionType)
+    {
+        if (!_conditionSuppressions.TryGetValue(conditionType, out var suppressionCount)) return;
+
+        if (suppressionCount <= 1)
+        {
+            _conditionSuppressions.Remove(conditionType);
+            return;
+        }
+
+        _conditionSuppressions[conditionType] = suppressionCount - 1;
+    }
+
+    public int GetConditionSuppressionCount(ConditionType conditionType)
+    {
+        return _conditionSuppressions.TryGetValue(conditionType, out var suppressionCount) ? suppressionCount : 0;
+    }
+
     public void EnableManaShield(uint duration)
     {
         AddCondition(new Condition(ConditionType.ManaShield, duration,
@@ -1439,8 +1469,8 @@ public class Player : CombatActor, IPlayer
 
         switch (condition.Type)
         {
-            case ConditionType.Drunk when Inventory.HasEquippedItemWithImmunity(Immunity.Drunkenness):
-            case ConditionType.Drowning when Inventory.HasEquippedItemWithImmunity(Immunity.Drown):
+            case ConditionType.Drunk when GetConditionSuppressionCount(ConditionType.Drunk) > 0:
+            case ConditionType.Drowning when GetConditionSuppressionCount(ConditionType.Drowning) > 0:
                 return;
             default:
                 base.AddCondition(condition);

--- a/src/Core/NeoServer.Domain/Items/Services/ItemAbilityApplierService.cs
+++ b/src/Core/NeoServer.Domain/Items/Services/ItemAbilityApplierService.cs
@@ -108,7 +108,7 @@ public static class ItemAbilityApplier
         return Result.Success;
     }
 
-    private static void ToggleConditions(IPlayer player, IItem item, bool supress)
+    private static void ToggleConditions(IPlayer player, IItem item, bool suppress)
     {
         ReadOnlySpan<ItemTypeAttribute> suppressAttributes =
         [
@@ -120,8 +120,8 @@ public static class ItemAbilityApplier
 
         foreach (var suppressAttribute in suppressAttributes)
         {
-            if (!item.Metadata.Attributes.TryGetAttribute<bool>(suppressAttribute, out var suppress)) continue;
-            if (!suppress) continue;
+            if (!item.Metadata.Attributes.TryGetAttribute<bool>(suppressAttribute, out var suppressCondition)) continue;
+            if (!suppressCondition) continue;
 
             var condition = suppressAttribute switch
             {
@@ -138,7 +138,7 @@ public static class ItemAbilityApplier
 
             if (condition == ConditionType.None) continue;
 
-            if (supress)
+            if (suppress)
             {
                 player.AddConditionSuppression(condition);
 

--- a/src/Core/NeoServer.Domain/Items/Services/ItemAbilityApplierService.cs
+++ b/src/Core/NeoServer.Domain/Items/Services/ItemAbilityApplierService.cs
@@ -115,8 +115,7 @@ public static class ItemAbilityApplier
             ItemTypeAttribute.SuppressDrown, ItemTypeAttribute.SuppressDrunk,
             ItemTypeAttribute.SuppressCurse, ItemTypeAttribute.SuppressDazzle,
             ItemTypeAttribute.SuppressEnergy, ItemTypeAttribute.SuppressFire,
-            ItemTypeAttribute.SuppressFreeze, ItemTypeAttribute.SuppressPhysical,
-            ItemTypeAttribute.SuppressPoison
+            ItemTypeAttribute.SuppressFreeze, ItemTypeAttribute.SuppressPoison
         ];
 
         foreach (var suppressAttribute in suppressAttributes)
@@ -133,7 +132,6 @@ public static class ItemAbilityApplier
                 ItemTypeAttribute.SuppressEnergy => ConditionType.Electrified,
                 ItemTypeAttribute.SuppressFire => ConditionType.Burning,
                 ItemTypeAttribute.SuppressFreeze => ConditionType.Freezing,
-                ItemTypeAttribute.SuppressPhysical => ConditionType.None,
                 ItemTypeAttribute.SuppressPoison => ConditionType.Poisoned,
                 _ => ConditionType.None
             };
@@ -142,9 +140,19 @@ public static class ItemAbilityApplier
 
             if (supress)
             {
+                player.AddConditionSuppression(condition);
+
+                if (player.GetConditionSuppressionCount(condition) > 1)
+                    return;
+
                 player.DisableCondition(condition);
                 return;
             }
+
+            player.RemoveConditionSuppression(condition);
+
+            if (player.GetConditionSuppressionCount(condition) > 0)
+                return;
 
             player.EnableCondition(condition);
         }

--- a/tests/NeoServer.Domain.Tests/Creature/Players/PlayerEquipmentSuppressConditionTest.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Players/PlayerEquipmentSuppressConditionTest.cs
@@ -8,7 +8,7 @@ using NeoServer.Domain.Tests.Helpers.Player;
 
 namespace NeoServer.Domain.Tests.Creature.Players;
 
-public class PlayerEquipmentSupressConditionTest
+public class PlayerEquipmentSuppressConditionTest
 {
     [Fact]
     public void Player_loses_drunk_condition_when_equipping_ring_with_suppress_drunk_attribute()

--- a/tests/NeoServer.Domain.Tests/Creature/Players/PlayerEquipmentSupressConditionTest.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Players/PlayerEquipmentSupressConditionTest.cs
@@ -1,0 +1,164 @@
+using NeoServer.Domain.Common.Item;
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Domain.Creatures.Conditions.Implementations;
+using NeoServer.Domain.Creatures.Player.Inventory;
+using NeoServer.Domain.Tests.Helpers;
+using NeoServer.Domain.Tests.Helpers.Player;
+
+namespace NeoServer.Domain.Tests.Creature.Players;
+
+public class PlayerEquipmentSupressConditionTest
+{
+    [Fact]
+    public void Player_loses_drunk_condition_when_equipping_ring_with_suppress_drunk_attribute()
+    {
+        // arrange
+        var player = PlayerTestDataBuilder.Build();
+        var ringWithSuppressDrunk = ItemTestDataBuilder.CreateDefenseEquipmentItem(2162, "ring",
+            itemTypeAttributes:
+            [
+                (ItemTypeAttribute.SuppressDrunk, true)
+            ]);
+
+        player.AddCondition(new Condition(ConditionType.Drunk, 500));
+
+        player.Inventory[Slot.Ring].Should().BeNull();
+        player.HasCondition(ConditionType.Drunk).Should().BeTrue();
+
+        // act
+        var result = player.Inventory.AddItem(ringWithSuppressDrunk, Slot.Ring);
+
+        // assert
+        result.Succeeded.Should().BeTrue();
+        player.HasCondition(ConditionType.Drunk).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Player_gets_drunk_condition_back_when_removing_ring_with_suppress_drunk_attribute()
+    {
+        // arrange
+        var player = PlayerTestDataBuilder.Build();
+        var ringWithSuppressDrunk = ItemTestDataBuilder.CreateDefenseEquipmentItem(2162, "ring",
+            itemTypeAttributes:
+            [
+                (ItemTypeAttribute.SuppressDrunk, true)
+            ]);
+
+        player.AddCondition(new Condition(ConditionType.Drunk, 5000));
+
+        player.HasCondition(ConditionType.Drunk).Should().BeTrue();
+
+        // act
+        var equipResult = player.Inventory.AddItem(ringWithSuppressDrunk, Slot.Ring);
+
+        // assert
+        equipResult.Succeeded.Should().BeTrue();
+        player.HasCondition(ConditionType.Drunk).Should().BeFalse();
+
+        // act
+        var removeResult = player.Inventory.RemoveItem(Slot.Ring, 1);
+
+        // assert
+        removeResult.Succeeded.Should().BeTrue();
+        player.HasCondition(ConditionType.Drunk).Should().BeTrue();
+    }
+
+    [Fact]
+    [ThreadBlocking]
+    public void Player_loses_drunk_condition_after_500ms_even_when_ring_with_suppress_drunk_is_removed_after_200ms()
+    {
+        // arrange
+        var player = PlayerTestDataBuilder.Build();
+        var ringWithSuppressDrunk = ItemTestDataBuilder.CreateDefenseEquipmentItem(2162, "ring",
+            itemTypeAttributes:
+            [
+                (ItemTypeAttribute.SuppressDrunk, true)
+            ]);
+
+        player.AddCondition(new Condition(ConditionType.Drunk, 500));
+
+        player.HasCondition(ConditionType.Drunk).Should().BeTrue();
+
+        // act
+        var equipResult = player.Inventory.AddItem(ringWithSuppressDrunk, Slot.Ring);
+
+        // assert
+        equipResult.Succeeded.Should().BeTrue();
+        player.HasCondition(ConditionType.Drunk).Should().BeFalse();
+
+        // act
+        Thread.Sleep(200);
+        var removeResult = player.Inventory.RemoveItem(Slot.Ring, 1);
+
+        // assert
+        removeResult.Succeeded.Should().BeTrue();
+        player.HasCondition(ConditionType.Drunk).Should().BeTrue();
+
+        // act
+        Thread.Sleep(300);
+        ExecuteConditionTick(player);
+
+        // assert
+        player.HasCondition(ConditionType.Drunk).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Player_gets_drunk_condition_back_only_after_removing_ring_1_and_boots_with_suppress_drunk_attribute()
+    {
+        // arrange
+        var player = PlayerTestDataBuilder.Build();
+        var ring1WithSuppressDrunk = ItemTestDataBuilder.CreateDefenseEquipmentItem(2162, "ring",
+            itemTypeAttributes:
+            [
+                (ItemTypeAttribute.SuppressDrunk, true)
+            ]);
+        var bootsWithSuppressDrunk = ItemTestDataBuilder.CreateBodyEquipmentItem(2202, "feet",
+            itemTypeAttributes:
+            [
+                (ItemTypeAttribute.SuppressDrunk, true)
+            ]);
+
+        player.AddCondition(new Condition(ConditionType.Drunk, 5000));
+        player.HasCondition(ConditionType.Drunk).Should().BeTrue();
+
+        // act
+        var equipRing1Result = player.Inventory.AddItem(ring1WithSuppressDrunk, Slot.Ring);
+
+        // assert
+        equipRing1Result.Succeeded.Should().BeTrue();
+        player.HasCondition(ConditionType.Drunk).Should().BeFalse();
+
+        // act
+        var equipBootsResult = player.Inventory.AddItem(bootsWithSuppressDrunk, Slot.Feet);
+
+        // assert
+        equipBootsResult.Succeeded.Should().BeTrue();
+        player.HasCondition(ConditionType.Drunk).Should().BeFalse();
+
+        // act
+        var removeBootsResult = player.Inventory.RemoveItem(Slot.Feet, 1);
+
+        // assert
+        removeBootsResult.Succeeded.Should().BeTrue();
+        player.HasCondition(ConditionType.Drunk).Should().BeFalse();
+
+        // act
+        var removeRing1Result = player.Inventory.RemoveItem(Slot.Ring, 1);
+
+        // assert
+        removeRing1Result.Succeeded.Should().BeTrue();
+        player.HasCondition(ConditionType.Drunk).Should().BeTrue();
+    }
+
+    private static void ExecuteConditionTick(ICombatActor creature)
+    {
+        foreach (var condition in creature.GetConditions())
+        {
+            if (!condition.HasExpired) continue;
+
+            condition.End();
+            creature.RemoveCondition(condition);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Introduced functionality to manage condition suppression for players and ensured proper restoration behavior.

### Key Changes
- Added `AddConditionSuppression`, `RemoveConditionSuppression`, and `GetConditionSuppressionCount` methods in `Player`.
- Refactored `ItemAbilityApplierService` to incorporate condition suppression logic.
- Introduced unit tests to validate behavior of the new functionality.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [x] Code refactoring
- [ ] Merge Down

### Test Case
- Verified that conditions are suppressed and restored appropriately using the new methods.
- Conducted unit tests to ensure that `AddConditionSuppression` and `RemoveConditionSuppression` work as expected.