### PR TITLE
feat: persist invisible conditions between player sessions

### DIFF
--- a/src/Core/NeoServer.Domain/Creatures/Conditions/Implementations/ConditionInvisible.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Conditions/Implementations/ConditionInvisible.cs
@@ -1,4 +1,5 @@
-﻿using NeoServer.Domain.Common.Contracts.Creatures;
+﻿#nullable enable
+using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Common.Creatures;
 using NeoServer.Domain.Creatures.Conditions.Enums;
 
@@ -30,4 +31,29 @@ public class ConditionInvisible : BaseCondition
 
         return true;
     }
+
+    public ConditionInvisibleState CaptureState()
+    {
+        return new ConditionInvisibleState(
+            Type,
+            Effect,
+            Math.Max(0, RemainingTime));
+    }
+
+    public static ConditionInvisible? Restore(ConditionInvisibleState state)
+    {
+        var durationMs = Math.Max(0, state.RemainingTimeMilliseconds);
+
+        if (durationMs <= 0)
+            return null;
+
+        return new ConditionInvisible(
+            (uint)durationMs,
+            state.Effect);
+    }
 }
+
+public sealed record ConditionInvisibleState(
+    ConditionType Type,
+    EffectT Effect,
+    long RemainingTimeMilliseconds);

--- a/src/Database/NeoServer.Data/Helpers/ConditionParsers/ConditionInvisibleParser.cs
+++ b/src/Database/NeoServer.Data/Helpers/ConditionParsers/ConditionInvisibleParser.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using System;
+using System.Text.Json;
+using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Domain.Creatures.Conditions.Implementations;
+
+namespace NeoServer.Data.Helpers.ConditionParsers;
+
+public static class ConditionInvisibleParser
+{
+    public static string Serialize(ConditionInvisible condition)
+    {
+        ArgumentNullException.ThrowIfNull(condition);
+
+        var state = condition.CaptureState();
+        return JsonSerializer.Serialize(state);
+    }
+
+    public static ConditionInvisible? Deserialize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        var state = JsonSerializer.Deserialize<ConditionInvisibleState>(json);
+
+        if (state is null)
+            throw new InvalidOperationException("Failed to deserialize invisible condition: JSON was null.");
+
+        // Restore returns null when the condition has expired (RemainingTimeMilliseconds <= 0).
+        // The caller (ConditionListParser) skips null entries, so expired invisible records
+        // are silently ignored rather than failing player materialization.
+        return ConditionInvisible.Restore(state);
+    }
+
+    public static bool CanHandle(ConditionType type)
+    {
+        return type is ConditionType.Invisible;
+    }
+}

--- a/src/Database/NeoServer.Data/Helpers/ConditionParsers/ConditionListParser.cs
+++ b/src/Database/NeoServer.Data/Helpers/ConditionParsers/ConditionListParser.cs
@@ -34,6 +34,11 @@ public static class ConditionListParser
             {
                 serializedConditions.Add(ParalyzeConditionParser.Serialize(paralyzeCondition));
             }
+
+            if (ConditionInvisibleParser.CanHandle(condition.Type) && condition is ConditionInvisible invisibleCondition)
+            {
+                serializedConditions.Add(ConditionInvisibleParser.Serialize(invisibleCondition));
+            }
         }
 
         return $"[{string.Join(",", serializedConditions)}]";
@@ -86,6 +91,15 @@ public static class ConditionListParser
                 // Restore returns null for expired conditions; silently skip those
                 // to avoid persisting a never-expiring paralyze.
                 var condition = ParalyzeConditionParser.Deserialize(conditionJson);
+                if (condition is not null)
+                    conditions.Add(condition);
+            }
+
+            if (ConditionInvisibleParser.CanHandle(conditionType))
+            {
+                // Restore returns null for expired conditions; silently skip those
+                // to avoid persisting a never-expiring invisible.
+                var condition = ConditionInvisibleParser.Deserialize(conditionJson);
                 if (condition is not null)
                     conditions.Add(condition);
             }

