### PR TITLE
feat: persist regeneration conditions between player sessions

### DIFF
--- a/src/Core/NeoServer.Domain/Creatures/Conditions/Implementations/ConditionRegeneration.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Conditions/Implementations/ConditionRegeneration.cs
@@ -1,3 +1,5 @@
+#nullable enable
+using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Creatures.Conditions.Enums;
 
 namespace NeoServer.Domain.Creatures.Conditions.Implementations;
@@ -6,22 +8,50 @@ public class ConditionRegeneration : BaseCondition
 {
     private const uint MAX_DURATION_MS = 1200 * 1000; // 20 minutes
 
-    public ConditionRegeneration(uint duration, Action onExpired) : base(duration)
+    public ConditionRegeneration(uint duration) : base(duration)
     {
         Type = ConditionType.Regeneration;
-        EndAction = onExpired;
     }
 
     public override ConditionType Type { get; }
+
+    internal override bool Start(ICreature creature)
+    {
+        if (!base.Start(creature)) return false;
+        if (creature is IPlayer player)
+            EndAction = player.SetAsHungry;
+        return true;
+    }
+
+    public ConditionRegenerationState CaptureState()
+    {
+        return new ConditionRegenerationState(
+            Type,
+            Math.Max(0, RemainingTime));
+    }
+
+    public static ConditionRegeneration? Restore(ConditionRegenerationState state)
+    {
+        var durationMs = Math.Max(0, state.RemainingTimeMilliseconds);
+
+        if (durationMs <= 0)
+            return null;
+
+        return new ConditionRegeneration((uint)durationMs);
+    }
 
     public bool TryExtend(uint additionalMs)
     {
         var effectiveRemainingMs = Math.Max(0, RemainingTime);
         if (effectiveRemainingMs + additionalMs >= MAX_DURATION_MS) return false;
 
-        if (EndTime == 0 && Duration > 0) Start(null);
+        if (EndTime == 0 && Duration > 0) Start(default!);
 
         Extend(additionalMs, MAX_DURATION_MS);
         return true;
     }
 }
+
+public sealed record ConditionRegenerationState(
+    ConditionType Type,
+    long RemainingTimeMilliseconds);

--- a/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
+++ b/src/Core/NeoServer.Domain/Creatures/Player/Player.cs
@@ -1025,7 +1025,7 @@ public class Player : CombatActor, IPlayer
         else
         {
             RemoveHungry();
-            AddCondition(new ConditionRegeneration(regenerationMs, SetAsHungry));
+            AddCondition(new ConditionRegeneration(regenerationMs));
         }
 
         return true;

--- a/src/Database/NeoServer.Data/Configurations/ForSqLite/ForSqLitePlayerEntityConfiguration.cs
+++ b/src/Database/NeoServer.Data/Configurations/ForSqLite/ForSqLitePlayerEntityConfiguration.cs
@@ -68,7 +68,6 @@ public class ForSqLitePlayerEntityConfiguration : IEntityTypeConfiguration<Playe
         ConfigureProperty(entity, e => e.SkillSword, null, "10");
         ConfigureProperty(entity, e => e.SkillSwordTries, null, "0");
         ConfigureProperty(entity, e => e.Vocation, "int(11)", "0");
-        ConfigureProperty(entity, e => e.RemainingRecoverySeconds, "int(11)", "0");
         ConfigureProperty(entity, e => e.BankAmount, "int(11)", "0");
         ConfigureProperty(entity, e => e.Skull, "int(11)", "0");
         entity.Property(e => e.SkullEndsAt);

--- a/src/Database/NeoServer.Data/Configurations/PlayerEntityConfiguration.cs
+++ b/src/Database/NeoServer.Data/Configurations/PlayerEntityConfiguration.cs
@@ -66,7 +66,6 @@ public class PlayerEntityConfiguration : IEntityTypeConfiguration<PlayerEntity>
         ConfigureProperty(entity, e => e.SkillSword, null, "10");
         ConfigureProperty(entity, e => e.SkillSwordTries, null, "0");
         ConfigureProperty(entity, e => e.Vocation, "int", "0");
