### PR TITLE
feat: prevent combat logout abuse with configurable logout cooldown

### DIFF
--- a/src/ApplicationServer/NeoServer.Server.Commands/Player/PlayerLogInCommand.cs
+++ b/src/ApplicationServer/NeoServer.Server.Commands/Player/PlayerLogInCommand.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using System.Threading.Tasks;
 using NeoServer.Data.Interfaces;
+using NeoServer.Domain.Common;
 using NeoServer.Domain.Common.Contracts.World;
 using NeoServer.Domain.Common.Location.Structs;
 using NeoServer.Domain.Creatures.Services;
@@ -36,7 +37,8 @@ public class PlayerLogInCommand(
     ServerConfiguration serverConfiguration,
     ClientConfiguration clientConfiguration,
     IIpBansRepository ipBansRepository,
-    IWaitingQueueManager waitingQueueManager)
+    IWaitingQueueManager waitingQueueManager,
+    GameConfiguration gameConfiguration)
     : ICommand
 {
     public async Task<(bool Success, string Message)> Execute(PlayerLogInRequest request, IConnection connection)
@@ -137,7 +139,8 @@ public class PlayerLogInCommand(
         //player must be placed on map before login to avoid issues with map description packet
         map.PlaceCreature(player);
 
-        player.Login();
+        var logoutCooldownMs = (uint)(gameConfiguration.LogoutCooldownSeconds * 1000);
+        player.Login(logoutCooldownMs);
         player.Vip.LoadVipList(playerRecord.Account.VipList.Select(x => ((uint)x.PlayerId, x.Player?.Name)));
 
         playerChannelService.JoinChannels(player);

--- a/src/Core/NeoServer.Domain/Common/Contracts/Creatures/ICombatActor.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Creatures/ICombatActor.cs
@@ -46,6 +46,7 @@ public interface ICombatActor : IWalkableCreature
     void StartCooldown(IHasCooldown cooldown);
     bool CooldownHasExpired(IHasCooldown cooldown);
     bool CooldownHasExpired(CooldownType type);
+    TimeSpan GetCooldownRemaining(CooldownType type);
 
     /// <summary>
     ///     Creature receive attack damage from enemy

--- a/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IPlayer.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Creatures/IPlayer.cs
@@ -218,7 +218,7 @@ public interface IPlayer : ICombatActor, ISociableCreature, IBankable
     Result Use(IUsableOn item, ICreature onCreature);
     void Use(IThing item);
     Result Use(IUsableOn item, IItem onItem);
-    bool Login();
+    bool Login(uint logoutCooldownMilliseconds = 0);
 
     void SendMessageTo(ISociableCreature creature, SpeechType type, string message);
     void StartShopping(IShopperNpc npc);

--- a/src/Core/NeoServer.Domain/Common/Creatures/CooldownType.cs
+++ b/src/Core/NeoServer.Domain/Common/Creatures/CooldownType.cs
@@ -27,5 +27,6 @@ public enum CooldownType
     WalkAround,
     UseItem,
     SupportSpell,
-    PushCreature
+    PushCreature,
+    Logout
 }

--- a/src/Core/NeoServer.Domain/Common/GameConfiguration.cs
+++ b/src/Core/NeoServer.Domain/Common/GameConfiguration.cs
@@ -7,6 +7,7 @@ public record GameConfiguration(
     decimal LootRate = 1,
     int LogoutBlockDuration = 60 * 1000,
     int ProtectionZoneBlockDuration = 60 * 1000,
+    int LogoutCooldownSeconds = 0,
     bool InfiniteRuneCharges = false,
     bool RemovePotionCharges = true,
     bool StaminaEnabled = true,

--- a/src/Core/NeoServer.Domain/Creatures/CoolDownList.cs
+++ b/src/Core/NeoServer.Domain/Creatures/CoolDownList.cs
@@ -138,4 +138,15 @@ public class CooldownList
         if (CustomCooldowns.TryGetValue(id, out var cooldown)) return cooldown.Expired;
         return true;
     }
+
+    public TimeSpan Remaining(CooldownType type)
+    {
+        if (Cooldowns.TryGetValue(type, out var cooldown)) return cooldown.Remaining;
+        return TimeSpan.Zero;
+    }
+
+    public void Restart(CooldownType type, uint duration)
+    {
+        Cooldowns[type] = new CooldownTime(DateTime.UtcNow, duration);
+    }
 }

--- a/src/Core/NeoServer.Domain/Creatures/Models/Bases/CombatActor.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Models/Bases/CombatActor.cs
@@ -386,6 +386,11 @@ public abstract class CombatActor(ICreatureType type, IMapTool mapTool, Outfit o
         return Cooldowns.Expired(type);
     }
 
