### PR TITLE
feat: persist haste conditions between player sessions

### DIFF
--- a/src/Core/NeoServer.Domain/Creatures/Conditions/Implementations/HasteCondition.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Conditions/Implementations/HasteCondition.cs
@@ -21,6 +21,8 @@ public class HasteCondition : BaseCondition
     public EffectT Effect { get; }
     public uint Interval { get; }
 
+    internal ushort SpeedBoost { get; private set; }
+
     internal override bool Start(ICreature creature)
     {
         if (!base.Start(creature))
@@ -35,19 +37,61 @@ public class HasteCondition : BaseCondition
             combatActor.RemoveCondition(ConditionType.Paralyze);
         }
 
-        var baseSpeed = walkableCreature.RawSpeed;
+        if (SpeedBoost == 0) // not yet set; generate
+        {
+            var baseSpeed = walkableCreature.RawSpeed;
 
-        var min = walkableCreature.RawSpeed * FormulaValues.MinA + FormulaValues.MinB;
-        var max = walkableCreature.RawSpeed * FormulaValues.MaxA + FormulaValues.MaxB;
+            var min = walkableCreature.RawSpeed * FormulaValues.MinA + FormulaValues.MinB;
+            var max = walkableCreature.RawSpeed * FormulaValues.MaxA + FormulaValues.MaxB;
 
-        var random = Random.Shared;
-        var randomSpeed = random.Next((int)min, (int)max);
-        var speed = randomSpeed - baseSpeed;
+            var random = Random.Shared;
+            var randomSpeed = random.Next((int)min, (int)max);
+            SpeedBoost = (ushort)(randomSpeed - baseSpeed);
+        }
 
-        walkableCreature.IncreaseSpeed((ushort)speed);
+        walkableCreature.IncreaseSpeed(SpeedBoost);
 
-        EndAction = () => walkableCreature.DecreaseSpeed((ushort)speed);
+        EndAction = () => walkableCreature.DecreaseSpeed(SpeedBoost);
 
         return true;
     }
+
+    public HasteConditionState CaptureState()
+    {
+        return new HasteConditionState(
+            Type,
+            Effect,
+            SpeedBoost,
+            Math.Max(0, RemainingTime),
+            Duration,
+            FormulaValues);
+    }
+
+    public static HasteCondition Restore(HasteConditionState state)
+    {
+        // Use remaining time so the condition expires at the correct moment.
+        // If remaining is 0 (expired), fall back to 1ms
+        // as a reasonable default.
+        var durationMs = state.RemainingTimeMilliseconds > 0
+            ? state.RemainingTimeMilliseconds
+            : 1;
+
+        var condition = new HasteCondition(
+            (uint)durationMs,
+            state.FormulaValues,
+            state.Effect)
+        {
+            SpeedBoost = state.SpeedBoost
+        };
+
+        return condition;
+    }
 }
+
+public sealed record HasteConditionState(
+    ConditionType Type,
+    EffectT Effect,
+    ushort SpeedBoost,
+    long RemainingTimeMilliseconds,
+    long Duration,
+    FormulaValues FormulaValues);

--- a/src/Core/NeoServer.Domain/Creatures/Conditions/Implementations/HasteCondition.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Conditions/Implementations/HasteCondition.cs
@@ -22,6 +22,7 @@ public class HasteCondition : BaseCondition
     public uint Interval { get; }
 
     internal ushort SpeedBoost { get; private set; }
+    private bool _speedBoostInitialized;
 
     internal override bool Start(ICreature creature)
     {
@@ -37,7 +38,7 @@ public class HasteCondition : BaseCondition
             combatActor.RemoveCondition(ConditionType.Paralyze);
         }
 
-        if (SpeedBoost == 0) // not yet set; generate
+        if (!_speedBoostInitialized) // not yet set; generate
         {
             var baseSpeed = walkableCreature.RawSpeed;
 
@@ -47,6 +48,7 @@ public class HasteCondition : BaseCondition
             var random = Random.Shared;
             var randomSpeed = random.Next((int)min, (int)max);
             SpeedBoost = (ushort)(randomSpeed - baseSpeed);
+            _speedBoostInitialized = true;
         }
 
         walkableCreature.IncreaseSpeed(SpeedBoost);
