### PR TITLE
Add support for conditional end actions in RemoveCondition

### DIFF
--- a/src/Core/NeoServer.Domain/Common/Contracts/Creatures/ICombatActor.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Creatures/ICombatActor.cs
@@ -86,7 +86,7 @@ public interface ICombatActor : IWalkableCreature
     void RemoveCondition(ICondition condition);
     void DisableCondition(ConditionType type);
     void EnableCondition(ConditionType type);
-    void RemoveCondition(ConditionType type);
+    void RemoveCondition(ConditionType type, bool endCondition = true);
     bool HasCondition(ConditionType type, out ICondition condition);
     bool HasCondition(ConditionType type);
     ICondition GetCondition(ConditionType type);

--- a/src/Core/NeoServer.Domain/Creatures/ConditionList.cs
+++ b/src/Core/NeoServer.Domain/Creatures/ConditionList.cs
@@ -69,7 +69,7 @@ public class ConditionList : IEnumerable<ICondition>
     /// Removes all conditions of the specified condition type from the condition list. If there are no conditions of the specified type, the method does nothing. The cache of conditions is invalidated after the removal.
     /// </summary>
     /// <param name="type"></param>
-    public void RemoveByType(ConditionType type)
+    public void RemoveByType(ConditionType type, bool endCondition = true)
     {
         if (!Conditions.TryGetValue(type, out var conditions)) return;
 
@@ -78,9 +78,12 @@ public class ConditionList : IEnumerable<ICondition>
             return;
         }
 
-        foreach (var condition in conditions)
+        if (endCondition)
         {
-            condition?.End();
+            foreach (var condition in conditions)
+            {
+                condition?.End();
+            }
         }
 
         conditions.Clear();

--- a/src/Core/NeoServer.Domain/Creatures/ConditionList.cs
+++ b/src/Core/NeoServer.Domain/Creatures/ConditionList.cs
@@ -66,9 +66,15 @@ public class ConditionList : IEnumerable<ICondition>
     }
 
     /// <summary>
-    /// Removes all conditions of the specified condition type from the condition list. If there are no conditions of the specified type, the method does nothing. The cache of conditions is invalidated after the removal.
+    /// Removes all conditions of the specified condition type from the condition list.
+    /// If there are no conditions of the specified type, the method does nothing.
+    /// The cache of conditions is invalidated after the removal.
     /// </summary>
-    /// <param name="type"></param>
+    /// <param name="type">The type of conditions to remove from the condition list.</param>
+    /// <param name="endCondition">
+    /// <see langword="true"/> to invoke <see cref="ICondition.End()"/> for each removed condition before clearing them;
+    /// otherwise, <see langword="false"/> to remove the conditions without invoking their end actions.
+    /// </param>
     public void RemoveByType(ConditionType type, bool endCondition = true)
     {
         if (!Conditions.TryGetValue(type, out var conditions)) return;

--- a/src/Core/NeoServer.Domain/Creatures/Models/Bases/CombatActor.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Models/Bases/CombatActor.cs
@@ -92,12 +92,12 @@ public abstract class CombatActor(ICreatureType type, IMapTool mapTool, Outfit o
         EventAggregator.Invoke(new CreatureConditionAddedEvent(this, firstCondition));
     }
 
-    public virtual void RemoveCondition(ConditionType type)
+    public virtual void RemoveCondition(ConditionType type, bool endCondition = true)
     {
         var firstCondition = Conditions.GetByType(type).FirstOrDefault();
         if (firstCondition is null) return;
         
-        Conditions.RemoveByType(type);
+        Conditions.RemoveByType(type, endCondition);
 
         EventAggregator.Invoke(new CreatureConditionRemovedEvent(this, firstCondition));
     }

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -1040,7 +1040,7 @@ public class Player : CombatActor, IPlayer
 
     public void SetAsHungry()
     {
-        RemoveCondition(ConditionType.Regeneration);
+        RemoveCondition(ConditionType.Regeneration, false);
         AddCondition(new Condition(ConditionType.Hungry, uint.MaxValue));
     }
 

--- a/tests/NeoServer.Domain.Tests/Creature/Players/PlayerTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Players/PlayerTests.cs
@@ -316,9 +316,7 @@ public class PlayerTests
         var regenerationCondition = new Condition(ConditionType.Regeneration, 10000, sut.SetAsHungry);
         sut.AddCondition(regenerationCondition);
 
-        var act = () => sut.SetAsHungry();
-
-        act.Should().NotThrow<StackOverflowException>();
+        sut.SetAsHungry();
         sut.HasCondition(ConditionType.Regeneration).Should().BeFalse();
         sut.HasCondition(ConditionType.Hungry).Should().BeTrue();
     }

