### PR TITLE
Prevent duplicate player channel joins and add unit tests

### DIFF
--- a/src/Core/NeoServer.Domain/Creatures/Services/PlayerChannelService.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Services/PlayerChannelService.cs
@@ -35,8 +35,8 @@ public class PlayerChannelService(IChatChannelStore chatChannelStore)
 
         foreach (var channel in channels)
         {
-            if (!channel.HasUser(player))
-                player.Channels.JoinChannel(channel);
+            if (channel.HasUser(player)) continue;
+            player.Channels.JoinChannel(channel);
         }
     }
 }

--- a/src/Core/NeoServer.Domain/Creatures/Services/PlayerChannelService.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Services/PlayerChannelService.cs
@@ -33,6 +33,10 @@ public class PlayerChannelService(IChatChannelStore chatChannelStore)
             ? channels
             : channels.Concat(privateChannels.Where(x => x.Opened));
 
-        foreach (var channel in channels) player.Channels.JoinChannel(channel);
+        foreach (var channel in channels)
+        {
+            if (!channel.HasUser(player))
+                player.Channels.JoinChannel(channel);
+        }
     }
 }

--- a/src/NetworkingServer/NeoServer.Networking.Handlers/Chat/PlayerOpenChannelHandler.cs
+++ b/src/NetworkingServer/NeoServer.Networking.Handlers/Chat/PlayerOpenChannelHandler.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.IO;
+using System.Linq;
 using NeoServer.Domain.Chat;
 using NeoServer.Domain.Common.Contracts.DataStores;
 using NeoServer.Networking.Packets.Incoming.Chat;
@@ -34,6 +35,10 @@ public class PlayerOpenChannelHandler : PacketHandler
 
         if (channel is null) return;
 
-        _game.Dispatcher.AddEvent(new Event(() => player.Channels.JoinChannel(channel)));
+        _game.Dispatcher.AddEvent(new Event(() =>
+        {
+            if (channel.HasUser(player)) return;
+            player.Channels.JoinChannel(channel);
+        }));
     }
 }

--- a/tests/NeoServer.Domain.Tests/Creature/Services/PlayerChannelServiceTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Services/PlayerChannelServiceTests.cs
@@ -1,0 +1,75 @@
+using Moq;
+using NeoServer.Domain.Chat;
+using NeoServer.Domain.Common.Contracts.DataStores;
+using NeoServer.Domain.Creatures.Services;
+using NeoServer.Domain.Tests.Helpers.Player;
+
+namespace NeoServer.Domain.Tests.Creature.Services;
+
+public class PlayerChannelServiceTests
+{
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void JoinChannels_joins_open_channels_player_is_not_in()
+    {
+        // Arrange
+        var player = PlayerTestDataBuilder.Build();
+        var channel = new ChatChannel(1, "World Chat") { Opened = true };
+        var chatChannelStore = new Mock<IChatChannelStore>();
+        chatChannelStore.Setup(x => x.All).Returns([channel]);
+
+        var sut = new PlayerChannelService(chatChannelStore.Object);
+
+        // Act
+        sut.JoinChannels(player);
+
+        // Assert
+        channel.HasUser(player).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void JoinChannels_does_not_send_error_when_player_already_in_channel()
+    {
+        // Arrange
+        var player = PlayerTestDataBuilder.Build();
+        var channel = new ChatChannel(1, "World Chat") { Opened = true };
+        channel.AddUser(player);
+
+        var chatChannelStore = new Mock<IChatChannelStore>();
+        chatChannelStore.Setup(x => x.All).Returns([channel]);
+
+        var sut = new PlayerChannelService(chatChannelStore.Object);
+
+        using var monitor = player.Channels.Monitor();
+
+        // Act
+        sut.JoinChannels(player);
+
+        // Assert - should not raise OnJoinedChannel since player is already in
+        monitor.Should().NotRaise(nameof(player.Channels.OnJoinedChannel));
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void JoinChannels_joins_only_channels_player_is_not_already_in()
+    {
+        // Arrange
+        var player = PlayerTestDataBuilder.Build();
+        var joinedChannel = new ChatChannel(1, "World Chat") { Opened = true };
+        var unjoinedChannel = new ChatChannel(2, "Game Chat") { Opened = true };
+        joinedChannel.AddUser(player);
+
+        var chatChannelStore = new Mock<IChatChannelStore>();
+        chatChannelStore.Setup(x => x.All).Returns([joinedChannel, unjoinedChannel]);
+
+        var sut = new PlayerChannelService(chatChannelStore.Object);
+
+        // Act
+        sut.JoinChannels(player);
+
+        // Assert
+        joinedChannel.HasUser(player).Should().BeTrue();
+        unjoinedChannel.HasUser(player).Should().BeTrue();
+    }
+}


### PR DESCRIPTION
### Description
Updated the `PlayerChannelService.JoinChannels` method to prevent players from rejoining channels they are already a part of. Added corresponding unit tests to verify the behavior.
Fix #978

### Key Changes
- Modified logic in `PlayerChannelService.JoinChannels` to exclude previously joined channels when attempting to join.
- Added three unit tests:
  - Verify no errors occur when trying to rejoin an already joined channel.
  - Ensure only unjoined channels are added.
  - Confirm proper handling of open channels during the join process.

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
- Tested prevention of duplicate channel joins with valid scenarios through added unit tests.
- Verified correct behavior for mixed joined and unjoined channel sets.