@@ -70,18 +72,16 @@ public class HasteCondition : BaseCondition
     public static HasteCondition Restore(HasteConditionState state)
     {
         // Use remaining time so the condition expires at the correct moment.
-        // If remaining is 0 (expired), fall back to 1ms
-        // as a reasonable default.
-        var durationMs = state.RemainingTimeMilliseconds > 0
-            ? state.RemainingTimeMilliseconds
-            : 1;
+        // Zero remaining time is preserved as-is (an expired condition).
+        var durationMs = Math.Max(0, state.RemainingTimeMilliseconds);
 
         var condition = new HasteCondition(
             (uint)durationMs,
             state.FormulaValues,
             state.Effect)
         {
-            SpeedBoost = state.SpeedBoost
+            SpeedBoost = state.SpeedBoost,
+            _speedBoostInitialized = true
         };
 
         return condition;

--- a/src/Database/NeoServer.Data/Helpers/ConditionParsers/ConditionListParser.cs
+++ b/src/Database/NeoServer.Data/Helpers/ConditionParsers/ConditionListParser.cs
@@ -24,6 +24,11 @@ public static class ConditionListParser
             {
                 serializedConditions.Add(ConditionDamageParser.Serialize(damageCondition));
             }
+
+            if (HasteConditionParser.CanHandle(condition.Type) && condition is HasteCondition hasteCondition)
+            {
+                serializedConditions.Add(HasteConditionParser.Serialize(hasteCondition));
+            }
         }
 
         return $"[{string.Join(",", serializedConditions)}]";
@@ -59,6 +64,12 @@ public static class ConditionListParser
             if (ConditionDamageParser.CanHandle(conditionType))
             {
                 var condition = ConditionDamageParser.Deserialize(conditionJson);
+                conditions.Add(condition);
+            }
+
+            if (HasteConditionParser.CanHandle(conditionType))
+            {
+                var condition = HasteConditionParser.Deserialize(conditionJson);
                 conditions.Add(condition);
             }
         }

--- a/src/Database/NeoServer.Data/Helpers/ConditionParsers/HasteConditionParser.cs
+++ b/src/Database/NeoServer.Data/Helpers/ConditionParsers/HasteConditionParser.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Text.Json;
+using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Domain.Creatures.Conditions.Implementations;
+
+namespace NeoServer.Data.Helpers.ConditionParsers;
+
+public static class HasteConditionParser
+{
+    public static string Serialize(HasteCondition condition)
+    {
+        ArgumentNullException.ThrowIfNull(condition);
+
+        var state = condition.CaptureState();
+        return JsonSerializer.Serialize(state);
+    }
+
+    public static HasteCondition Deserialize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        var state = JsonSerializer.Deserialize<HasteConditionState>(json);
+
+        if (state is null)
+            throw new InvalidOperationException("Failed to deserialize haste condition: JSON was null.");
+
+        if(state.RemainingTimeMilliseconds <= 0)
+        {
+            throw new InvalidOperationException("Failed to deserialize haste condition: Remaining time must be greater than zero.");
+        }
+
+        return HasteCondition.Restore(state);
+    }
+
+    public static bool CanHandle(ConditionType type)
+    {
+        return type is ConditionType.Haste;
+    }
+}

--- a/src/Database/NeoServer.Data/Helpers/ConditionParsers/HasteConditionParser.cs
+++ b/src/Database/NeoServer.Data/Helpers/ConditionParsers/HasteConditionParser.cs
@@ -23,12 +23,7 @@ public static class HasteConditionParser
 
         if (state is null)
             throw new InvalidOperationException("Failed to deserialize haste condition: JSON was null.");
-
-        if(state.RemainingTimeMilliseconds <= 0)
-        {
-            throw new InvalidOperationException("Failed to deserialize haste condition: Remaining time must be greater than zero.");
-        }
-
+        
         return HasteCondition.Restore(state);
     }
 

