### PR TITLE
feat: persist outfit conditions between player sessions

### DIFF
--- a/src/Core/NeoServer.Domain/Creatures/Conditions/Implementations/OutfitCondition.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Conditions/Implementations/OutfitCondition.cs
@@ -1,3 +1,5 @@
+#nullable enable
+using System;
 using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Creatures.Conditions.Enums;
 
@@ -5,33 +7,72 @@ namespace NeoServer.Domain.Creatures.Conditions.Implementations;
 
 public class OutfitCondition : BaseCondition
 {
-    private readonly ushort _lookType;
-    private readonly byte _head;
-    private readonly byte _body;
-    private readonly byte _legs;
-    private readonly byte _feet;
-    private readonly byte _addon;
-
     public override ConditionType Type => ConditionType.Outfit;
+    public ushort LookType { get; }
+    public byte Head { get; }
+    public byte Body { get; }
+    public byte Legs { get; }
+    public byte Feet { get; }
+    public byte Addon { get; }
 
     public OutfitCondition(uint duration, ushort lookType, byte head, byte body, byte legs, byte feet, byte addon)
         : base(duration)
     {
-        _lookType = lookType;
-        _head = head;
-        _body = body;
-        _legs = legs;
-        _feet = feet;
-        _addon = addon;
+        LookType = lookType;
+        Head = head;
+        Body = body;
+        Legs = legs;
+        Feet = feet;
+        Addon = addon;
     }
 
     internal override bool Start(ICreature creature)
     {
         if (!base.Start(creature)) return false;
         
-        creature.SetTemporaryOutfit(_lookType, _head, _body, _legs, _feet, _addon);
+        creature.SetTemporaryOutfit(LookType, Head, Body, Legs, Feet, Addon);
         EndAction = creature.BackToOldOutfit;
 
         return true;
     }
+
+    public OutfitConditionState CaptureState()
+    {
+        return new OutfitConditionState(
+            Type,
+            LookType,
+            Head,
+            Body,
+            Legs,
+            Feet,
+            Addon,
+            Math.Max(0, RemainingTime));
+    }
+
+    public static OutfitCondition? Restore(OutfitConditionState state)
+    {
+        var durationMs = Math.Max(0, state.RemainingTimeMilliseconds);
+
+        if (durationMs <= 0)
+            return null;
+
+        return new OutfitCondition(
+            (uint)durationMs,
+            state.LookType,
+            state.Head,
+            state.Body,
+            state.Legs,
+            state.Feet,
+            state.Addon);
+    }
 }
+
+public sealed record OutfitConditionState(
+    ConditionType Type,
+    ushort LookType,
+    byte Head,
+    byte Body,
+    byte Legs,
+    byte Feet,
+    byte Addon,
+    long RemainingTimeMilliseconds);

--- a/src/Database/NeoServer.Data/Helpers/ConditionParsers/ConditionListParser.cs
+++ b/src/Database/NeoServer.Data/Helpers/ConditionParsers/ConditionListParser.cs
@@ -39,6 +39,11 @@ public static class ConditionListParser
             {
                 serializedConditions.Add(ConditionInvisibleParser.Serialize(invisibleCondition));
             }
+
+            if (OutfitConditionParser.CanHandle(condition.Type) && condition is OutfitCondition outfitCondition)
+            {
+                serializedConditions.Add(OutfitConditionParser.Serialize(outfitCondition));
+            }
         }
 
         return $"[{string.Join(",", serializedConditions)}]";
@@ -100,6 +105,15 @@ public static class ConditionListParser
                 // Restore returns null for expired conditions; silently skip those
                 // to avoid persisting a never-expiring invisible.
                 var condition = ConditionInvisibleParser.Deserialize(conditionJson);
+                if (condition is not null)
+                    conditions.Add(condition);
+            }
+
+            if (OutfitConditionParser.CanHandle(conditionType))
+            {
+                // Restore returns null for expired conditions; silently skip those
+                // to avoid persisting a never-expiring outfit.
+                var condition = OutfitConditionParser.Deserialize(conditionJson);
                 if (condition is not null)
                     conditions.Add(condition);
             }