-        ConfigureProperty(entity, e => e.RemainingRecoverySeconds, "int", "0");
         ConfigureProperty(entity, e => e.BankAmount, "numeric(20, 0)", "0");
         ConfigureProperty(entity, e => e.Skull, "int", "0");
         entity.Property(e => e.SkullEndsAt);

--- a/src/Database/NeoServer.Data/Entities/PlayerEntity.cs
+++ b/src/Database/NeoServer.Data/Entities/PlayerEntity.cs
@@ -77,8 +77,6 @@ public sealed class PlayerEntity
     public FightMode FightMode { get; set; }
     public Gender Gender { get; set; }
     public byte Vocation { get; set; }
-    public int RemainingRecoverySeconds { get; set; }
-
     public Skull Skull { get; set; }
     public DateTime? SkullEndsAt { get; set; }
     public DateTime? LastLogOut { get; set; }

--- a/src/Database/NeoServer.Data/Helpers/ConditionParsers/ConditionListParser.cs
+++ b/src/Database/NeoServer.Data/Helpers/ConditionParsers/ConditionListParser.cs
@@ -44,6 +44,11 @@ public static class ConditionListParser
             {
                 serializedConditions.Add(OutfitConditionParser.Serialize(outfitCondition));
             }
+
+            if (ConditionRegenerationParser.CanHandle(condition.Type) && condition is ConditionRegeneration regenCondition)
+            {
+                serializedConditions.Add(ConditionRegenerationParser.Serialize(regenCondition));
+            }
         }
 
         return $"[{string.Join(",", serializedConditions)}]";
@@ -114,6 +119,15 @@ public static class ConditionListParser
                 // Restore returns null for expired conditions; silently skip those
                 // to avoid persisting a never-expiring outfit.
                 var condition = OutfitConditionParser.Deserialize(conditionJson);
+                if (condition is not null)
+                    conditions.Add(condition);
+            }
+
+            if (ConditionRegenerationParser.CanHandle(conditionType))
+            {
+                // Restore returns null for expired conditions; silently skip those
+                // to avoid persisting a never-expiring regeneration.
+                var condition = ConditionRegenerationParser.Deserialize(conditionJson);
                 if (condition is not null)
                     conditions.Add(condition);
             }

--- a/src/Database/NeoServer.Data/Helpers/ConditionParsers/ConditionRegenerationParser.cs
+++ b/src/Database/NeoServer.Data/Helpers/ConditionParsers/ConditionRegenerationParser.cs
@@ -1,0 +1,35 @@
+#nullable enable
+using System;
+using System.Text.Json;
+using NeoServer.Domain.Creatures.Conditions.Enums;
+using NeoServer.Domain.Creatures.Conditions.Implementations;
+
+namespace NeoServer.Data.Helpers.ConditionParsers;
+
+public static class ConditionRegenerationParser
+{
+    public static string Serialize(ConditionRegeneration condition)
+    {
+        ArgumentNullException.ThrowIfNull(condition);
+
+        var state = condition.CaptureState();
+        return JsonSerializer.Serialize(state);
+    }
+
+    public static ConditionRegeneration? Deserialize(string json)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(json);
+
+        var state = JsonSerializer.Deserialize<ConditionRegenerationState>(json);
+
+        if (state is null)
+            throw new InvalidOperationException("Failed to deserialize regeneration condition: JSON was null.");
+
+        return ConditionRegeneration.Restore(state);
+    }
+
+    public static bool CanHandle(ConditionType type)
+    {
+        return type is ConditionType.Regeneration;
+    }
+}