--- a/tests/NeoServer.Domain.Tests/Creature/Conditions/HasteConditionSaveRestoreTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Conditions/HasteConditionSaveRestoreTests.cs
@@ -1,0 +1,249 @@
+using NeoServer.Domain.Common.Creatures;
+using NeoServer.Domain.Common.Creatures.Structs;
+using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Domain.Creatures.Conditions.Implementations;
+using NeoServer.Domain.Tests.Helpers.Player;
+
+namespace NeoServer.Domain.Tests.Creature.Conditions;
+
+public class HasteConditionSaveRestoreTests
+{
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CaptureState_returns_correct_state_after_Start()
+    {
+        var creature = PlayerTestDataBuilder.Build(speed: 400);
+        var formula = new FormulaValues { MinA = 0.5, MinB = 50, MaxA = 1.0, MaxB = 100 };
+        var condition = new HasteCondition(10_000, formula, EffectT.GlitterBlue);
+        condition.Start(creature);
+
+        var state = condition.CaptureState();
+
+        state.Type.Should().Be(ConditionType.Haste);
+        state.Effect.Should().Be(EffectT.GlitterBlue);
+        state.SpeedBoost.Should().BeGreaterThan((ushort)0);
+        state.RemainingTimeMilliseconds.Should().BeGreaterThan(0);
+        state.Duration.Should().Be(10_000 * TimeSpan.TicksPerMillisecond);
+        state.FormulaValues.Should().Be(formula);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void CaptureState_returns_zero_SpeedBoost_when_not_started()
+    {
+        var formula = new FormulaValues { MinA = 0.5, MinB = 50, MaxA = 1.0, MaxB = 100 };
+        var condition = new HasteCondition(10_000, formula, EffectT.GlitterBlue);
+
+        var state = condition.CaptureState();
+
+        state.SpeedBoost.Should().Be(0);
+        state.RemainingTimeMilliseconds.Should().Be(10_000);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CaptureState_returns_correct_type_and_effect()
+    {
+        var formula = new FormulaValues { MinA = 0.5, MinB = 50, MaxA = 1.0, MaxB = 100 };
+        var condition = new HasteCondition(10_000, formula, EffectT.GroundShaker);
+
+        var state = condition.CaptureState();
+
+        state.Type.Should().Be(ConditionType.Haste);
+        state.Effect.Should().Be(EffectT.GroundShaker);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Restore_creates_condition_with_preserved_SpeedBoost()
+    {
+        var formula = new FormulaValues { MinA = 0.5, MinB = 50, MaxA = 1.0, MaxB = 100 };
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.GlitterBlue,
+            SpeedBoost: 240,
+            RemainingTimeMilliseconds: 30_000,
+            Duration: 60_000 * TimeSpan.TicksPerMillisecond,
+            FormulaValues: formula);
+
+        var condition = HasteCondition.Restore(state);
+
+        condition.Should().NotBeNull();
+        condition.SpeedBoost.Should().Be(240);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Restore_preserves_FormulaValues_and_Effect()
+    {
+        var formula = new FormulaValues { MinA = 1.5, MinB = 200, MaxA = 2.5, MaxB = 400 };
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.GroundShaker,
+            SpeedBoost: 350,
+            RemainingTimeMilliseconds: 15_000,
+            Duration: 30_000 * TimeSpan.TicksPerMillisecond,
+            FormulaValues: formula);
+
+        var condition = HasteCondition.Restore(state);
+
+        condition.FormulaValues.MinA.Should().Be(1.5);
+        condition.FormulaValues.MinB.Should().Be(200);
+        condition.FormulaValues.MaxA.Should().Be(2.5);
+        condition.FormulaValues.MaxB.Should().Be(400);
+        condition.Effect.Should().Be(EffectT.GroundShaker);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Restore_Start_applies_saved_speed_boost()
+    {
+        var player = PlayerTestDataBuilder.Build(speed: 400);
+        var formula = new FormulaValues { MinA = 1, MinB = 100, MaxA = 1, MaxB = 100 };
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 200,
+            RemainingTimeMilliseconds: 10_000,
+            Duration: 60_000 * TimeSpan.TicksPerMillisecond,
+            FormulaValues: formula);
+
+        var condition = HasteCondition.Restore(state);
+        player.AddCondition(condition);
+
+        player.Speed.Should().Be(600);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Restore_Start_does_not_regenerate_SpeedBoost()
+    {
+        var player = PlayerTestDataBuilder.Build(speed: 400);
+        var formula = new FormulaValues { MinA = 1, MinB = 100, MaxA = 1, MaxB = 100 };
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 200,
+            RemainingTimeMilliseconds: 10_000,
+            Duration: 60_000 * TimeSpan.TicksPerMillisecond,
+            FormulaValues: formula);
+
+        var condition = HasteCondition.Restore(state);
+        player.AddCondition(condition);
+
+        condition.SpeedBoost.Should().Be(200);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Restore_Start_removes_paralyze()
+    {
+        var player = PlayerTestDataBuilder.Build(speed: 400);
+        player.AddCondition(new ParalyzeCondition(30_000, 100));
+        player.Speed.Should().Be(300);
+
+        var formula = new FormulaValues { MinA = 1, MinB = 50, MaxA = 1, MaxB = 50 };
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 100,
+            RemainingTimeMilliseconds: 10_000,
+            Duration: 60_000 * TimeSpan.TicksPerMillisecond,
+            FormulaValues: formula);
+
+        var condition = HasteCondition.Restore(state);
+        player.AddCondition(condition);
+
+        player.HasCondition(ConditionType.Paralyze).Should().BeFalse();
+        player.Speed.Should().Be(500);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void HasExpired_is_false_after_Restore()
+    {
+        var formula = new FormulaValues { MinA = 0.5, MinB = 50, MaxA = 1.0, MaxB = 100 };
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.GlitterBlue,
+            SpeedBoost: 240,
+            RemainingTimeMilliseconds: 30_000,
+            Duration: 60_000 * TimeSpan.TicksPerMillisecond,
+            FormulaValues: formula);
+
+        var condition = HasteCondition.Restore(state);
+
+        condition.HasExpired.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CaptureState_after_Restore_and_Start_returns_saved_SpeedBoost()
+    {
+        var player = PlayerTestDataBuilder.Build(speed: 400);
+        var formula = new FormulaValues { MinA = 1, MinB = 100, MaxA = 1, MaxB = 100 };
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 200,
+            RemainingTimeMilliseconds: 10_000,
+            Duration: 60_000 * TimeSpan.TicksPerMillisecond,
+            FormulaValues: formula);
+
+        var condition = HasteCondition.Restore(state);
+        player.AddCondition(condition);
+
+        var recaptured = condition.CaptureState();
+
+        recaptured.SpeedBoost.Should().Be(200);
+        recaptured.Type.Should().Be(ConditionType.Haste);
+        recaptured.Effect.Should().Be(EffectT.None);
+        // Remaining time must be close to the saved value (10_000 ms),
+        // not the full Duration (60_000 ms).
+        recaptured.RemainingTimeMilliseconds.Should().BeInRange(9_000, 10_001);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Restore_does_not_throw_when_state_has_EffectT_None()
+    {
+        var formula = new FormulaValues { MinA = 0.5, MinB = 50, MaxA = 1.0, MaxB = 100 };
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 150,
+            RemainingTimeMilliseconds: 5_000,
+            Duration: 30_000 * TimeSpan.TicksPerMillisecond,
+            FormulaValues: formula);
+
+        var action = () => HasteCondition.Restore(state);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CaptureState_restore_Start_CaptureState_round_trip_preserves_remaining_time()
+    {
+        var player = PlayerTestDataBuilder.Build(speed: 400);
+        var formula = new FormulaValues { MinA = 1, MinB = 100, MaxA = 1, MaxB = 100 };
+        var condition = new HasteCondition(60_000, formula, EffectT.GlitterBlue);
+        condition.Start(player);
+
+        // Capture remaining time after condition has been running
+        var firstState = condition.CaptureState();
+        var savedRemaining = firstState.RemainingTimeMilliseconds;
+
+        // Restore and re-apply
+        var restored = HasteCondition.Restore(firstState);
+        player.AddCondition(restored);
+
+        // Re-capture — remaining time should be close to the saved value,
+        // not the full original Duration (60_000 ms).
+        var secondState = restored.CaptureState();
+
+        secondState.RemainingTimeMilliseconds.Should().BeInRange(
+            (long)(savedRemaining * 0.95),
+            savedRemaining + 1);
+    }
+}

--- a/tests/NeoServer.Server.Tests/Data/HasteConditionParserTest.cs
+++ b/tests/NeoServer.Server.Tests/Data/HasteConditionParserTest.cs
@@ -272,9 +272,9 @@ public class HasteConditionParserTest
 
     [Fact]
     [Trait("Category", "EdgeCase")]
-    public void Deserialize_with_zero_remaining_time_falls_back_to_duration()
+    public void Deserialize_preserves_zero_remaining_time()
     {
-        // Arrange - HasteCondition.Restore uses Duration when RemainingTimeMilliseconds == 0
+        // Arrange - RemainingTimeMilliseconds of 0 is preserved as-is (an expired condition)
         var json = $$"""
             {
                 "Type": {{(uint)ConditionType.Haste}},
@@ -295,10 +295,11 @@ public class HasteConditionParserTest
         // Act
         var condition = HasteConditionParser.Deserialize(json);
 
-        // Assert - the condition should have a non-expired duration (fell back to 10000ms)
+        // Assert
         condition.Type.Should().Be(ConditionType.Haste);
         var captured = condition.CaptureState();
         captured.SpeedBoost.Should().Be(50);
+        captured.RemainingTimeMilliseconds.Should().Be(0);
     }
 
     [Fact]

--- a/tests/NeoServer.Server.Tests/Data/HasteConditionParserTest.cs
+++ b/tests/NeoServer.Server.Tests/Data/HasteConditionParserTest.cs
@@ -1,0 +1,680 @@
+using System;
+using System.Text.Json;
+using FluentAssertions;
+using NeoServer.Data.Helpers.ConditionParsers;
+using NeoServer.Domain.Common.Combat.Structs;
+using NeoServer.Domain.Common.Creatures;
+using NeoServer.Domain.Common.Creatures.Structs;
+using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Domain.Creatures.Conditions.Implementations;
+using Xunit;
+
+namespace NeoServer.Server.Tests.Data;
+
+public class HasteConditionParserTest
+{
+    #region CanHandle
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CanHandle_returns_true_for_haste()
+    {
+        HasteConditionParser.CanHandle(ConditionType.Haste).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void CanHandle_returns_false_for_non_haste_condition_types()
+    {
+        var nonHasteTypes = new[]
+        {
+            ConditionType.None,
+            ConditionType.Poisoned,
+            ConditionType.Burning,
+            ConditionType.Paralyze,
+            ConditionType.Outfit,
+            ConditionType.Invisible,
+            ConditionType.Light,
+            ConditionType.ManaShield,
+            ConditionType.LogoutBlock,
+            ConditionType.Drunk,
+            ConditionType.Regeneration,
+            ConditionType.Pacified,
+            ConditionType.Hungry
+        };
+
+        foreach (var type in nonHasteTypes)
+            HasteConditionParser.CanHandle(type).Should().BeFalse($"because {type} is not Haste");
+    }
+
+    #endregion
+
+    #region Serialization
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Serialize_creates_valid_json_with_all_state_fields()
+    {
+        // Arrange - build a condition with known state via Restore
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.RingsGreen,
+            SpeedBoost: 150,
+            RemainingTimeMilliseconds: 30000,
+            Duration: 60000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues
+            {
+                FormulaType = FormulaType.Damage,
+                MinA = 1.0,
+                MinB = 50,
+                MaxA = 1.0,
+                MaxB = 150
+            });
+
+        var condition = HasteCondition.Restore(state);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+
+        // Assert
+        json.Should().NotBeNullOrWhiteSpace();
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("Type").GetUInt32().Should().Be((uint)ConditionType.Haste);
+        doc.RootElement.GetProperty("Effect").GetUInt32().Should().Be((byte)EffectT.RingsGreen);
+        doc.RootElement.GetProperty("SpeedBoost").GetUInt32().Should().Be(150u);
+        doc.RootElement.GetProperty("RemainingTimeMilliseconds").GetInt64().Should().BeGreaterThan(0);
+        doc.RootElement.GetProperty("Duration").GetInt64().Should().Be(30000 * TimeSpan.TicksPerMillisecond);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Serialize_contains_formula_values()
+    {
+        // Arrange
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 100,
+            RemainingTimeMilliseconds: 10000,
+            Duration: 30000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues
+            {
+                FormulaType = FormulaType.Skill,
+                MinA = 0.8,
+                MinB = 10,
+                MaxA = 1.2,
+                MaxB = 20
+            });
+
+        var condition = HasteCondition.Restore(state);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+
+        // Assert
+        json.Should().NotBeNullOrWhiteSpace();
+        json.Should().Contain("\"MinA\":0.8");
+        json.Should().Contain("\"MinB\":10");
+        json.Should().Contain("\"MaxA\":1.2");
+        json.Should().Contain("\"MaxB\":20");
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Serialize_handles_zero_speed_boost()
+    {
+        // Arrange
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 0,
+            RemainingTimeMilliseconds: 5000,
+            Duration: 30000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues
+            {
+                FormulaType = FormulaType.None,
+                MinA = 0,
+                MinB = 0,
+                MaxA = 0,
+                MaxB = 0
+            });
+
+        var condition = HasteCondition.Restore(state);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+
+        // Assert
+        json.Should().NotBeNullOrWhiteSpace();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("SpeedBoost").GetUInt32().Should().Be(0u);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Serialize_handles_expired_condition_with_zero_remaining_time()
+    {
+        // Arrange - when RemainingTimeMilliseconds is 0, Restore falls back to Duration
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 75,
+            RemainingTimeMilliseconds: 0,
+            Duration: 0,
+            new FormulaValues());
+
+        var condition = HasteCondition.Restore(state);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+
+        // Assert - serialization should still produce valid JSON
+        json.Should().NotBeNullOrWhiteSpace();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("RemainingTimeMilliseconds").GetInt64().Should().Be(0);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Serialize_preserves_default_effect_as_none()
+    {
+        // Arrange
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 100,
+            RemainingTimeMilliseconds: 15000,
+            Duration: 30000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues());
+
+        var condition = HasteCondition.Restore(state);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+
+        // Assert
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("Effect").GetUInt32().Should().Be((byte)EffectT.None);
+    }
+
+    #endregion
+
+    #region Deserialization
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Deserialize_reconstructs_haste_condition()
+    {
+        // Arrange
+        var json = $$"""
+            {
+                "Type": {{(uint)ConditionType.Haste}},
+                "Effect": {{(byte)EffectT.RingsGreen}},
+                "SpeedBoost": 150,
+                "RemainingTimeMilliseconds": 30000,
+                "Duration": {{60000 * TimeSpan.TicksPerMillisecond}},
+                "FormulaValues": {
+                    "FormulaType": {{(int)FormulaType.Damage}},
+                    "MinA": 1.0,
+                    "MinB": 50,
+                    "MaxA": 1.0,
+                    "MaxB": 150
+                }
+            }
+            """;
+
+        // Act
+        var condition = HasteConditionParser.Deserialize(json);
+
+        // Assert
+        condition.Type.Should().Be(ConditionType.Haste);
+        condition.Effect.Should().Be(EffectT.RingsGreen);
+
+        var captured = condition.CaptureState();
+        captured.SpeedBoost.Should().Be(150);
+        captured.RemainingTimeMilliseconds.Should().Be(30000);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Deserialize_reconstructs_haste_condition_with_default_formula()
+    {
+        // Arrange
+        var json = $$"""
+            {
+                "Type": {{(uint)ConditionType.Haste}},
+                "Effect": 0,
+                "SpeedBoost": 100,
+                "RemainingTimeMilliseconds": 10000,
+                "Duration": 300000000,
+                "FormulaValues": {
+                    "FormulaType": 0,
+                    "MinA": 0,
+                    "MinB": 0,
+                    "MaxA": 0,
+                    "MaxB": 0
+                }
+            }
+            """;
+
+        // Act
+        var condition = HasteConditionParser.Deserialize(json);
+
+        // Assert
+        condition.Type.Should().Be(ConditionType.Haste);
+        var captured = condition.CaptureState();
+        captured.SpeedBoost.Should().Be(100);
+        captured.FormulaValues.FormulaType.Should().Be(FormulaType.None);
+        captured.FormulaValues.MinA.Should().Be(0);
+        captured.FormulaValues.MaxB.Should().Be(0);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Deserialize_with_zero_remaining_time_falls_back_to_duration()
+    {
+        // Arrange - HasteCondition.Restore uses Duration when RemainingTimeMilliseconds == 0
+        var json = $$"""
+            {
+                "Type": {{(uint)ConditionType.Haste}},
+                "Effect": 0,
+                "SpeedBoost": 50,
+                "RemainingTimeMilliseconds": 0,
+                "Duration": {{10000 * TimeSpan.TicksPerMillisecond}},
+                "FormulaValues": {
+                    "FormulaType": 0,
+                    "MinA": 0,
+                    "MinB": 0,
+                    "MaxA": 0,
+                    "MaxB": 0
+                }
+            }
+            """;
+
+        // Act
+        var condition = HasteConditionParser.Deserialize(json);
+
+        // Assert - the condition should have a non-expired duration (fell back to 10000ms)
+        condition.Type.Should().Be(ConditionType.Haste);
+        var captured = condition.CaptureState();
+        captured.SpeedBoost.Should().Be(50);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Deserialize_with_none_effect_reconstructs_correctly()
+    {
+        // Arrange - EffectT.None = 255
+        var json = $$"""
+            {
+                "Type": {{(uint)ConditionType.Haste}},
+                "Effect": 255,
+                "SpeedBoost": 200,
+                "RemainingTimeMilliseconds": 5000,
+                "Duration": {{30000 * TimeSpan.TicksPerMillisecond}},
+                "FormulaValues": {
+                    "FormulaType": 0,
+                    "MinA": 0,
+                    "MinB": 0,
+                    "MaxA": 0,
+                    "MaxB": 0
+                }
+            }
+            """;
+
+        // Act
+        var condition = HasteConditionParser.Deserialize(json);
+
+        // Assert
+        condition.Effect.Should().Be(EffectT.None);
+        var captured = condition.CaptureState();
+        captured.SpeedBoost.Should().Be(200);
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_throws_on_null_json()
+    {
+        // Act
+        Action act = () => HasteConditionParser.Deserialize(null);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_throws_on_empty_json()
+    {
+        // Act
+        Action act = () => HasteConditionParser.Deserialize(string.Empty);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_throws_on_whitespace_json()
+    {
+        // Act
+        Action act = () => HasteConditionParser.Deserialize("   ");
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_throws_on_malformed_json()
+    {
+        // Act
+        Action act = () => HasteConditionParser.Deserialize("{{{{{invalid}}}}");
+
+        // Assert
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_does_not_throw_when_type_field_is_missing()
+    {
+        // Arrange — JSON without a Type property; the state record defaults to
+        // None, but HasteCondition.Type is always Haste at runtime
+        var json = $$"""
+            {
+                "Effect": 0,
+                "SpeedBoost": 100,
+                "RemainingTimeMilliseconds": 10000,
+                "Duration": 300000000
+            }
+            """;
+
+        // Act
+        var condition = HasteConditionParser.Deserialize(json);
+
+        // Assert
+        condition.Type.Should().Be(ConditionType.Haste);
+    }
+
+    #endregion
+
+    #region Round-Trip
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Round_trip_preserves_all_state_for_haste_condition()
+    {
+        // Arrange
+        var originalState = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.SparkYellow,
+            SpeedBoost: 180,
+            RemainingTimeMilliseconds: 45000,
+            Duration: 60000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues
+            {
+                FormulaType = FormulaType.Damage,
+                MinA = 1.0,
+                MinB = 60,
+                MaxA = 1.0,
+                MaxB = 180
+            });
+
+        var condition = HasteCondition.Restore(originalState);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+        var restored = HasteConditionParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        // Assert
+        restoredState.Type.Should().Be(originalState.Type);
+        restoredState.Effect.Should().Be(originalState.Effect);
+        restoredState.SpeedBoost.Should().Be(originalState.SpeedBoost);
+        restoredState.RemainingTimeMilliseconds.Should().Be(originalState.RemainingTimeMilliseconds);
+        restoredState.FormulaValues.FormulaType.Should().Be(originalState.FormulaValues.FormulaType);
+        restoredState.FormulaValues.MinA.Should().Be(originalState.FormulaValues.MinA);
+        restoredState.FormulaValues.MinB.Should().Be(originalState.FormulaValues.MinB);
+        restoredState.FormulaValues.MaxA.Should().Be(originalState.FormulaValues.MaxA);
+        restoredState.FormulaValues.MaxB.Should().Be(originalState.FormulaValues.MaxB);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Round_trip_preserves_non_default_effect()
+    {
+        // Arrange
+        var originalState = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.RingsBlue,
+            SpeedBoost: 120,
+            RemainingTimeMilliseconds: 20000,
+            Duration: 40000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues
+            {
+                FormulaType = FormulaType.None,
+                MinA = 0,
+                MinB = 0,
+                MaxA = 0,
+                MaxB = 0
+            });
+
+        var condition = HasteCondition.Restore(originalState);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+        var restored = HasteConditionParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        // Assert
+        restoredState.Effect.Should().Be(EffectT.RingsBlue);
+        restoredState.SpeedBoost.Should().Be(120);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Round_trip_preserves_zero_speed_boost()
+    {
+        // Arrange
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 0,
+            RemainingTimeMilliseconds: 10000,
+            Duration: 30000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues());
+
+        var condition = HasteCondition.Restore(state);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+        var restored = HasteConditionParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        // Assert
+        restoredState.SpeedBoost.Should().Be(0);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Round_trip_preserves_formula_values_with_precision()
+    {
+        // Arrange
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 90,
+            RemainingTimeMilliseconds: 25000,
+            Duration: 50000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues
+            {
+                FormulaType = FormulaType.MagicLevel,
+                MinA = 0.75,
+                MinB = 15,
+                MaxA = 1.5,
+                MaxB = 35
+            });
+
+        var condition = HasteCondition.Restore(state);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+        var restored = HasteConditionParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        // Assert
+        restoredState.FormulaValues.FormulaType.Should().Be(FormulaType.MagicLevel);
+        restoredState.FormulaValues.MinA.Should().BeApproximately(0.75, 0.001);
+        restoredState.FormulaValues.MinB.Should().Be(15);
+        restoredState.FormulaValues.MaxA.Should().BeApproximately(1.5, 0.001);
+        restoredState.FormulaValues.MaxB.Should().Be(35);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Round_trip_preserves_remaining_time_with_small_tolerance()
+    {
+        // Arrange
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 100,
+            RemainingTimeMilliseconds: 4950, // slightly consumed
+            Duration: 10000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues());
+
+        var condition = HasteCondition.Restore(state);
+
+        // Capture the expected value immediately after Restore, before any
+        // serialization overhead adds wall-clock drift.
+        var expectedRemaining = condition.CaptureState().RemainingTimeMilliseconds;
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+        using var doc = JsonDocument.Parse(json);
+        var serializedRemaining = doc.RootElement.GetProperty("RemainingTimeMilliseconds").GetInt64();
+
+        // Assert — the serialized value should match the captured value
+        // within a generous tolerance. Both are read from the same live
+        // object, so the gap is only the time between CaptureState() and
+        // JsonSerializer.Serialize() — well under 50ms.
+        serializedRemaining.Should().BeCloseTo(expectedRemaining, 50);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Round_trip_preserves_max_remaining_time()
+    {
+        // Arrange — use a large remaining time
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 250,
+            RemainingTimeMilliseconds: int.MaxValue,
+            Duration: uint.MaxValue * TimeSpan.TicksPerMillisecond,
+            new FormulaValues());
+
+        var condition = HasteCondition.Restore(state);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+        var restored = HasteConditionParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        // Assert
+        restoredState.RemainingTimeMilliseconds.Should().Be(int.MaxValue);
+        restoredState.SpeedBoost.Should().Be(250);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Round_trip_preserves_minimal_remaining_time()
+    {
+        // Arrange — minimal positive remaining time (1ms)
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 5,
+            RemainingTimeMilliseconds: 1,
+            Duration: 1000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues());
+
+        var condition = HasteCondition.Restore(state);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+        var restored = HasteConditionParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        // Assert
+        restoredState.RemainingTimeMilliseconds.Should().Be(1);
+        restoredState.SpeedBoost.Should().Be(5);
+    }
+
+    #endregion
+
+    #region Validation
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Serialize_throws_on_null_condition()
+    {
+        // Act
+        Action act = () => HasteConditionParser.Serialize(null);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Serialize_with_minimal_interval_produces_valid_json()
+    {
+        // Arrange — interval of 1ms via RemainingTimeMilliseconds = 1
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: 10,
+            RemainingTimeMilliseconds: 1,
+            Duration: 1000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues());
+
+        var condition = HasteCondition.Restore(state);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+
+        // Assert
+        json.Should().NotBeNullOrWhiteSpace();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("RemainingTimeMilliseconds").GetInt64().Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Serialize_with_large_speed_boost_produces_valid_json()
+    {
+        // Arrange — speed boost at the upper bound of ushort
+        var state = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.None,
+            SpeedBoost: ushort.MaxValue,
+            RemainingTimeMilliseconds: 30000,
+            Duration: 60000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues());
+
+        var condition = HasteCondition.Restore(state);
+
+        // Act
+        var json = HasteConditionParser.Serialize(condition);
+
+        // Assert
+        json.Should().NotBeNullOrWhiteSpace();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("SpeedBoost").GetUInt32().Should().Be(ushort.MaxValue);
+    }
+
+    #endregion
+}


### PR DESCRIPTION
### Description
Haste conditions (from spells, items, or runes) are now saved on logout and restored on login so players keep their active speed boosts across sessions.

### Key Changes
- Added `CaptureState`/`Restore` to `HasteCondition` for serializable snapshots
- Added `HasteConditionParser` with round-trip serialization support
- Wired parser into `ConditionListParser` so haste conditions are included in player persistence

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
`dotnet test tests/`