--- a/tests/NeoServer.Domain.Tests/Creature/Conditions/ConditionInvisibleSaveRestoreTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Conditions/ConditionInvisibleSaveRestoreTests.cs
@@ -1,0 +1,215 @@
+using NeoServer.Domain.Common.Creatures;
+using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Domain.Creatures.Conditions.Implementations;
+using NeoServer.Domain.Tests.Helpers.Player;
+
+namespace NeoServer.Domain.Tests.Creature.Conditions;
+
+public class ConditionInvisibleSaveRestoreTests
+{
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CaptureState_returns_correct_state_after_Start()
+    {
+        var creature = PlayerTestDataBuilder.Build();
+        var condition = new ConditionInvisible(120_000, EffectT.GlitterBlue);
+        condition.Start(creature);
+
+        var state = condition.CaptureState();
+
+        state.Type.Should().Be(ConditionType.Invisible);
+        state.Effect.Should().Be(EffectT.GlitterBlue);
+        state.RemainingTimeMilliseconds.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void CaptureState_returns_correct_effect_when_not_started()
+    {
+        var condition = new ConditionInvisible(120_000, EffectT.RingsGreen);
+
+        var state = condition.CaptureState();
+
+        state.Effect.Should().Be(EffectT.RingsGreen);
+        state.RemainingTimeMilliseconds.Should().Be(120_000);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CaptureState_returns_correct_type()
+    {
+        var condition = new ConditionInvisible(10_000, EffectT.None);
+
+        var state = condition.CaptureState();
+
+        state.Type.Should().Be(ConditionType.Invisible);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Restore_creates_condition_with_preserved_Effect()
+    {
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = ConditionInvisible.Restore(state);
+
+        condition.Should().NotBeNull();
+        condition!.Effect.Should().Be(EffectT.GlitterBlue);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Restore_creates_condition_with_preserved_remaining_time()
+    {
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = ConditionInvisible.Restore(state);
+
+        condition.Should().NotBeNull();
+        var recaptured = condition!.CaptureState();
+        recaptured.RemainingTimeMilliseconds.Should().Be(75_000);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Restore_Start_applies_invisibility()
+    {
+        var player = PlayerTestDataBuilder.Build();
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = ConditionInvisible.Restore(state);
+        player.AddCondition(condition!);
+
+        player.HasCondition(ConditionType.Invisible).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Restore_Start_sets_EndAction_to_TurnVisible()
+    {
+        var player = PlayerTestDataBuilder.Build();
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = ConditionInvisible.Restore(state);
+        player.AddCondition(condition!);
+
+        // After Start, the EndAction is set to TurnVisible.
+        // We cannot directly assert on EndAction (it's a delegate),
+        // but we can verify the condition is present and not expired.
+        player.HasCondition(ConditionType.Invisible).Should().BeTrue();
+        condition!.HasExpired.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void HasExpired_is_false_after_Restore()
+    {
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = ConditionInvisible.Restore(state);
+
+        condition!.HasExpired.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CaptureState_after_Restore_and_Start_returns_saved_Effect()
+    {
+        var player = PlayerTestDataBuilder.Build();
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = ConditionInvisible.Restore(state);
+        player.AddCondition(condition!);
+
+        var recaptured = condition!.CaptureState();
+
+        recaptured.Effect.Should().Be(EffectT.GlitterBlue);
+        recaptured.Type.Should().Be(ConditionType.Invisible);
+        recaptured.RemainingTimeMilliseconds.Should().BeInRange(74_000, 75_001);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Restore_does_not_throw_when_state_has_EffectT_None()
+    {
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.None,
+            RemainingTimeMilliseconds: 5_000);
+
+        var action = () => ConditionInvisible.Restore(state);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CaptureState_restore_Start_CaptureState_round_trip_preserves_remaining_time()
+    {
+        var player = PlayerTestDataBuilder.Build();
+        var condition = new ConditionInvisible(60_000, EffectT.GlitterBlue);
+        condition.Start(player);
+
+        // Capture remaining time after condition has been running
+        var firstState = condition.CaptureState();
+        var savedRemaining = firstState.RemainingTimeMilliseconds;
+
+        // Restore and re-apply
+        var restored = ConditionInvisible.Restore(firstState);
+        player.AddCondition(restored!);
+
+        // Re-capture — remaining time should be close to the saved value,
+        // not the full original Duration (60_000 ms).
+        var secondState = restored!.CaptureState();
+
+        secondState.RemainingTimeMilliseconds.Should().BeInRange(
+            (long)(savedRemaining * 0.95),
+            savedRemaining + 1);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Restore_returns_null_when_remaining_time_is_zero()
+    {
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 0);
+
+        var condition = ConditionInvisible.Restore(state);
+
+        condition.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Restore_returns_null_when_remaining_time_is_negative()
+    {
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: -1);
+
+        var condition = ConditionInvisible.Restore(state);
+
+        condition.Should().BeNull();
+    }
+}

--- a/tests/NeoServer.Server.Tests/Data/ConditionInvisibleParserTest.cs
+++ b/tests/NeoServer.Server.Tests/Data/ConditionInvisibleParserTest.cs
@@ -1,0 +1,411 @@
+using System;
+using System.Text.Json;
+using FluentAssertions;
+using NeoServer.Data.Helpers.ConditionParsers;
+using NeoServer.Domain.Common.Creatures;
+using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Domain.Creatures.Conditions.Implementations;
+using Xunit;
+
+namespace NeoServer.Server.Tests.Data;
+
+public class ConditionInvisibleParserTest
+{
+    #region CanHandle
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CanHandle_returns_true_for_invisible()
+    {
+        ConditionInvisibleParser.CanHandle(ConditionType.Invisible).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void CanHandle_returns_false_for_non_invisible_condition_types()
+    {
+        var nonInvisibleTypes = new[]
+        {
+            ConditionType.None,
+            ConditionType.Poisoned,
+            ConditionType.Burning,
+            ConditionType.Haste,
+            ConditionType.Paralyze,
+            ConditionType.Outfit,
+            ConditionType.Light,
+            ConditionType.ManaShield,
+            ConditionType.LogoutBlock,
+            ConditionType.Drunk,
+            ConditionType.Regeneration,
+            ConditionType.Pacified,
+            ConditionType.Hungry
+        };
+
+        foreach (var type in nonInvisibleTypes)
+            ConditionInvisibleParser.CanHandle(type).Should().BeFalse($"because {type} is not Invisible");
+    }
+
+    #endregion
+
+    #region Serialization
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Serialize_creates_valid_json_with_all_state_fields()
+    {
+        // Arrange - build a condition with known state via Restore
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = ConditionInvisible.Restore(state);
+
+        // Act
+        var json = ConditionInvisibleParser.Serialize(condition!);
+
+        // Assert
+        json.Should().NotBeNullOrWhiteSpace();
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("Type").GetUInt32().Should().Be((uint)ConditionType.Invisible);
+        doc.RootElement.GetProperty("Effect").GetUInt32().Should().Be((byte)EffectT.GlitterBlue);
+        doc.RootElement.GetProperty("RemainingTimeMilliseconds").GetInt64().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Serialize_uses_remaining_time_not_full_duration()
+    {
+        // Arrange
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 45_000);
+
+        var condition = ConditionInvisible.Restore(state);
+
+        // Act
+        var json = ConditionInvisibleParser.Serialize(condition!);
+
+        // Assert — serialized RemainingTimeMilliseconds should be close to 45_000, not 120_000
+        using var doc = JsonDocument.Parse(json);
+        var remaining = doc.RootElement.GetProperty("RemainingTimeMilliseconds").GetInt64();
+        remaining.Should().BeInRange(44_000, 45_001);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Serialize_handles_effect_none()
+    {
+        // Arrange — EffectT.None = 255
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.None,
+            RemainingTimeMilliseconds: 30_000);
+
+        var condition = ConditionInvisible.Restore(state);
+
+        // Act
+        var json = ConditionInvisibleParser.Serialize(condition!);
+
+        // Assert
+        json.Should().NotBeNullOrWhiteSpace();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("Effect").GetUInt32().Should().Be((byte)EffectT.None);
+    }
+
+    #endregion
+
+    #region Deserialization
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Deserialize_reconstructs_invisible_condition()
+    {
+        // Arrange
+        var json = $$"""
+            {
+                "Type": {{(uint)ConditionType.Invisible}},
+                "Effect": {{(byte)EffectT.GlitterBlue}},
+                "RemainingTimeMilliseconds": 75000
+            }
+            """;
+
+        // Act
+        var condition = ConditionInvisibleParser.Deserialize(json);
+
+        // Assert
+        condition!.Type.Should().Be(ConditionType.Invisible);
+
+        var captured = condition!.CaptureState();
+        captured.Effect.Should().Be(EffectT.GlitterBlue);
+        captured.RemainingTimeMilliseconds.Should().Be(75000);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Deserialize_reconstructs_invisible_condition_with_different_values()
+    {
+        // Arrange
+        var json = $$"""
+            {
+                "Type": {{(uint)ConditionType.Invisible}},
+                "Effect": {{(byte)EffectT.RingsGreen}},
+                "RemainingTimeMilliseconds": 15000
+            }
+            """;
+
+        // Act
+        var condition = ConditionInvisibleParser.Deserialize(json);
+
+        // Assert
+        condition!.Type.Should().Be(ConditionType.Invisible);
+        var captured = condition!.CaptureState();
+        captured.Effect.Should().Be(EffectT.RingsGreen);
+        captured.RemainingTimeMilliseconds.Should().Be(15000);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Deserialize_returns_null_for_expired_invisible()
+    {
+        // Arrange — expired condition with zero remaining time.
+        // The parser must not throw; it should silently skip expired
+        // records so player materialisation does not fail.
+        var json = $$"""
+            {
+                "Type": {{(uint)ConditionType.Invisible}},
+                "Effect": {{(byte)EffectT.GlitterBlue}},
+                "RemainingTimeMilliseconds": 0
+            }
+            """;
+
+        // Act
+        var condition = ConditionInvisibleParser.Deserialize(json);
+
+        // Assert
+        condition.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Deserialize_returns_null_for_negative_remaining_time()
+    {
+        // Arrange — expired condition with negative remaining time
+        var json = $$"""
+            {
+                "Type": {{(uint)ConditionType.Invisible}},
+                "Effect": {{(byte)EffectT.GlitterBlue}},
+                "RemainingTimeMilliseconds": -1
+            }
+            """;
+
+        // Act
+        var condition = ConditionInvisibleParser.Deserialize(json);
+
+        // Assert
+        condition.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_throws_on_null_json()
+    {
+        // Act
+        Action act = () => ConditionInvisibleParser.Deserialize(null);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_throws_on_empty_json()
+    {
+        // Act
+        Action act = () => ConditionInvisibleParser.Deserialize(string.Empty);
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_throws_on_whitespace_json()
+    {
+        // Act
+        Action act = () => ConditionInvisibleParser.Deserialize("   ");
+
+        // Assert
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_throws_on_malformed_json()
+    {
+        // Act
+        Action act = () => ConditionInvisibleParser.Deserialize("{{{{{invalid}}}}");
+
+        // Assert
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Deserialize_does_not_throw_when_type_field_is_missing()
+    {
+        // Arrange — JSON without a Type property; the state record defaults to
+        // None, but ConditionInvisible.Type is always Invisible at runtime
+        var json = $$"""
+            {
+                "Effect": {{(byte)EffectT.GlitterBlue}},
+                "RemainingTimeMilliseconds": 10000
+            }
+            """;
+
+        // Act
+        var condition = ConditionInvisibleParser.Deserialize(json);
+
+        // Assert
+        condition!.Type.Should().Be(ConditionType.Invisible);
+    }
+
+    #endregion
+
+    #region Round-Trip
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Round_trip_preserves_all_state_for_invisible_condition()
+    {
+        // Arrange
+        var originalState = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 45_000);
+
+        var condition = ConditionInvisible.Restore(originalState);
+
+        // Act
+        var json = ConditionInvisibleParser.Serialize(condition!);
+        var restored = ConditionInvisibleParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        // Assert
+        restoredState.Type.Should().Be(originalState.Type);
+        restoredState.Effect.Should().Be(originalState.Effect);
+        restoredState.RemainingTimeMilliseconds.Should().Be(originalState.RemainingTimeMilliseconds);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Round_trip_preserves_effect()
+    {
+        // Arrange
+        var originalState = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.RingsBlue,
+            RemainingTimeMilliseconds: 30_000);
+
+        var condition = ConditionInvisible.Restore(originalState);
+
+        // Act
+        var json = ConditionInvisibleParser.Serialize(condition!);
+        var restored = ConditionInvisibleParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        // Assert
+        restoredState.Effect.Should().Be(EffectT.RingsBlue);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Round_trip_preserves_remaining_time_with_small_tolerance()
+    {
+        // Arrange
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 4950);
+
+        var condition = ConditionInvisible.Restore(state);
+
+        // Capture the expected value immediately after Restore, before any
+        // serialization overhead adds wall-clock drift.
+        var expectedRemaining = condition!.CaptureState().RemainingTimeMilliseconds;
+
+        // Act
+        var json = ConditionInvisibleParser.Serialize(condition);
+        using var doc = JsonDocument.Parse(json);
+        var serializedRemaining = doc.RootElement.GetProperty("RemainingTimeMilliseconds").GetInt64();
+
+        // Assert — the serialized value should match the captured value
+        // within a generous tolerance. Both are read from the same live
+        // object, so the gap is only the time between CaptureState() and
+        // JsonSerializer.Serialize() — well under 50ms.
+        serializedRemaining.Should().BeCloseTo(expectedRemaining, 50);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Round_trip_preserves_minimal_remaining_time()
+    {
+        // Arrange — minimal positive remaining time (1ms)
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 1);
+
+        var condition = ConditionInvisible.Restore(state);
+
+        // Act
+        var json = ConditionInvisibleParser.Serialize(condition!);
+        var restored = ConditionInvisibleParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        // Assert
+        restoredState.RemainingTimeMilliseconds.Should().Be(1);
+        restoredState.Effect.Should().Be(EffectT.GlitterBlue);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Round_trip_preserves_max_remaining_time()
+    {
+        // Arrange — use a large remaining time
+        var state = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: int.MaxValue);
+
+        var condition = ConditionInvisible.Restore(state);
+
+        // Act
+        var json = ConditionInvisibleParser.Serialize(condition!);
+        var restored = ConditionInvisibleParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        // Assert
+        restoredState.RemainingTimeMilliseconds.Should().Be(int.MaxValue);
+        restoredState.Effect.Should().Be(EffectT.GlitterBlue);
+    }
+
+    #endregion
+
+    #region Validation
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Serialize_throws_on_null_condition()
+    {
+        // Act
+        Action act = () => ConditionInvisibleParser.Serialize(null);
+
+        // Assert
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    #endregion
+}

--- a/tests/NeoServer.Server.Tests/Data/ConditionListParserTest.cs
+++ b/tests/NeoServer.Server.Tests/Data/ConditionListParserTest.cs
@@ -149,6 +149,97 @@ public class ConditionListParserTest
 
     [Fact]
     [Trait("Category", "HappyPath")]
+    public void Serialize_Deserialize_round_trips_invisible_condition()
+    {
+        // Arrange — build a ConditionInvisible with a known remaining time
+        var invisibleState = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 75_000);
+
+        var conditions = new List<ICondition>
+        {
+            ConditionInvisible.Restore(invisibleState)!
+        };
+
+        // Act
+        var json = ConditionListParser.Serialize(conditions);
+        var restored = ConditionListParser.Deserialize(json);
+
+        // Assert
+        restored.Should().HaveCount(1);
+        restored[0].Type.Should().Be(ConditionType.Invisible);
+        restored[0].Should().BeOfType<ConditionInvisible>();
+        ((ConditionInvisible)restored[0]).Effect.Should().Be(EffectT.GlitterBlue);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Serialize_Deserialize_skips_expired_invisible()
+    {
+        // Arrange — expired invisible (zero remaining time)
+        var expiredInvisible = new ConditionInvisible(0, EffectT.None);
+
+        var conditions = new List<ICondition>
+        {
+            expiredInvisible
+        };
+
+        // Act
+        var json = ConditionListParser.Serialize(conditions);
+        var restored = ConditionListParser.Deserialize(json);
+
+        // Assert — expired invisible is filtered out
+        restored.Should().BeEmpty();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Serialize_Deserialize_round_trips_mixed_with_invisible()
+    {
+        // Arrange — one condition of each parser path including Invisible
+        var manaShield = new Condition(ConditionType.ManaShield, 30_000);
+
+        var hasteState = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.GlitterBlue,
+            SpeedBoost: 180,
+            RemainingTimeMilliseconds: 25_000,
+            Duration: 60_000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues());
+
+        var paralyzeState = new ParalyzeConditionState(
+            ConditionType.Paralyze,
+            SpeedReduction: 120,
+            RemainingTimeMilliseconds: 15_000);
+
+        var invisibleState = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 75_000);
+
+        var conditions = new List<ICondition>
+        {
+            manaShield,
+            HasteCondition.Restore(hasteState)!,
+            ParalyzeCondition.Restore(paralyzeState)!,
+            ConditionInvisible.Restore(invisibleState)!
+        };
+
+        // Act
+        var json = ConditionListParser.Serialize(conditions);
+        var restored = ConditionListParser.Deserialize(json);
+
+        // Assert — all four conditions survive the round-trip
+        restored.Should().HaveCount(4);
+        restored[0].Type.Should().Be(ConditionType.ManaShield);
+        restored[1].Type.Should().Be(ConditionType.Haste);
+        restored[2].Type.Should().Be(ConditionType.Paralyze);
+        restored[3].Type.Should().Be(ConditionType.Invisible);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
     public void Serialize_Deserialize_handles_empty_list()
     {
         // Arrange


### PR DESCRIPTION
### Description
Players no longer lose invisible condition on logout. Invisible state is now captured on save and restored on login, matching the existing persistence support for haste and paralyze conditions.

### Key Changes
- Added `CaptureState()` and `Restore()` to `ConditionInvisible` following the `ParalyzeCondition`/`HasteCondition` pattern
- Added `ConditionInvisibleParser` for serializing/deserializing invisible state
- Extended `ConditionListParser` with invisible branches in both serialize and deserialize paths

### Types of Changes
- [x] New feature (non-breaking change which adds functionality)

### Test Case
```sh
dotnet test tests/NeoServer.Domain.Tests --filter "FullyQualifiedName~ConditionInvisibleSaveRestore"
dotnet test tests/NeoServer.Server.Tests --filter "FullyQualifiedName~ConditionInvisibleParserTest\|FullyQualifiedName~ConditionListParserTest"
```