--- a/src/Database/NeoServer.Data/Repositories/Player/PlayerRepository.cs
+++ b/src/Database/NeoServer.Data/Repositories/Player/PlayerRepository.cs
@@ -154,10 +154,6 @@ public class PlayerRepository(DbContextOptions<NeoContext> contextOptions, ILogg
         playerEntity.Experience = player.Experience;
         playerEntity.ChaseMode = player.ChaseMode;
         playerEntity.FightMode = player.FightMode;
-        playerEntity.RemainingRecoverySeconds =
-            (int)(player.GetCondition(ConditionType.Regeneration) is { } condition
-                ? Math.Max(0, condition.RemainingTime / 1000)
-                : 0);
         playerEntity.Vocation = player.VocationType;
         playerEntity.Skull = player.Skull;
         playerEntity.SkullEndsAt = player.SkullEndsAt;

--- a/src/Loaders/NeoServer.Loaders/Players/PlayerLoader.cs
+++ b/src/Loaders/NeoServer.Loaders/Players/PlayerLoader.cs
@@ -132,7 +132,6 @@ public class PlayerLoader(
             player.GuildRank = new GuildRankInfo((ushort)guildRank.Id, guildRank.Name, (byte)guildRank.Level);
         }
 
-        AddRegenerationCondition(playerEntity, player);
         LoadConditions(playerEntity, player);
 
         player.AddInventory(ConvertToInventory(player, playerEntity));
@@ -188,36 +187,25 @@ public class PlayerLoader(
         return dynamicTile as IDynamicTile;
     }
 
-    private static void AddRegenerationCondition(PlayerEntity playerEntity, IPlayer player)
-    {
-        if (playerEntity.RemainingRecoverySeconds != 0)
-        {
-            player.AddCondition(
-                new ConditionRegeneration((uint)(playerEntity.RemainingRecoverySeconds * 1000),
-                    player.SetAsHungry));
-            return;
-        }
-
-        player.SetAsHungry();
-    }
-
-    /// <summary>
-    ///     Loads all persisted conditions from the player entity into the player instance.
-    ///     Conditions that have already expired are skipped.
-    /// </summary>
-    /// <param name="playerEntity">The entity containing the persisted conditions.</param>
-    /// <param name="player">The player instance to load conditions into.</param>
     private static void LoadConditions(PlayerEntity playerEntity, IPlayer player)
     {
         if (playerEntity.Conditions is null || playerEntity.Conditions.Count == 0)
+        {
+            player.SetAsHungry();
             return;
+        }
+
+        var hadRegeneration = false;
 
         foreach (var condition in playerEntity.Conditions)
         {
             if (condition.HasExpired) continue;
-
+            if (condition is ConditionRegeneration) hadRegeneration = true;
             player.AddCondition(condition);
         }
+
+        if (!hadRegeneration)
+            player.SetAsHungry();
     }
 
     /// <summary>

--- a/tests/NeoServer.Domain.Tests/Creature/Conditions/ConditionRegenerationTests.cs
+++ b/tests/NeoServer.Domain.Tests/Creature/Conditions/ConditionRegenerationTests.cs
@@ -1,3 +1,5 @@
+using Moq;
+using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Creatures.Conditions.Enums;
 using NeoServer.Domain.Creatures.Conditions.Implementations;
 
@@ -8,7 +10,7 @@ public class ConditionRegenerationTests
     [Fact]
     public void Constructor_sets_type_to_regeneration()
     {
-        var sut = new ConditionRegeneration(10000, () => { });
+        var sut = new ConditionRegeneration(10000);
 
         sut.Type.Should().Be(ConditionType.Regeneration);
     }
@@ -17,7 +19,10 @@ public class ConditionRegenerationTests
     public void End_invokes_onExpired_callback()
     {
         var expired = false;
-        var sut = new ConditionRegeneration(10000, () => expired = true);
+        var sut = new ConditionRegeneration(10000);
+        var mockPlayer = new Mock<IPlayer>();
+        mockPlayer.Setup(p => p.SetAsHungry()).Callback(() => expired = true);
+        sut.Start(mockPlayer.Object);
 
         sut.End();
 
@@ -28,7 +33,10 @@ public class ConditionRegenerationTests
     public void End_guards_against_double_invocation()
     {
         var callCount = 0;
-        var sut = new ConditionRegeneration(10000, () => callCount++);
+        var sut = new ConditionRegeneration(10000);
+        var mockPlayer = new Mock<IPlayer>();
+        mockPlayer.Setup(p => p.SetAsHungry()).Callback(() => callCount++);
+        sut.Start(mockPlayer.Object);
 
         sut.End();
         sut.End();
@@ -40,7 +48,10 @@ public class ConditionRegenerationTests
     public void End_does_not_invoke_onExpired_when_condition_is_persistent()
     {
         var expired = false;
-        var sut = new ConditionRegeneration(0, () => expired = true);
+        var sut = new ConditionRegeneration(0);
+        var mockPlayer = new Mock<IPlayer>();
+        mockPlayer.Setup(p => p.SetAsHungry()).Callback(() => expired = true);
+        sut.Start(mockPlayer.Object);
 
         sut.End();
 
@@ -50,7 +61,7 @@ public class ConditionRegenerationTests
     [Fact]
     public void TryExtend_extends_duration_when_under_max()
     {
-        var sut = new ConditionRegeneration(10000, () => { });
+        var sut = new ConditionRegeneration(10000);
         sut.Start(null);
 
         var result = sut.TryExtend(5000);
@@ -62,7 +73,7 @@ public class ConditionRegenerationTests
     [Fact]
     public void TryExtend_returns_false_when_exceeding_max()
     {
-        var sut = new ConditionRegeneration(10000, () => { });
+        var sut = new ConditionRegeneration(10000);
         sut.Start(null);
 
         var result = sut.TryExtend(1_200_000);
@@ -73,7 +84,7 @@ public class ConditionRegenerationTests
     [Fact]
     public void TryExtend_extends_up_to_but_not_over_max_duration()
     {
-        var sut = new ConditionRegeneration(10000, () => { });
+        var sut = new ConditionRegeneration(10000);
         sut.Start(null);
 
         var result = sut.TryExtend(1_189_000);
@@ -86,7 +97,7 @@ public class ConditionRegenerationTests
     [Fact]
     public void TryExtend_treats_negative_remaining_time_as_zero()
     {
-        var sut = new ConditionRegeneration(10000, () => { });
+        var sut = new ConditionRegeneration(10000);
 
         var result = sut.TryExtend(1_189_000);
 
@@ -97,10 +108,53 @@ public class ConditionRegenerationTests
     [Fact]
     public void TryExtend_returns_false_when_clamped_remaining_plus_additional_exceeds_max()
     {
-        var sut = new ConditionRegeneration(10000, () => { });
+        var sut = new ConditionRegeneration(10000);
 
         var result = sut.TryExtend(1_200_001);
 
         result.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CaptureState_returns_remaining_time()
+    {
+        var sut = new ConditionRegeneration(90000);
+
+        var state = sut.CaptureState();
+
+        state.Type.Should().Be(ConditionType.Regeneration);
+        state.RemainingTimeMilliseconds.Should().Be(90000);
+    }
+
+    [Fact]
+    public void Restore_creates_condition_from_state()
+    {
+        var state = new ConditionRegenerationState(ConditionType.Regeneration, 45000);
+
+        var result = ConditionRegeneration.Restore(state);
+
+        result.Should().NotBeNull();
+        result.Type.Should().Be(ConditionType.Regeneration);
+        result.RemainingTime.Should().Be(45000);
+    }
+
+    [Fact]
+    public void Restore_returns_null_when_remaining_time_is_zero()
+    {
+        var state = new ConditionRegenerationState(ConditionType.Regeneration, 0);
+
+        var result = ConditionRegeneration.Restore(state);
+
+        result.Should().BeNull();
+    }
+
+    [Fact]
+    public void Restore_returns_null_when_remaining_time_is_negative()
+    {
+        var state = new ConditionRegenerationState(ConditionType.Regeneration, -1000);
+
+        var result = ConditionRegeneration.Restore(state);
+
+        result.Should().BeNull();
     }
 }

--- a/tests/NeoServer.Server.Tests/Data/ConditionListParserTest.cs
+++ b/tests/NeoServer.Server.Tests/Data/ConditionListParserTest.cs
@@ -357,5 +357,113 @@ public class ConditionListParserTest
         restored.Should().BeEmpty();
     }
 
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Serialize_Deserialize_round_trips_regeneration_condition()
+    {
+        // Arrange
+        var regenState = new ConditionRegenerationState(
+            ConditionType.Regeneration,
+            RemainingTimeMilliseconds: 90_000);
+
+        var conditions = new List<ICondition>
+        {
+            ConditionRegeneration.Restore(regenState)!
+        };
+
+        // Act
+        var json = ConditionListParser.Serialize(conditions);
+        var restored = ConditionListParser.Deserialize(json);
+
+        // Assert
+        restored.Should().HaveCount(1);
+        restored[0].Type.Should().Be(ConditionType.Regeneration);
+        restored[0].Should().BeOfType<ConditionRegeneration>();
+        restored[0].RemainingTime.Should().Be(90_000);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Serialize_Deserialize_skips_expired_regeneration()
+    {
+        // Arrange — expired regeneration (zero remaining time)
+        var expiredRegen = new ConditionRegeneration(0);
+
+        var conditions = new List<ICondition>
+        {
+            expiredRegen
+        };
+
+        // Act
+        var json = ConditionListParser.Serialize(conditions);
+        var restored = ConditionListParser.Deserialize(json);
+
+        // Assert — expired regeneration is filtered out
+        restored.Should().BeEmpty();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Serialize_Deserialize_round_trips_mixed_with_regeneration()
+    {
+        // Arrange — one condition of each parser path including Regeneration
+        var manaShield = new Condition(ConditionType.ManaShield, 30_000);
+
+        var hasteState = new HasteConditionState(
+            ConditionType.Haste,
+            EffectT.GlitterBlue,
+            SpeedBoost: 180,
+            RemainingTimeMilliseconds: 25_000,
+            Duration: 60_000 * TimeSpan.TicksPerMillisecond,
+            new FormulaValues());
+
+        var paralyzeState = new ParalyzeConditionState(
+            ConditionType.Paralyze,
+            SpeedReduction: 120,
+            RemainingTimeMilliseconds: 15_000);
+
+        var invisibleState = new ConditionInvisibleState(
+            ConditionType.Invisible,
+            EffectT.GlitterBlue,
+            RemainingTimeMilliseconds: 75_000);
+
+        var outfitState = new OutfitConditionState(
+            ConditionType.Outfit,
+            LookType: 128,
+            Head: 1,
+            Body: 2,
+            Legs: 3,
+            Feet: 4,
+            Addon: 0,
+            RemainingTimeMilliseconds: 60_000);
+
+        var regenState = new ConditionRegenerationState(
+            ConditionType.Regeneration,
+            RemainingTimeMilliseconds: 45_000);
+
+        var conditions = new List<ICondition>
+        {
+            manaShield,
+            HasteCondition.Restore(hasteState)!,
+            ParalyzeCondition.Restore(paralyzeState)!,
+            ConditionInvisible.Restore(invisibleState)!,
+            OutfitCondition.Restore(outfitState)!,
+            ConditionRegeneration.Restore(regenState)!
+        };
+
+        // Act
+        var json = ConditionListParser.Serialize(conditions);
+        var restored = ConditionListParser.Deserialize(json);
+
+        // Assert — all six conditions survive the round-trip
+        restored.Should().HaveCount(6);
+        restored[0].Type.Should().Be(ConditionType.ManaShield);
+        restored[1].Type.Should().Be(ConditionType.Haste);
+        restored[2].Type.Should().Be(ConditionType.Paralyze);
+        restored[3].Type.Should().Be(ConditionType.Invisible);
+        restored[4].Type.Should().Be(ConditionType.Outfit);
+        restored[5].Type.Should().Be(ConditionType.Regeneration);
+    }
+
     #endregion
 }


### PR DESCRIPTION
### Description
Persist regeneration conditions (hunger/saturation) to the database so players don't lose their regeneration state on logout.

### Key Changes
- Add `ConditionRegeneration.CaptureState()` / `Restore()` for JSON serialization
- Add `ConditionRegenerationParser` to serialize/deserialize regen conditions in the `Conditions` JSON column
- Add `ConditionRegenerationState` record to store remaining time
- Remove standalone `RemainingRecoverySeconds` column and its EF Core configuration
- Update `Player.LoadConditions` to restore regen conditions from JSON state
- Update tests for constructor change (no longer takes `Action onExpired` callback)

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
dotnet test tests/NeoServer.Domain.Tests --filter "FullyQualifiedName~ConditionRegeneration"
dotnet test tests/NeoServer.Server.Tests --filter "FullyQualifiedName~ConditionListParser"