--- a/tests/NeoServer.Domain.Tests/Creature/Players/PlayerTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Players/PlayerTests.cs
@@ -1,11 +1,14 @@
 using AutoFixture;
 using Moq;
 using NeoServer.Domain.Common.Combat.Structs;
+using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Common.Contracts.World;
 using NeoServer.Domain.Common.Creatures;
 using NeoServer.Domain.Common.Item;
 using NeoServer.Domain.Common.Location;
 using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Domain.Creatures.Conditions.Implementations;
 using NeoServer.Domain.Creatures.Player;
 using NeoServer.Domain.Creatures.Player.Modes;
 using NeoServer.Domain.Creatures.Player.Outfit;
@@ -278,5 +281,45 @@ public class PlayerTests
 
         //assert
         sut.Direction.Should().Be(Direction.North);
+    }
+
+    [Fact]
+    public void SetAsHungry_replaces_regeneration_with_hungry_condition()
+    {
+        var sut = PlayerTestDataBuilder.Build();
+        var regenerationCondition = new Condition(ConditionType.Regeneration, 10000);
+        sut.AddCondition(regenerationCondition);
+
+        sut.SetAsHungry();
+
+        sut.HasCondition(ConditionType.Regeneration).Should().BeFalse();
+        sut.HasCondition(ConditionType.Hungry).Should().BeTrue();
+    }
+
+    [Fact]
+    public void SetAsHungry_does_not_invoke_endaction_of_removed_regeneration_condition()
+    {
+        var endActionInvoked = false;
+        var sut = PlayerTestDataBuilder.Build();
+        var regenerationCondition = new Condition(ConditionType.Regeneration, 10000, () => endActionInvoked = true);
+        sut.AddCondition(regenerationCondition);
+
+        sut.SetAsHungry();
+
+        endActionInvoked.Should().BeFalse();
+    }
+
+    [Fact]
+    public void SetAsHungry_does_not_stack_overflow_when_regeneration_has_endaction_set_to_setashungry()
+    {
+        var sut = PlayerTestDataBuilder.Build();
+        var regenerationCondition = new Condition(ConditionType.Regeneration, 10000, sut.SetAsHungry);
+        sut.AddCondition(regenerationCondition);
+
+        var act = () => sut.SetAsHungry();
+
+        act.Should().NotThrow<StackOverflowException>();
+        sut.HasCondition(ConditionType.Regeneration).Should().BeFalse();
+        sut.HasCondition(ConditionType.Hungry).Should().BeTrue();
     }
 }


### PR DESCRIPTION
### Description
Extended the `RemoveCondition` functionality to support an optional `endCondition` flag, allowing selective invocation of end actions when removing conditions.

fix #967 

### Key Changes
- Added `endCondition` flag to the `RemoveCondition` method.
- Modified `ConditionList.RemoveByType` method to optionally skip end actions.
- Updated `SetAsHungry` logic to avoid undesired end action execution.
- Implemented new unit tests to validate behavior under various scenarios.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Test Case
- Verified the `RemoveCondition` behavior with and without the `endCondition` flag using unit tests.