--- a/src/Database/NeoServer.Data/Helpers/ConditionParsers/OutfitConditionParser.cs
+++ b/src/Database/NeoServer.Data/Helpers/ConditionParsers/OutfitConditionParser.cs
@@ -1,0 +1,38 @@
+#nullable enable
+using System;
+using System.Text.Json;
+using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Domain.Creatures.Conditions.Implementations;
+
+namespace NeoServer.Data.Helpers.ConditionParsers;
+
+public static class OutfitConditionParser
+{
+    public static string Serialize(OutfitCondition condition)
+    {
+        ArgumentNullException.ThrowIfNull(condition);
+
+        var state = condition.CaptureState();
+        return JsonSerializer.Serialize(state);
+    }
+
+    public static OutfitCondition? Deserialize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        var state = JsonSerializer.Deserialize<OutfitConditionState>(json);
+
+        if (state is null)
+            throw new InvalidOperationException("Failed to deserialize outfit condition: JSON was null.");
+
+        // Restore returns null when the condition has expired (RemainingTimeMilliseconds <= 0).
+        // The caller (ConditionListParser) skips null entries, so expired outfit records
+        // are silently ignored rather than failing player materialization.
+        return OutfitCondition.Restore(state);
+    }
+
+    public static bool CanHandle(ConditionType type)
+    {
+        return type is ConditionType.Outfit;
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Creature/Conditions/OutfitConditionSaveRestoreTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Conditions/OutfitConditionSaveRestoreTests.cs
@@ -1,0 +1,287 @@
+using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Domain.Creatures.Conditions.Implementations;
+using NeoServer.Domain.Tests.Helpers.Player;
+
+namespace NeoServer.Domain.Tests.Creature.Conditions;
+
+public class OutfitConditionSaveRestoreTests
+{
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CaptureState_returns_correct_state_after_Start()
+    {
+        var creature = PlayerTestDataBuilder.Build();
+        var condition = new OutfitCondition(120_000, 128, 1, 2, 3, 4, 0);
+        condition.Start(creature);
+
+        var state = condition.CaptureState();
+
+        state.Type.Should().Be(ConditionType.Outfit);
+        state.LookType.Should().Be(128);
+        state.Head.Should().Be(1);
+        state.Body.Should().Be(2);
+        state.Legs.Should().Be(3);
+        state.Feet.Should().Be(4);
+        state.Addon.Should().Be(0);
+        state.RemainingTimeMilliseconds.Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void CaptureState_returns_correct_values_when_not_started()
+    {
+        var condition = new OutfitCondition(120_000, 129, 5, 6, 7, 8, 3);
+
+        var state = condition.CaptureState();
+
+        state.LookType.Should().Be(129);
+        state.Head.Should().Be(5);
+        state.Body.Should().Be(6);
+        state.Legs.Should().Be(7);
+        state.Feet.Should().Be(8);
+        state.Addon.Should().Be(3);
+        state.RemainingTimeMilliseconds.Should().Be(120_000);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CaptureState_returns_correct_type()
+    {
+        var condition = new OutfitCondition(10_000, 128, 0, 0, 0, 0, 0);
+
+        var state = condition.CaptureState();
+
+        state.Type.Should().Be(ConditionType.Outfit);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Public_properties_match_constructor_args()
+    {
+        var condition = new OutfitCondition(60_000, 130, 10, 20, 30, 40, 1);
+
+        condition.LookType.Should().Be(130);
+        condition.Head.Should().Be(10);
+        condition.Body.Should().Be(20);
+        condition.Legs.Should().Be(30);
+        condition.Feet.Should().Be(40);
+        condition.Addon.Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Restore_creates_condition_with_preserved_outfit()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = OutfitCondition.Restore(state);
+
+        condition.Should().NotBeNull();
+        condition!.LookType.Should().Be(128);
+        condition.Head.Should().Be(1);
+        condition.Body.Should().Be(2);
+        condition.Legs.Should().Be(3);
+        condition.Feet.Should().Be(4);
+        condition.Addon.Should().Be(0);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Restore_creates_condition_with_preserved_remaining_time()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = OutfitCondition.Restore(state);
+
+        condition.Should().NotBeNull();
+        var recaptured = condition!.CaptureState();
+        recaptured.RemainingTimeMilliseconds.Should().Be(75_000);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Restore_Start_applies_outfit()
+    {
+        var player = PlayerTestDataBuilder.Build();
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = OutfitCondition.Restore(state);
+        player.AddCondition(condition!);
+
+        player.Outfit.LookType.Should().Be(128);
+        player.Outfit.Head.Should().Be(1);
+        player.Outfit.Body.Should().Be(2);
+        player.Outfit.Legs.Should().Be(3);
+        player.Outfit.Feet.Should().Be(4);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void HasExpired_is_false_after_Restore()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = OutfitCondition.Restore(state);
+
+        condition!.HasExpired.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CaptureState_after_Restore_and_Start_returns_saved_values()
+    {
+        var player = PlayerTestDataBuilder.Build();
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = OutfitCondition.Restore(state);
+        player.AddCondition(condition!);
+
+        var recaptured = condition!.CaptureState();
+
+        recaptured.LookType.Should().Be(128);
+        recaptured.Head.Should().Be(1);
+        recaptured.Body.Should().Be(2);
+        recaptured.Legs.Should().Be(3);
+        recaptured.Feet.Should().Be(4);
+        recaptured.Addon.Should().Be(0);
+        recaptured.Type.Should().Be(ConditionType.Outfit);
+        recaptured.RemainingTimeMilliseconds.Should().BeInRange(74_000, 75_001);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Restore_does_not_throw_when_state_has_zero_addon()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 0,
+            Body: 0,
+            Legs: 0,
+            Feet: 0,
+            Addon: 0,
+            RemainingTimeMilliseconds: 5_000);
+
+        var action = () => OutfitCondition.Restore(state);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Restore_does_not_throw_when_state_has_max_addon()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 0,
+            Body: 0,
+            Legs: 0,
+            Feet: 0,
+            Addon: 7,
+            RemainingTimeMilliseconds: 5_000);
+
+        var action = () => OutfitCondition.Restore(state);
+
+        action.Should().NotThrow();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CaptureState_restore_Start_CaptureState_round_trip_preserves_remaining_time()
+    {
+        var player = PlayerTestDataBuilder.Build();
+        var condition = new OutfitCondition(60_000, 128, 1, 2, 3, 4, 0);
+        condition.Start(player);
+
+        var firstState = condition.CaptureState();
+        var savedRemaining = firstState.RemainingTimeMilliseconds;
+
+        var restored = OutfitCondition.Restore(firstState);
+        player.AddCondition(restored!);
+
+        var secondState = restored!.CaptureState();
+
+        secondState.RemainingTimeMilliseconds.Should().BeInRange(
+            (long)(savedRemaining * 0.95),
+            savedRemaining + 1);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Restore_returns_null_when_remaining_time_is_zero()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 0);
+
+        var condition = OutfitCondition.Restore(state);
+
+        condition.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Restore_returns_null_when_remaining_time_is_negative()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: -1);
+
+        var condition = OutfitCondition.Restore(state);
+
+        condition.Should().BeNull();
+    }
+}

--- a/tests/NeoServer.Server.Tests/Data/ConditionListParserTest.cs
+++ b/tests/NeoServer.Server.Tests/Data/ConditionListParserTest.cs
@@ -240,6 +240,110 @@ public class ConditionListParserTest
 
     [Fact]
     [Trait("Category", "HappyPath")]
+    public void Serialize_Deserialize_round_trips_outfit_condition()
+    {
+        var outfitState = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 75_000);
+
+        var conditions = new List<ICondition>
+        {
+            OutfitCondition.Restore(outfitState)!
+        };
+
+        var json = ConditionListParser.Serialize(conditions);
+        var restored = ConditionListParser.Deserialize(json);
+
+        restored.Should().HaveCount(1);
+        restored[0].Type.Should().Be(ConditionType.Outfit);
+        restored[0].Should().BeOfType<OutfitCondition>();
+        ((OutfitCondition)restored[0]).LookType.Should().Be(128);
+        ((OutfitCondition)restored[0]).Head.Should().Be(1);
+        ((OutfitCondition)restored[0]).Body.Should().Be(2);
+        ((OutfitCondition)restored[0]).Legs.Should().Be(3);
+        ((OutfitCondition)restored[0]).Feet.Should().Be(4);
+        ((OutfitCondition)restored[0]).Addon.Should().Be(0);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Serialize_Deserialize_skips_expired_outfit()
+    {
+        var expiredOutfit = new OutfitCondition(0, 128, 1, 2, 3, 4, 0);
+
+        var conditions = new List<ICondition>
+        {
+            expiredOutfit
+        };
+
+        var json = ConditionListParser.Serialize(conditions);
+        var restored = ConditionListParser.Deserialize(json);
+
+        restored.Should().BeEmpty();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Serialize_Deserialize_round_trips_mixed_with_outfit()
+    {
+        var manaShield = new Condition(ConditionType.ManaShield, 30_000);
+
+        var hasteState = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.GlitterBlue,
+            SpeedBoost: 180,
+            RemainingTimeMilliseconds: 25_000,
+            Duration: 60_000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues());
+
+        var paralyzeState = new ParalyzeConditionState(
+            ConditionType.Paralyze,
+            SpeedReduction: 120,
+            RemainingTimeMilliseconds: 15_000);
+
+        var invisibleState = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 75_000);
+
+        var outfitState = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 60_000);
+
+        var conditions = new List<ICondition>
+        {
+            manaShield,
+            HasteCondition.Restore(hasteState)!,
+            ParalyzeCondition.Restore(paralyzeState)!,
+            ConditionInvisible.Restore(invisibleState)!,
+            OutfitCondition.Restore(outfitState)!
+        };
+
+        var json = ConditionListParser.Serialize(conditions);
+        var restored = ConditionListParser.Deserialize(json);
+
+        restored.Should().HaveCount(5);
+        restored[0].Type.Should().Be(ConditionType.ManaShield);
+        restored[1].Type.Should().Be(ConditionType.Haste);
+        restored[2].Type.Should().Be(ConditionType.Paralyze);
+        restored[3].Type.Should().Be(ConditionType.Invisible);
+        restored[4].Type.Should().Be(ConditionType.Outfit);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
     public void Serialize_Deserialize_handles_empty_list()
     {
         // Arrange

--- a/tests/NeoServer.Server.Tests/Data/OutfitConditionParserTest.cs
+++ b/tests/NeoServer.Server.Tests/Data/OutfitConditionParserTest.cs
@@ -1,0 +1,467 @@
+using System;
+using System.Text.Json;
+using FluentAssertions;
+using NeoServer.Data.Helpers.ConditionParsers;
+using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Domain.Creatures.Conditions.Implementations;
+using Xunit;
+
+namespace NeoServer.Server.Tests.Data;
+
+public class OutfitConditionParserTest
+{
+    #region CanHandle
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CanHandle_returns_true_for_outfit()
+    {
+        OutfitConditionParser.CanHandle(ConditionType.Outfit).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void CanHandle_returns_false_for_non_outfit_condition_types()
+    {
+        var nonOutfitTypes = new[]
+        {
+            ConditionType.None,
+            ConditionType.Poisoned,
+            ConditionType.Burning,
+            ConditionType.Haste,
+            ConditionType.Paralyze,
+            ConditionType.Invisible,
+            ConditionType.Light,
+            ConditionType.ManaShield,
+            ConditionType.LogoutBlock,
+            ConditionType.Drunk,
+            ConditionType.Regeneration,
+            ConditionType.Pacified,
+            ConditionType.Hungry
+        };
+
+        foreach (var type in nonOutfitTypes)
+            OutfitConditionParser.CanHandle(type).Should().BeFalse($"because {type} is not Outfit");
+    }
+
+    #endregion
+
+    #region Serialization
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Serialize_creates_valid_json_with_all_state_fields()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 75_000);
+
+        var condition = OutfitCondition.Restore(state);
+
+        var json = OutfitConditionParser.Serialize(condition!);
+
+        json.Should().NotBeNullOrWhiteSpace();
+
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("Type").GetUInt32().Should().Be((uint)ConditionType.Outfit);
+        doc.RootElement.GetProperty("LookType").GetUInt32().Should().Be(128);
+        doc.RootElement.GetProperty("Head").GetUInt32().Should().Be(1);
+        doc.RootElement.GetProperty("Body").GetUInt32().Should().Be(2);
+        doc.RootElement.GetProperty("Legs").GetUInt32().Should().Be(3);
+        doc.RootElement.GetProperty("Feet").GetUInt32().Should().Be(4);
+        doc.RootElement.GetProperty("Addon").GetUInt32().Should().Be(0);
+        doc.RootElement.GetProperty("RemainingTimeMilliseconds").GetInt64().Should().BeGreaterThan(0);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Serialize_uses_remaining_time_not_full_duration()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 45_000);
+
+        var condition = OutfitCondition.Restore(state);
+
+        var json = OutfitConditionParser.Serialize(condition!);
+
+        using var doc = JsonDocument.Parse(json);
+        var remaining = doc.RootElement.GetProperty("RemainingTimeMilliseconds").GetInt64();
+        remaining.Should().BeInRange(44_000, 45_001);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Serialize_handles_addon_none()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 0,
+            Body: 0,
+            Legs: 0,
+            Feet: 0,
+            Addon: 0,
+            RemainingTimeMilliseconds: 30_000);
+
+        var condition = OutfitCondition.Restore(state);
+
+        var json = OutfitConditionParser.Serialize(condition!);
+
+        json.Should().NotBeNullOrWhiteSpace();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("Addon").GetUInt32().Should().Be(0);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Serialize_handles_max_addon()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 0,
+            Body: 0,
+            Legs: 0,
+            Feet: 0,
+            Addon: 7,
+            RemainingTimeMilliseconds: 30_000);
+
+        var condition = OutfitCondition.Restore(state);
+
+        var json = OutfitConditionParser.Serialize(condition!);
+
+        json.Should().NotBeNullOrWhiteSpace();
+        using var doc = JsonDocument.Parse(json);
+        doc.RootElement.GetProperty("Addon").GetUInt32().Should().Be(7);
+    }
+
+    #endregion
+
+    #region Deserialization
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Deserialize_reconstructs_outfit_condition()
+    {
+        var json = $$"""
+            {
+                "Type": {{(uint)ConditionType.Outfit}},
+                "LookType": 128,
+                "Head": 1,
+                "Body": 2,
+                "Legs": 3,
+                "Feet": 4,
+                "Addon": 0,
+                "RemainingTimeMilliseconds": 75000
+            }
+            """;
+
+        var condition = OutfitConditionParser.Deserialize(json);
+
+        condition!.Type.Should().Be(ConditionType.Outfit);
+
+        var captured = condition!.CaptureState();
+        captured.LookType.Should().Be(128);
+        captured.Head.Should().Be(1);
+        captured.Body.Should().Be(2);
+        captured.Legs.Should().Be(3);
+        captured.Feet.Should().Be(4);
+        captured.Addon.Should().Be(0);
+        captured.RemainingTimeMilliseconds.Should().Be(75000);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Deserialize_reconstructs_outfit_condition_with_different_values()
+    {
+        var json = $$"""
+            {
+                "Type": {{(uint)ConditionType.Outfit}},
+                "LookType": 130,
+                "Head": 10,
+                "Body": 20,
+                "Legs": 30,
+                "Feet": 40,
+                "Addon": 3,
+                "RemainingTimeMilliseconds": 15000
+            }
+            """;
+
+        var condition = OutfitConditionParser.Deserialize(json);
+
+        condition!.Type.Should().Be(ConditionType.Outfit);
+        var captured = condition!.CaptureState();
+        captured.LookType.Should().Be(130);
+        captured.Head.Should().Be(10);
+        captured.Body.Should().Be(20);
+        captured.Legs.Should().Be(30);
+        captured.Feet.Should().Be(40);
+        captured.Addon.Should().Be(3);
+        captured.RemainingTimeMilliseconds.Should().Be(15000);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Deserialize_returns_null_for_expired_outfit()
+    {
+        var json = $$"""
+            {
+                "Type": {{(uint)ConditionType.Outfit}},
+                "LookType": 128,
+                "Head": 1,
+                "Body": 2,
+                "Legs": 3,
+                "Feet": 4,
+                "Addon": 0,
+                "RemainingTimeMilliseconds": 0
+            }
+            """;
+
+        var condition = OutfitConditionParser.Deserialize(json);
+
+        condition.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Deserialize_returns_null_for_negative_remaining_time()
+    {
+        var json = $$"""
+            {
+                "Type": {{(uint)ConditionType.Outfit}},
+                "LookType": 128,
+                "Head": 1,
+                "Body": 2,
+                "Legs": 3,
+                "Feet": 4,
+                "Addon": 0,
+                "RemainingTimeMilliseconds": -1
+            }
+            """;
+
+        var condition = OutfitConditionParser.Deserialize(json);
+
+        condition.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_throws_on_null_json()
+    {
+        Action act = () => OutfitConditionParser.Deserialize(null);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_throws_on_empty_json()
+    {
+        Action act = () => OutfitConditionParser.Deserialize(string.Empty);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_throws_on_whitespace_json()
+    {
+        Action act = () => OutfitConditionParser.Deserialize("   ");
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Deserialize_throws_on_malformed_json()
+    {
+        Action act = () => OutfitConditionParser.Deserialize("{{{{{invalid}}}}");
+
+        act.Should().Throw<JsonException>();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Deserialize_does_not_throw_when_type_field_is_missing()
+    {
+        var json = $$"""
+            {
+                "LookType": 128,
+                "Head": 1,
+                "Body": 2,
+                "Legs": 3,
+                "Feet": 4,
+                "Addon": 0,
+                "RemainingTimeMilliseconds": 10000
+            }
+            """;
+
+        var condition = OutfitConditionParser.Deserialize(json);
+
+        condition!.Type.Should().Be(ConditionType.Outfit);
+    }
+
+    #endregion
+
+    #region Round-Trip
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Round_trip_preserves_all_state_for_outfit_condition()
+    {
+        var originalState = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 45_000);
+
+        var condition = OutfitCondition.Restore(originalState);
+
+        var json = OutfitConditionParser.Serialize(condition!);
+        var restored = OutfitConditionParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        restoredState.Type.Should().Be(originalState.Type);
+        restoredState.LookType.Should().Be(originalState.LookType);
+        restoredState.Head.Should().Be(originalState.Head);
+        restoredState.Body.Should().Be(originalState.Body);
+        restoredState.Legs.Should().Be(originalState.Legs);
+        restoredState.Feet.Should().Be(originalState.Feet);
+        restoredState.Addon.Should().Be(originalState.Addon);
+        restoredState.RemainingTimeMilliseconds.Should().Be(originalState.RemainingTimeMilliseconds);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Round_trip_preserves_look_type_and_colors()
+    {
+        var originalState = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 130,
+            Head: 10,
+            Body: 20,
+            Legs: 30,
+            Feet: 40,
+            Addon: 3,
+            RemainingTimeMilliseconds: 30_000);
+
+        var condition = OutfitCondition.Restore(originalState);
+
+        var json = OutfitConditionParser.Serialize(condition!);
+        var restored = OutfitConditionParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        restoredState.LookType.Should().Be(130);
+        restoredState.Head.Should().Be(10);
+        restoredState.Body.Should().Be(20);
+        restoredState.Legs.Should().Be(30);
+        restoredState.Feet.Should().Be(40);
+        restoredState.Addon.Should().Be(3);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Round_trip_preserves_remaining_time_with_small_tolerance()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 4950);
+
+        var condition = OutfitCondition.Restore(state);
+
+        var expectedRemaining = condition!.CaptureState().RemainingTimeMilliseconds;
+
+        var json = OutfitConditionParser.Serialize(condition);
+        using var doc = JsonDocument.Parse(json);
+        var serializedRemaining = doc.RootElement.GetProperty("RemainingTimeMilliseconds").GetInt64();
+
+        serializedRemaining.Should().BeCloseTo(expectedRemaining, 50);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Round_trip_preserves_minimal_remaining_time()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 1);
+
+        var condition = OutfitCondition.Restore(state);
+
+        var json = OutfitConditionParser.Serialize(condition!);
+        var restored = OutfitConditionParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        restoredState.RemainingTimeMilliseconds.Should().Be(1);
+        restoredState.LookType.Should().Be(128);
+        restoredState.Head.Should().Be(1);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Round_trip_preserves_max_remaining_time()
+    {
+        var state = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: int.MaxValue);
+
+        var condition = OutfitCondition.Restore(state);
+
+        var json = OutfitConditionParser.Serialize(condition!);
+        var restored = OutfitConditionParser.Deserialize(json);
+        var restoredState = restored.CaptureState();
+
+        restoredState.RemainingTimeMilliseconds.Should().Be(int.MaxValue);
+        restoredState.LookType.Should().Be(128);
+    }
+
+    #endregion
+
+    #region Validation
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Serialize_throws_on_null_condition()
+    {
+        Action act = () => OutfitConditionParser.Serialize(null);
+
+        act.Should().Throw<ArgumentNullException>();
+    }
+
+    #endregion
+}


### PR DESCRIPTION
### Description
Adds CaptureState/Restore and a JSON parser for OutfitCondition so outfit transformations (e.g., from creature illusion, quest rewards) survive player logout and server restart.

### Key Changes
- Implement `CaptureState()` / `Restore(OutfitConditionState)` on `OutfitCondition` with an `OutfitConditionState` record for look type, colors, addon, and remaining time
- Add `OutfitConditionParser` (serialize/deserialize/CanHandle) and register it in `ConditionListParser`
- Cover `OutfitCondition` save/restore and parser with 35 unit tests across domain and server test projects

### Types of Changes
- [x] New feature (non-breaking change which adds functionality)

### Test Case
`dotnet test tests/NeoServer.Domain.Tests` and `dotnet test tests/NeoServer.Server.Tests`