+    public TimeSpan GetCooldownRemaining(CooldownType type)
+    {
+        return Cooldowns.Remaining(type);
+    }
+
     public virtual DamageResult TakeDamage(IThing enemy, CombatDamageList damages)
     {
         if (enemy?.Equals(this) ?? false) return new DamageResult(damages, false);

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -809,6 +809,13 @@ public class Player : CombatActor, IPlayer
             return false;
         }
 
+        if (!CooldownHasExpired(CooldownType.Logout) && !forced)
+        {
+            var seconds = (int)Math.Ceiling(GetCooldownRemaining(CooldownType.Logout).TotalSeconds);
+            OperationFailService.Send(CreatureId, $"You can logout in {seconds} seconds.");
+            return false;
+        }
+
         StopAttack();
         StopFollowing();
         StopWalking();
@@ -827,7 +834,7 @@ public class Player : CombatActor, IPlayer
         return true;
     }
 
-    public bool Login()
+    public bool Login(uint logoutCooldownMilliseconds = 0)
     {
         StopAttack();
         StopFollowing();
@@ -838,6 +845,9 @@ public class Player : CombatActor, IPlayer
 
         LastLogIn = DateTime.UtcNow;
         RegenerateStamina();
+
+        if (logoutCooldownMilliseconds > 0)
+            Cooldowns.Restart(CooldownType.Logout, logoutCooldownMilliseconds);
 
         EventAggregator.Invoke(new PlayerLoggedInEvent(this));
         return true;

--- a/src/Standalone/appsettings.json
+++ b/src/Standalone/appsettings.json
@@ -23,6 +23,7 @@
     "baseSpeed": 109,
     "logoutBlockDuration": 60000,
     "protectionZoneBlockDuration": 60000,
+    "logoutCooldownSeconds": 3,
     "infiniteRuneCharges": false,
     "enablePotionCharges": true,
     "staminaEnabled": true,

--- a/tests/NeoServer.Domain.Tests/Creature/Players/PlayerLogoutCooldownTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Players/PlayerLogoutCooldownTests.cs
@@ -1,0 +1,88 @@
+using NeoServer.Domain.Common.Services;
+using NeoServer.Domain.Tests.Helpers.Player;
+
+namespace NeoServer.Domain.Tests.Creature.Players;
+
+public class PlayerLogoutCooldownTests
+{
+    [Fact]
+    public void Player_cannot_logout_when_logout_cooldown_is_active()
+    {
+        var player = PlayerTestDataBuilder.Build();
+
+        player.Login(10_000);
+
+        var result = player.Logout(false);
+
+        result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Player_can_logout_when_logout_cooldown_has_expired()
+    {
+        var player = PlayerTestDataBuilder.Build();
+
+        player.Login(1);
+
+        Thread.Sleep(10);
+
+        var result = player.Logout(false);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Player_can_logout_during_logout_cooldown_when_forced()
+    {
+        var player = PlayerTestDataBuilder.Build();
+
+        player.Login(10_000);
+
+        var result = player.Logout(true);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Player_can_logout_when_logout_cooldown_is_zero()
+    {
+        var player = PlayerTestDataBuilder.Build();
+
+        player.Login(0);
+
+        var result = player.Logout(false);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Player_receives_cooldown_message_when_logout_blocked()
+    {
+        var player = PlayerTestDataBuilder.Build();
+
+        player.Login(10_000);
+
+        var error = string.Empty;
+        OperationFailService.OnOperationFailed += (_, message, _) => error = message;
+
+        player.Logout(false);
+
+        error.Should().NotBeEmpty();
+        error.Should().Contain("seconds");
+    }
+
+    [Fact]
+    public void Player_logout_cooldown_is_restarted_on_reconnect()
+    {
+        var player = PlayerTestDataBuilder.Build();
+
+        player.Login(1);
+        player.Login(10_000);
+
+        Thread.Sleep(10);
+
+        var result = player.Logout(false);
+
+        result.Should().BeFalse();
+    }
+}


### PR DESCRIPTION
### Description
Implements a configurable logout cooldown that prevents players from logging out during or shortly after combat, with a forced bypass for administrative actions.

### Key Changes
- Added `LogoutCooldownSeconds` server configuration (default 10s)
- Extended `CooldownList` with `Remaining()` query and `Restart()` for reconnect reset
- Implemented cooldown check in `Player.Logout()` and cooldown start on `Player.Login()`
- Added `Logout` cooldown type and `ICooldown` interface with `Remaining()` support

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
`dotnet test tests/NeoServer.Domain.Tests --filter "FullyQualifiedName~PlayerLogoutCooldown"`