### PR TITLE
Prevent logout block on protection zone tiles

### DIFF
--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -1707,6 +1707,12 @@ public class Player : CombatActor, IPlayer
     {
         if (Group.FlagIsEnabled(PlayerFlag.NotGainInFight)) return;
 
+        if (Tile?.ProtectionZone ?? false)
+        {
+            RemoveLogoutBlock();
+            return;
+        }
+
         if (IsPacified) return;
 
         if (HasCondition(ConditionType.LogoutBlock, out var condition))
@@ -1729,6 +1735,7 @@ public class Player : CombatActor, IPlayer
         switch (fromTile?.ProtectionZone)
         {
             case null when toTile.ProtectionZone:
+                RemoveLogoutBlock();
                 AddCondition(new Condition(ConditionType.Pacified, 0));
                 RemoveProtectionZoneBlock();
                 break;

--- a/tests/NeoServer.Domain.Tests/Creature/Players/PlayerAttackTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Players/PlayerAttackTests.cs
@@ -179,6 +179,29 @@ public class PlayerAttackTests
     }
 
     [Fact]
+    public void Player_does_not_get_logout_block_on_protection_zone_tile()
+    {
+        //arrange
+        var location = new Location(100, 100, 7);
+        var ground = MapTestDataBuilder.CreateGround(location);
+
+        var protectionZoneTile = new DynamicTile(new Coordinate(100, 100, 7), (TileFlag)TileFlags.ProtectionZone,
+            ground, null, null);
+
+        var map = MapTestDataBuilder.Build(protectionZoneTile);
+        var player = (NeoServer.Domain.Creatures.Player.Player)PlayerTestDataBuilder.Build(map: map);
+
+        protectionZoneTile.AddCreature(player);
+
+        //act
+        player.SetLogoutBlock();
+
+        //assert
+        player.IsLogoutBlocked.Should().BeFalse();
+        player.CannotLogout.Should().BeFalse();
+    }
+
+    [Fact]
     public void Player_cannot_attack_dead_enemy()
     {
         //arrange


### PR DESCRIPTION
### Description
Fixed an issue where players were unable to log out while on protection zone tiles.

### Key Changes
- Updated the logout logic to ensure players can log out without restrictions on protection zone tiles.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
Ensure players can log out successfully when located on protection zone tiles.