### PR TITLE
feat: add house ownership, access control, and rent system (Phase 1 — domain)

### DIFF
--- a/docs/house-system/House-System-Plan.md
+++ b/docs/house-system/House-System-Plan.md
@@ -1,0 +1,247 @@
+# House System — Implementation Plan (OpenCoreMMO)
+
+## Context
+
+OpenCoreMMO has **partial, dormant house scaffolding** but no working house system:
+`DynamicTile` already carries `uint? HouseId` and an injectable `CanEnterFunction`; `TileFactory`
+already routes `houseId` into dynamic tiles; `WorldLoader.LoadTile` already reads `tileNode.HouseId`;
+`NeoContext` already exposes `DbSet<HouseEntity>`/`DbSet<HouseListEntity>` with EF configurations.
+What's missing is the **domain aggregate, the map-load attach step, the OTBM house-tile parser,
+persistence/loader, the Lua API surface, and the Lua scripts** that turn those columns and that
+`HouseId` into actual houses with ownership, access control, invited-entry, eviction and rent.
+
+This plan ports the rules from `forgottenserver-downgrade` (`house.cpp`, `housetile.cpp`,
+`luahouse.cpp`, and the house talkactions/spell scripts) onto OpenCoreMMO's idioms, mirroring the
+**Guild** feature end-to-end (aggregate → store → repository → loader → Lua functions).
+
+**Scope (confirmed):** Core ownership + rent — buy/sell/leave, access lists (guest/subowner/door),
+invited-entry enforcement, eviction, rent cycle with 7-warning eviction. Auction/bidding
+(`Bid/BidEnd/HighestBidder` columns) is **out of scope**, left intact for a future phase.
+
+**Delivery (confirmed):** Three phased, independently-mergeable PRs (see end).
+
+---
+
+## Key design decisions
+
+1. **No `HouseTile` subclass.** Realize the house tile by *configuring* the existing `DynamicTile`,
+   not subclassing it. At attach time the `House` aggregate sets the `ProtectionZone` flag and
+   installs a closure on `tile.CanEnterFunction` that consults the access list. Subclassing would
+   fork the static/dynamic `TileFactory` routing, duplicate the large `DynamicTile` body, and break
+   `is IDynamicTile` checks. House tiles are always dynamic (the factory already forces this for
+   `houseId > 0`), so `tile as IDynamicTile` is always safe.
+
+2. **Domain references no EF.** Persistence goes through `IHouseRepository` (domain interface)
+   injected into `HouseService` (domain service), mirroring `MailService`/`IPlayerMailRepository`.
+   The `House` aggregate stays pure; `HouseService` orchestrates operations that need DB access.
+   Domain events still exist for player notifications (eviction, rent warning) but not for DB calls.
+
+3. **Item throw/move gating lives in the movement layer, not in `DynamicTile`.** `DynamicTile.CanAddItem`
+   has no acting-player context. Add a small, unit-testable `IHouseItemMovementPolicy` consulted by
+   throw/move commands (`IHouseStore.GetByTile(toTile)` → `house.IsInvited(player)`).
+
+4. **Mirror Guild** for every infrastructure piece so the PR reads idiomatically.
+
+---
+
+## Phase 1 — Domain + unit tests
+
+New folder: `src/Core/NeoServer.Domain/Houses/`.
+
+### Enums / value objects
+- `HouseAccessLevel.cs` — `enum : byte { NotInvited=0, Guest=1, SubOwner=2, Owner=3 }` (compared with `>=`).
+- `HouseListId.cs` — constants `Guest = 0x100`, `SubOwner = 0x101`; any value `0..254` is a **door id**.
+- `AccessList/HouseAccessList.cs` — structured value object with
+  `AddPlayer(name)`, `AddGuild(guildId)`, `AddGuildRank(guildId, minLevel)`, `AllowAll()`,
+  `Clear()`, and `IsInList(IPlayer)`. No text parsing — receives already-resolved data
+  from `HouseAccessListLoader` (in Loaders project, Phase 2).
+
+### Aggregate `House.cs`
+- **State:** `Id`, `Name`, `TownId`, `Rent`, `PaidUntil`, `PayRentWarnings` (clamped 0..7),
+  `OwnerGuid` (0 = unowned), `OwnerName`, `OwnerAccountId`, `EntryPosition`,
+  internal `_tiles`, `_doors` (keyed by door id), `_beds`, `_accessLists` (keyed by listId).
+- **Linkage (called by loader after world load):**
+  `LinkTile(IDynamicTile)` → adds tile, sets `ProtectionZone` flag, installs
+  `CanEnterFunction = c => c is IPlayer p && GetAccessLevel(p) != NotInvited`;
+  `LinkDoor(uint doorId, IDoorItem)`; `LinkBed(IBedItem)`. Throws if a tile is linked to two houses.
+- **Access:** `GetAccessLevel(IPlayer)`, `IsInvited`, `CanEnter(ICreature)`,
+  `CanEditAccessList(listId, IPlayer)` (owner edits subowner list; owner+subowner edit guest list/doors),
+  `GetAccessList(listId)` / `SetAccessList(listId, HouseAccessList)`.
+- **`SetNewOwner(guid, name, accountId, updatePaidUntil, now, rentPeriodSeconds)`** (ports `House::setOwner`):
+  pure domain state change. On owner *change* → clear all access + door lists; set owner fields
+  (0/empty = unowned); if `updatePaidUntil && guid != 0` set `PaidUntil = now + rentPeriod` and
+  reset warnings. Same-guid = no-op except paidUntil. No eviction/wake/depot — `HouseService`
+  reads `Tiles`/`Players`/`Beds`/`AllItems` after calling this and performs side effects.
+- **`CanKick(caster, target)`** — pure check: returns `bool` (caster `>= SubOwner` and
+  `level(caster) > level(target)`, never the owner, target in this house).
+  `HouseService` teleports target on success.
+- **`PayRent(owner, ICoinTypeStore, now, rentPeriodSeconds)`** (ports `payHouses`): returns
+  `HouseRentResult { NotDue, Paid, Warned, Evicted }`. Not due / rent 0 / unowned → `NotDue`.
+  Sufficient bank → withdraw, advance `PaidUntil`, reset warnings → `Paid`. Insufficient → increment
+  warnings; on 7th → returns `Evicted`. No I/O inside the aggregate. `HouseService` raises events and persists.
+
+### Domain events
+- `HouseOwnerChangedEvent(House, oldOwnerGuid, newOwnerGuid)` — raised by `House.SetNewOwner`.
+- `HouseRentWarningEvent(House, owner, warningNumber)` — raised by `HouseService` (not aggregate)
+  to notify the player via game event.
+- `HouseEvictedEvent(House)` — raised by `HouseService` when eviction occurs.
+
+Events are for player notifications, not for DB persistence. `HouseService` calls `IHouseRepository` directly.
+
+### HouseService (domain service, mirrors MailService)
+- `Houses/Services/IHouseService.cs` + `HouseService.cs`. Constructor takes
+  `IHouseRepository`, `IHouseEviction`, `IHouseBedWaker`, `IHouseDepotTransfer`.
+- `SetOwner(House, guid, name, accountId, updatePaidUntil, now, rentPeriodSeconds)` — calls
+  `House.SetNewOwner(...)`, then iterates `House.Tiles` to evict now-uninvited players (via
+  `IHouseEviction`), wake beds (`IHouseBedWaker`), transfer pickupable items to old owner depot
+  (`IHouseDepotTransfer`). Persists via `IHouseRepository`. Raises `HouseOwnerChangedEvent`.
+- `PayRent(House, owner)` — calls `House.PayRent(...)`, persists via `IHouseRepository`,
+  raises `HouseRentWarningEvent` or `HouseEvictedEvent` as needed.
+- `KickPlayer(House, caster, target)` — calls `House.KickPlayer(...)`, on success teleports target
+  via `IHouseEviction` and persists via `IHouseRepository`.
+
+### Stores / factory
+- `Common/Contracts/DataStores/IHouseStore.cs` : `IDataStore<uint, House>` + `GetByTile(ITile)`
+  (reads `(tile as IDynamicTile)?.HouseId`) + `GetByHouseId(uint)`. Impl `HouseStore` in the
+  in-memory data-store project, mirroring `GuildStore`.
+- `Houses/IHouseFactory.cs` + impl — `Create(HouseEntity)` creates aggregate with empty access lists.
+  In Phase 2, `HouseAccessListLoader` populates lists from `HouseListEntity` rows after factory call.
+- `Houses/IHouseItemMovementPolicy.cs` — `CanMoveItem(IPlayer, ITile)` for the movement layer (Phase 2/3 hook).
+
+### Deliverable: domain-test spec markdown
+Create **`docs/house-system/domain-tests.md`** capturing every domain test case below with a
+one-line *expected output*, grouped by area. This is the requested "domain unit tests output
+expected" artifact and doubles as the Phase-1 acceptance checklist.
+
+### Tests — `tests/NeoServer.Domain.Tests/Houses/` (xUnit + FluentAssertions + Moq + AutoFixture)
+Add `Helpers/House/HouseTestDataBuilder.cs`; reuse `PlayerTestDataBuilder` and
+`EventAggregatorTestHelper.SetupEventAggregator<T>`. Naming `[Method]_[Scenario]_[Expected]`.
+
+- **HouseOwnershipTests:** set owner populates fields; updatePaidUntil sets future PaidUntil + resets
+  warnings; owner change clears guest/subowner/door lists, evicts occupants to entry, wakes bed
+  sleepers, transfers pickupables to old owner depot, leaves fixed items; zero-guid → unowned;
+  same-guid → no evict/clear; raises `HouseOwnerChangedEvent` once.
+- **HouseAccessListTests:** `AddPlayer` (case-insensitive), `AddGuild`, `AddGuildRank` (rank `>=` match),
+  `AllowAll`, `Clear` resets state, `IsInList` combinations.
+- **HouseAccessLevelTests:** owner/subowner/guest/none resolution; both-lists → SubOwner wins;
+  `IsInvited` true/false; `CanEnter` invited/uninvited; non-player → true; `CanEditAccessList`
+  owner-vs-subowner-list, subowner-vs-guest-list, guest-edits-anything-false.
+- **HouseEvictionTests:** owner/subowner kicks guest → exit; guest kicks → fail; kick owner → fail;
+  target not in house → fail; `KickOccupants` only moves now-uninvited.
+- **HouseRentTests:** not due → NotDue/no deduction; due+funds → deduct + advance + reset warnings;
+  due+no funds → increment warnings + letter event; 7th warning → evict + unown; rent 0 / unowned →
+  NotDue; warnings above cap clamp to 7.
+- **HouseTileAssociationTests:** `LinkTile` sets ProtectionZone; CanEnterFunction blocks uninvited /
+  allows invited; tile count; `Store.GetByTile` returns owner house / null when no houseId; same tile
+  to two houses throws.
+- **HouseDoorBedTests:** `GetDoorIdByPosition` known/none; door-listId updates only that door; door
+  count; `LinkBed` reflected in bed count; owner change wakes all beds.
+- **HouseFactoryTests:** entity → id/name/town/rent/warnings/owner mapping; seeds guest (0x100),
+  subowner (0x101), and door access lists; unowned entity → empty lists.
+
+---
+
+## Phase 2 — Map load + persistence
+
+### OTBM house-tile parsing
+Finish the stub `src/Loaders/NeoServer.Loaders/OTBM/Structure/TileArea/HouseTile.cs`: parse the
+`OTBM_HOUSETILE (0x0E)` node — read `HouseId = stream.ReadUInt32()` **before** tile attributes, then
+parse contents like a normal tile; surface `NodeType.HouseTile` and `HouseId` on `TileNode`.
+**Highest-risk item:** a mis-aligned read corrupts the rest of the tile area — verify against a known map.
+
+### Load ordering & attach
+1. **Guilds load first** (so guild names resolve for access-list parsing).
+2. **`HouseLoader`** (`src/Loaders/NeoServer.Loaders/Houses/HouseLoader.cs`, mirrors `GuildLoader`):
+   `repo.GetAll()` → `factory.Create(...)` → `houseStore.AddOrUpdate`. Houses now have ownership but empty access lists.
+3. **`HouseAccessListLoader`** (`src/Loaders/NeoServer.Loaders/Houses/HouseAccessListLoader.cs`):
+   iterates `houseListEntities` per house, parses raw text, resolves guild names via `IGuildStore`,
+   builds `HouseAccessList` via structured API (`AddPlayer`/`AddGuild`/`AddGuildRank`/`AllowAll`),
+   and calls `house.SetAccessList(listId, list)`. Runs after `HouseLoader`.
+4. **`WorldLoader`** gains `IHouseStore`. In `LoadTile`, for `houseId > 0`:
+   `houseStore.GetByHouseId(id)?.LinkTile(dynamicTile)`, and scan tile items → `LinkDoor` (door + DoorId
+   attr) / `LinkBed` (bed). **Skip the static-cache fast-path when `houseId > 0`** (house tiles must
+   never be served from the shared cache).
+5. **Finalize:** set each house `EntryPosition` (entity value, else first tile); log houses with 0 tiles.
+
+### Persistence (mirror MailService pattern)
+- `HouseEntity.cs`: rename `Onwer` → `OwnerGuid`; repurpose/rename `Paid` → `PaidUntil` (unix);
+  add `EntryX/EntryY/EntryZ` (optional). Keep auction columns untouched.
+- `HouseListEntity`: `ListId` semantics — `0x100` guest, `0x101` subowner, `0..254` door id; ensure
+  `(HouseId, ListId)` index in `HouseListEntityConfiguration`.
+- `IHouseRepository` + `HouseRepository : BaseRepository<HouseEntity>` (mirror `IPlayerMailRepository`):
+  `GetAll()` / `GetById()` with `Include(h => h.HouseLists)`; `Save(House)`; `SaveAccessList(houseId, listId, text)`.
+  Called directly by `HouseService`, not through domain events or delegates.
+- **EF migration** for the rename + new columns + index, generated for SQLite and Postgres
+  (InMemory ignores migrations).
+
+---
+
+## Phase 3 — Lua handlers + scripts
+
+### `HouseFunctions.cs`
+`src/Extensions/NeoServer.Scripts.LuaJIT/Functions/HouseFunctions.cs` (+ `IHouseFunctions`), mirroring
+`GuildFunctions`/`TileFunctions`. `Init` registers class `House` (`House(id)` → `houseStore.GetByHouseId`),
+`__eq`, and methods: `getId`, `getName`, `getTown`, `getExitPosition`, `getOwnerName`, `getOwnerGuid`,
+`getOwnerAccountId`, `setOwnerGuid`, `getRent`/`setRent`, `getPaidUntil`/`setPaidUntil`,
+`getPayRentWarnings`/`setPayRentWarnings`, `getTiles`/`getTileCount`, `getDoors`/`getDoorCount`,
+`getDoorIdByPosition`, `getBeds`/`getBedCount`, `getItems`, `canEditAccessList(listId, player)`,
+`getAccessList(listId)`, `setAccessList(listId, text)`, `startTrade(player, partner)`,
+`kickPlayer(caster, target)`, `save`.
+
+### Extend existing function classes (don't add new Tile/Player classes)
+- `TileFunctions.Init`: add `Tile:getHouse()` → `houseStore.GetByTile(tile)`.
+- `PlayerFunctions.Init`: add `Player:getTile()` → `gameServer.Map.GetTile(player.Location)` (reuse if present).
+
+### Registration
+- `IoC/LuaJITInjection.cs`: `AddSingleton<IHouseFunctions, HouseFunctions>()`.
+- `LuaStartup`: add `IHouseFunctions` ctor param + `houseFunctions.Init(luaState)` in `Start()`.
+
+### Ported Lua scripts (loaded recursively from `data/`)
+- `data/scripts/talkactions/house/buyhouse.lua`, `leavehouse.lua`, `sellhouse.lua`
+  (use `player:getTile()`, `tile:getHouse()`, `house:setOwnerGuid`, `house:startTrade`).
+- `data/spells/scripts/house/edit_door.lua`, `invite_guests.lua`, `invite_subowners.lua`,
+  `kick_guest.lua` (use `house:canEditAccessList`, `getAccessList`/`setAccessList`, `kickPlayer`,
+  `getDoorIdByPosition`).
+
+---
+
+## DI wiring (exact modules)
+- `DataStoreInjection.cs` → `IHouseStore, HouseStore`
+- `DatabaseInjection.cs` → `IHouseRepository, HouseRepository`
+- `FactoryInjection.cs` → `IHouseFactory, HouseFactory`
+- `ServiceInjection.cs` → `IHouseService, HouseService`
+- `LuaJITInjection.cs` → `IHouseFunctions, HouseFunctions`
+- Loader orchestration → register `HouseLoader`; order **guilds → houses → world+attach**
+- `WorldLoader` registration → add `IHouseStore` to its ctor
+
+## Critical files
+- `src/Core/NeoServer.Domain/World/Models/Tiles/DynamicTile.cs` (read; `HouseId`, `CanEnterFunction`)
+- `src/Loaders/NeoServer.Loaders/World/WorldLoader.cs` (attach + cache-skip)
+- `src/Loaders/NeoServer.Loaders/OTBM/Structure/TileArea/HouseTile.cs` (finish parser)
+- `src/Database/NeoServer.Data/Entities/HouseEntity.cs` + `HouseListEntity.cs` (+ configs)
+- `src/Extensions/NeoServer.Scripts.LuaJIT/Functions/{TileFunctions,PlayerFunctions}.cs`
+- Reference aggregate to mirror: `src/Core/NeoServer.Domain/Guild/Guild.cs` (+ GuildRepository/GuildLoader/GuildStore)
+
+## Risks
+1. OTBM stream alignment when reading the house-tile uint32 (corruption risk) — verify on a real map.
+2. Static-tile cache must be bypassed for `houseId > 0` in both `WorldLoader` and `TileFactory`.
+3. Offline-owner depot transfer needs depot-store access, not online inventory.
+4. Item throw/move gating must be a movement-layer policy (no player context in `DynamicTile`).
+5. Guilds must load before houses for access-list guild/rank resolution.
+6. Domain must stay EF-free (events/delegates for save + letters).
+7. Migration spans SQLite + Postgres (InMemory ignores).
+
+## Verification
+- **Phase 1:** `dotnet test tests/NeoServer.Domain.Tests` — all `Houses/` tests green;
+  `docs/house-system/domain-tests.md` matches implemented cases.
+- **Phase 2:** boot the server with a house-bearing OTBM; assert houses in `IHouseStore` have the
+  expected tile counts, ProtectionZone flags set, and owners loaded from DB; confirm migration applies
+  on SQLite + Postgres.
+- **Phase 3:** in-game — uninvited player blocked from a house tile (redirected to entry); owner runs
+  buy/leave/sell talkactions; `aleta sio` / invite + kick spells update access lists and evict;
+  rent cycle deducts bank and evicts after 7 warnings.
+
+## Phasing (3 PRs)
+- **PR1 (Phase 1):** domain aggregate, value objects, store/factory, unit tests, `domain-tests.md`. No infra deps.
+- **PR2 (Phase 2):** OTBM parser, `HouseLoader`, `WorldLoader` attach, persistence/repository, migration, DI.
+- **PR3 (Phase 3):** `HouseFunctions`, Tile/Player Lua additions, ported talkactions + spell scripts, DI.

--- a/docs/house-system/House-System-Plan.md
+++ b/docs/house-system/House-System-Plan.md
@@ -75,10 +75,14 @@ New folder: `src/Core/NeoServer.Domain/Houses/`.
 - **`CanKick(caster, target)`** — pure check: returns `bool` (caster `>= SubOwner` and
   `level(caster) > level(target)`, never the owner, target in this house).
   `HouseService` teleports target on success.
-- **`PayRent(owner, ICoinTypeStore, now, rentPeriodSeconds)`** (ports `payHouses`): returns
+- **`PayRent(owner, now, rentPeriodSeconds)`** (ports `payHouses`): returns
   `HouseRentResult { NotDue, Paid, Warned, Evicted }`. Not due / rent 0 / unowned → `NotDue`.
   Sufficient bank → withdraw, advance `PaidUntil`, reset warnings → `Paid`. Insufficient → increment
   warnings; on 7th → returns `Evicted`. No I/O inside the aggregate. `HouseService` raises events and persists.
+  > **Note (m2):** `ICoinTypeStore` was intentionally removed from this signature in Phase 1.
+  > Rent is collected from `owner.Bank.Debit(Rent)` (bank-balance based, mirroring forgottenserver
+  > `payHouses`). If a future phase needs coin-specific rent, re-introduce the store at the service
+  > layer, not the aggregate.
 
 ### Domain events
 - `HouseOwnerChangedEvent(House, oldOwnerGuid, newOwnerGuid)` — raised by `House.SetNewOwner`.
@@ -184,7 +188,10 @@ parse contents like a normal tile; surface `NodeType.HouseTile` and `HouseId` on
 `__eq`, and methods: `getId`, `getName`, `getTown`, `getExitPosition`, `getOwnerName`, `getOwnerGuid`,
 `getOwnerAccountId`, `setOwnerGuid`, `getRent`/`setRent`, `getPaidUntil`/`setPaidUntil`,
 `getPayRentWarnings`/`setPayRentWarnings`, `getTiles`/`getTileCount`, `getDoors`/`getDoorCount`,
-`getDoorIdByPosition`, `getBeds`/`getBedCount`, `getItems`, `canEditAccessList(listId, player)`,
+`getDoorIdByPosition` (Phase-3 dependency: requires reverse `Dictionary<Location, uint>` map
+populated at Phase-2 door-location linkage — deferred from Phase 1 because door `Location` is
+not reliably available before world-attach; see `domain-tests.md` Deferred section),
+`getBeds`/`getBedCount`, `getItems`, `canEditAccessList(listId, player)`,
 `getAccessList(listId)`, `setAccessList(listId, text)`, `startTrade(player, partner)`,
 `kickPlayer(caster, target)`, `save`.
 

--- a/docs/house-system/domain-tests.md
+++ b/docs/house-system/domain-tests.md
@@ -1,0 +1,84 @@
+# House System — Domain Unit Tests (Expected Output)
+
+## HouseOwnershipTests
+- SetNewOwner_FromUnownedToPlayer_SetsOwnerGuidNameAccount → OwnerGuid=10, OwnerName="NewOwner", OwnerAccountId=100.
+- SetNewOwner_WithUpdatePaidUntilTrue_SetsPaidUntilToNowPlusRentPeriod → PaidUntil == now + 86400s.
+- SetNewOwner_WithUpdatePaidUntilTrue_ResetsPayRentWarningsToZero → PayRentWarnings == 0.
+- SetNewOwner_ChangingOwner_ClearsGuestAndSubownerLists → both lists null after change.
+- SetNewOwner_ChangingOwner_ClearsAllDoorAccessLists → all door lists null after change.
+- SetNewOwner_ToZeroGuid_MarksHouseUnowned → OwnerGuid=0, OwnerName empty, OwnerAccountId=0, lists cleared.
+- SetNewOwner_ToSameGuid_DoesNotClearLists → lists intact, owner fields unchanged.
+- SetNewOwner_SameGuidWithUpdatePaidUntil_RefreshesPaidUntil → PaidUntil advanced, warnings reset.
+
+## HouseAccessListTests
+- AddPlayer_AddsNameCaseInsensitive → IsInList true regardless of case.
+- AllowAll_MakesAnyPlayerInList → IsInList true for any player.
+- AddGuild_AddsGuildId → guild member IsInList true.
+- AddGuildRank_MatchesRankLevelOrAbove → player with rank >= list rank IsInList true.
+- AddGuildRank_LowerRankDoesNotMatch → player with rank < list rank IsInList false.
+- Clear_ResetsAllEntries → IsInList false for all previously added entries.
+- IsInList_PlayerNotInList_ReturnsFalse → false.
+- AddPlayer_MultipleNames_AllMatch → IsInList true for all added names.
+
+## HouseAccessLevelTests
+- GetAccessLevel_Owner_ReturnsOwner → Owner.
+- GetAccessLevel_PlayerInSubownerList_ReturnsSubOwner → SubOwner.
+- GetAccessLevel_PlayerInGuestListOnly_ReturnsGuest → Guest.
+- GetAccessLevel_PlayerInBothLists_ReturnsSubOwner → SubOwner (higher wins).
+- GetAccessLevel_UninvitedPlayer_ReturnsNotInvited → NotInvited.
+- IsInvited_GuestPlayer_ReturnsTrue → true.
+- IsInvited_UninvitedPlayer_ReturnsFalse → false.
+- CanEnter_InvitedPlayer_ReturnsTrue → true.
+- CanEnter_UninvitedPlayer_ReturnsFalse → false.
+- CanEnter_NonPlayerCreature_ReturnsFalse → false.
+- CanEditAccessList_OwnerEditsSubownerList_ReturnsTrue → true.
+- CanEditAccessList_SubownerEditsSubownerList_ReturnsFalse → false.
+- CanEditAccessList_SubownerEditsGuestList_ReturnsTrue → true.
+- CanEditAccessList_GuestEditsAnyList_ReturnsFalse → false for guest/subowner/door lists.
+
+## HouseEvictionTests
+- CanKick_OwnerKicksGuest_ReturnsTrue → true (caster >= SubOwner, level > target, target on house tile).
+- CanKick_SubownerKicksGuest_ReturnsTrue → true.
+- CanKick_GuestKicksAnyone_ReturnsFalse → false (caster access too low).
+- CanKick_AnyoneKicksOwner_ReturnsFalse → false (cannot kick owner).
+- CanKick_TargetNotInHouse_ReturnsFalse → false (target.Tile not in house tiles).
+
+## HouseRentTests
+- PayRent_NotDue_ReturnsNotDue_NoDeduction → NotDue, bank unchanged.
+- PayRent_DueAndSufficientBank_DeductsRentAndAdvancesPaidUntil → Paid, bank -= rent, PaidUntil advanced.
+- PayRent_DueAndSufficientBank_ResetsWarningsToZero → Paid, warnings == 0.
+- PayRent_DueAndInsufficientBank_IncrementsWarnings → Warned, warnings +1.
+- PayRent_SeventhWarning_ReturnsEvicted → Evicted, OwnerGuid == 0.
+- PayRent_RentZero_ReturnsNotDue → NotDue.
+- PayRent_Unowned_ReturnsNotDue → NotDue.
+- SetPayRentWarnings_AboveCap_ClampsToSeven → value == 7.
+
+## HouseTileAssociationTests
+- LinkTile_InstallsCanEnterFunction_BlockingUninvitedPlayer → CanEnterFunction false for stranger.
+- LinkTile_CanEnterFunction_AllowsInvitedPlayer → CanEnterFunction true for owner.
+- LinkTile_NonPlayerCreature_CanEnterFalse → CanEnterFunction false for non-player.
+- GetTileCount_AfterLinkingTiles_ReturnsCount → TileCount matches linked count.
+- LinkTile_SameTileToTwoHouses_Throws → InvalidOperationException.
+
+## HouseDoorBedTests
+- GetDoorCount_AfterLinking_ReturnsCount → DoorCount matches linked doors.
+- LinkBed_AddsBedToHouse_GetBedCountReflects → BedCount matches linked beds.
+- SetAccessList_DoorListId_UpdatesThatDoorOnly → only that door's list changes, other doors unaffected.
+- EntryPosition_DefaultsToFirstTileLocation → EntryPosition == first linked tile's Location.
+
+## HouseFactoryTests
+- Create_FromEntity_MapsIdNameTownRentWarningsOwner → all fields mapped from entity values.
+- Create_UnownedEntity_ProducesUnownedHouseWithEmptyLists → OwnerGuid 0, OwnerName empty, no tiles/doors/beds.
+
+## HouseServiceTests
+- SetOwner_EvictsNowUninvitedPlayers → eviction seam called for each player on tiles who isn't new owner.
+- SetOwner_WakesAllBeds → bed-waker seam called with all house beds.
+- SetOwner_TransfersPickupableItemsToOldOwnerDepot → depot seam receives pickupable items only.
+- SetOwner_LeavesNonPickupableItems → depot seam not called when only fixed items exist.
+- SetOwner_PersistsHouse → repository.Save called after aggregate state change.
+- SetOwner_RaisesHouseOwnerChangedEvent → event raised with old/new owner guids.
+- PayRent_Warned_RaisesHouseRentWarningEvent → warning event raised with house, owner, warning number.
+- PayRent_Evicted_RaisesHouseEvictedEvent → eviction event raised with house.
+- PayRent_Paid_PersistsHouseState → repository.Save called after successful payment.
+- CanKick_Success_TeleportsTargetAndPersists → eviction seam called + repository.Save.
+- CanKick_Failure_NoSideEffects → no eviction or persist calls.

--- a/docs/house-system/domain-tests.md
+++ b/docs/house-system/domain-tests.md
@@ -1,5 +1,8 @@
 # House System — Domain Unit Tests (Expected Output)
 
+> Phase 1 reference — 1:1 with implemented tests after review fixes (spec `review-fixes-spec.md`).
+> Every test name here corresponds to a real test in `tests/NeoServer.Domain.Tests/Houses/`.
+
 ## HouseOwnershipTests
 - SetNewOwner_FromUnownedToPlayer_SetsOwnerGuidNameAccount → OwnerGuid=10, OwnerName="NewOwner", OwnerAccountId=100.
 - SetNewOwner_WithUpdatePaidUntilTrue_SetsPaidUntilToNowPlusRentPeriod → PaidUntil == now + 86400s.
@@ -44,6 +47,11 @@
 - CanKick_TargetNotInHouse_ReturnsFalse → false (target.Tile not in house tiles).
 
 ## HouseRentTests
+
+> Note (m2): `PayRent(owner, now, rentPeriodSeconds)` — `ICoinTypeStore` was intentionally
+> removed in Phase 1. Rent is bank-balance based (`owner.Bank.Debit`). If a future phase needs
+> coin-specific rent, re-introduce the store at the service layer, not the aggregate.
+
 - PayRent_NotDue_ReturnsNotDue_NoDeduction → NotDue, bank unchanged.
 - PayRent_DueAndSufficientBank_DeductsRentAndAdvancesPaidUntil → Paid, bank -= rent, PaidUntil advanced.
 - PayRent_DueAndSufficientBank_ResetsWarningsToZero → Paid, warnings == 0.
@@ -54,11 +62,17 @@
 - SetPayRentWarnings_AboveCap_ClampsToSeven → value == 7.
 
 ## HouseTileAssociationTests
+
+> M1: `LinkTile` now sets `TileFlags.ProtectionZone` via `IDynamicTile.SetAsProtectionZone()`.
+> M2: cross-house detection via `CanEnterFunction != null` guard (see code comment for Phase-2 upgrade path).
+
 - LinkTile_InstallsCanEnterFunction_BlockingUninvitedPlayer → CanEnterFunction false for stranger.
 - LinkTile_CanEnterFunction_AllowsInvitedPlayer → CanEnterFunction true for owner.
 - LinkTile_NonPlayerCreature_CanEnterFalse → CanEnterFunction false for non-player.
 - GetTileCount_AfterLinkingTiles_ReturnsCount → TileCount matches linked count.
-- LinkTile_SameTileToTwoHouses_Throws → InvalidOperationException.
+- LinkTile_SetsProtectionZoneFlag → after LinkTile, HasFlag(ProtectionZone) is true. (M1)
+- LinkTile_SameTileToSameHouseTwice_Throws → InvalidOperationException when same tile linked to same house twice. (M2)
+- LinkTile_SameTileToTwoDifferentHouses_Throws → InvalidOperationException when tile claimed by house A is linked to house B. (M2)
 
 ## HouseDoorBedTests
 - GetDoorCount_AfterLinking_ReturnsCount → DoorCount matches linked doors.
@@ -69,6 +83,17 @@
 ## HouseFactoryTests
 - Create_FromEntity_MapsIdNameTownRentWarningsOwner → all fields mapped from entity values.
 - Create_UnownedEntity_ProducesUnownedHouseWithEmptyLists → OwnerGuid 0, OwnerName empty, no tiles/doors/beds.
+
+## HouseItemMovementPolicyTests
+
+> m1: `HouseItemMovementPolicy(IHouseStore)` implements the invited-only movement rule.
+> DI registration deferred to Phase 2/3 movement-layer wiring.
+
+- CanMoveItem_NonHouseTile_ReturnsTrue → GetByTile returns null → true for any player.
+- CanMoveItem_HouseTile_InvitedPlayer_ReturnsTrue → store returns house where IsInvited is true → true.
+- CanMoveItem_HouseTile_UninvitedPlayer_ReturnsFalse → store returns house where IsInvited is false → false.
+- CanMoveItem_HouseTile_NullPlayer_ReturnsFalse → house tile + null player → false.
+- CanMoveItem_NullTile_ReturnsTrue → no tile context → true.
 
 ## HouseServiceTests
 - SetOwner_EvictsNowUninvitedPlayers → eviction seam called for each player on tiles who isn't new owner.
@@ -82,3 +107,44 @@
 - PayRent_Paid_PersistsHouseState → repository.Save called after successful payment.
 - CanKick_Success_TeleportsTargetAndPersists → eviction seam called + repository.Save.
 - CanKick_Failure_NoSideEffects → no eviction or persist calls.
+
+---
+
+## LocationEqualityTests (Common/Structs)
+
+> C1: fixed `Location.Equals(object)` infinite recursion (StackOverflow) and cleaned dead
+> `NullReferenceException` catches from `operator ==`/`!=`.
+
+- Equals_BoxedEqualLocation_ReturnsTrue → boxed compare of equal locations returns true (does not overflow).
+- Equals_BoxedDifferentLocation_ReturnsFalse → boxed compare of different locations returns false.
+- Equals_BoxedNonLocation_ReturnsFalse → comparing a Location to a non-Location object returns false.
+- Equals_TypedOverload_MatchesOperator → `loc.Equals(other) == (loc == other)` for equal and unequal pairs.
+- Be_ViaFluentAssertions_DoesNotOverflow → FluentAssertions `.Be()` passes for equal locations (regression guard).
+- GetHashCode_EqualLocations_AreEqual → equal locations share the same hash code.
+- OperatorEquality_And_Inequality_AreConsistent → `(a == b) == !(a != b)` for equal and unequal pairs.
+
+---
+
+## Deferred to Phase 2/3
+
+The following cases are planned but not implemented in Phase 1. They are listed here to document
+their target phase explicitly — none were silently dropped.
+
+### GetDoorIdByPosition (Phase 3 dependency — m4)
+- `GetDoorIdByPosition_KnownDoor_ReturnsDoorId` — deferred to Phase 3.
+  Requires a reverse `Dictionary<Location, uint>` map populated at `LinkDoor` time.
+  A door item's `Location` is only reliably available after the Phase-2 world-attach step
+  (doors receive their location when linked from the map). Implementing in Phase 1 would require
+  storing a `Location` per door at link time without a reliable source for it.
+  See `House-System-Plan.md` Phase 3, `HouseFunctions.getDoorIdByPosition`.
+- `GetDoorIdByPosition_NoDoorAtPosition_ReturnsZero` — same blocker; deferred to Phase 3.
+
+### Factory access-list and door seeding (Phase 2 — HouseAccessListLoader)
+- `Create_FromEntity_SeedsGuestList_*`, `Create_FromEntity_SeedsSubownerList_*`,
+  `Create_FromEntity_SeedsDoorList_*` — deferred to Phase 2.
+  The factory creates empty lists in Phase 1. `HouseAccessListLoader` (Phase 2, Loaders project)
+  will populate access lists from `HouseListEntity` rows after the factory call.
+
+### SetNewOwner_WakesAllLinkedBeds (covered by HouseServiceTests)
+- This side effect lives in `HouseService`, not the aggregate. It is already tested by
+  `HouseServiceTests.SetOwner_WakesAllBeds`. No separate aggregate test needed.

--- a/docs/house-system/house-phase1-steps.md
+++ b/docs/house-system/house-phase1-steps.md
@@ -1,0 +1,312 @@
+# House System — Phase 1 Step-by-Step (Domain + Unit Tests)
+
+> Companion to `humble-growing-pony.md`. This document breaks **Phase 1 only** into an ordered,
+> verifiable checklist. Phase 1 is **pure domain**: no EF, no Lua, no map loading. Everything that
+> needs the outside world (depot transfer, teleport-on-evict, rent letters, persistence) is abstracted
+> behind interfaces/delegates and verified in tests with mocks + `EventAggregator` events. Real wiring
+> happens in Phases 2–3.
+
+## Phase 1 goal & definition of done
+
+**Goal:** A self-contained `House` aggregate with value objects, an in-memory store contract, a
+factory, and a complete unit-test suite — all compiling and green, plus the `domain-tests.md`
+deliverable.
+
+**Done when:**
+- [ ] `src/Core/NeoServer.Domain/Houses/**` compiles with zero new EF/Lua references.
+- [ ] `dotnet test tests/NeoServer.Domain.Tests` passes, all `Houses/` tests green.
+- [ ] `docs/house-system/domain-tests.md` exists and matches the implemented cases 1:1.
+- [ ] No changes to map loading, persistence, or Lua (those are Phase 2/3).
+
+**Reference to mirror:** `src/Core/NeoServer.Domain/Guild/Guild.cs` (+ its store) — copy its shape for
+events, `EventAggregator` usage, and immutability conventions.
+
+---
+
+## Pre-flight (verify before writing code)
+
+These are the existing domain types Phase 1 depends on. **Confirm the exact interface names/members**
+(grep first; the plan assumed these from exploration):
+
+- [ ] `IPlayer` — `Guid`/`Id`, `AccountId`, `Name`, `Town`, `Bank` (`IBank.BankAmount`, a withdraw method), `Location`. Path: `src/Core/NeoServer.Domain/Common/Contracts/Creatures/IPlayer.cs`.
+- [ ] `IDynamicTile` — has `uint? HouseId`, `Func<ICreature,bool> CanEnterFunction`, `HasFlag/SetFlag(TileFlags)`, `AllItems`, `Location`. Path: `src/Core/NeoServer.Domain/Common/Contracts/World/Tiles/IDynamicTile.cs`.
+- [ ] `TileFlags.ProtectionZone` exists. Path: `src/Core/NeoServer.Domain/Common/Location/TileFlags.cs`.
+- [ ] Door / Bed item contracts — **confirm exact names** (assumed `IDoorItem`, `IBedItem`). Grep `Door`, `Bed` under `src/Core/NeoServer.Domain/Items`. If a bed "sleeper/wakeup" API doesn't exist yet, model the wake step behind a small interface (see Step 5) and leave the concrete bed integration to Phase 2.
+- [ ] `ICoinTypeStore` and the player bank withdraw signature used for rent.
+- [ ] In-memory store base (`IDataStore<TKey,TValue>` / `DataStore<...>`) used by `GuildStore`. Path under `src/Database/NeoServer.Data.InMemory.DataStores/` (mirror it for `HouseStore`).
+- [ ] `IGuildStore` lookup-by-name + a guild's rank-level-by-name accessor (for access-list resolvers). Path: `src/Core/NeoServer.Domain/...Guild`.
+- [ ] Test helpers: `PlayerTestDataBuilder.Build(...)`, `EventAggregatorTestHelper.SetupEventAggregator<T>`. Path: `tests/NeoServer.Domain.Tests/Helpers/`.
+
+> If any assumed name is wrong, adjust the signatures below — the **logic** is what matters, not the
+> exact type names.
+
+---
+
+## Build order (dependency-first)
+
+Each step lists **What → Where → Depends on → Done-when**. Do them in order; the aggregate is built
+last from primitives so tests can target each piece in isolation.
+
+### Step 1 — Scaffold the folder
+- **What:** Create `Houses/` and `Houses/AccessList/` folders in the domain project. No new csproj.
+- **Where:** `src/Core/NeoServer.Domain/Houses/`
+- **Depends on:** nothing.
+- **Done-when:** folders exist; project still builds.
+
+### Step 2 — Enums & constants
+- **What:**
+  - `HouseAccessLevel.cs` → `enum HouseAccessLevel : byte { NotInvited=0, Guest=1, SubOwner=2, Owner=3 }` (compared with `>=`).
+  - `HouseRentResult.cs` → `enum { NotDue, Paid, Warned, Evicted }`.
+  - `HouseListId.cs` → `static class` with `const uint GuestList = 0x100; const uint SubOwnerList = 0x101;` and a helper `static bool IsDoorList(uint listId) => listId <= 254;`.
+- **Where:** `Houses/`
+- **Depends on:** Step 1.
+- **Done-when:** compiles; trivially unit-testable.
+
+### Step 3 — `HouseAccessList` value object
+- **What:** `Houses/AccessList/HouseAccessList.cs` with structured API:
+  `void AddPlayer(string name)`, `void AddGuild(ushort guildId)`,
+  `void AddGuildRank(ushort guildId, byte rankLevel)`, `void AllowAll()`,
+  `void Clear()`, `bool IsInList(IPlayer player)`.
+  No text parsing — receives already-resolved data from `HouseAccessListLoader`
+  (Loaders project, Phase 2). Case-insensitive player name matching.
+- **Where:** `Houses/AccessList/`
+- **Depends on:** Steps 1–2.
+- **Done-when:** `HouseAccessListTests` (Step 12) pass against it in isolation.
+
+### Step 4 — Domain events
+- **What:** Mirror Guild events. Create under `Houses/Events/` (or the project's event location):
+  - `HouseOwnerChangedEvent(House house, uint oldOwnerGuid, uint newOwnerGuid)`.
+  - `HouseRentWarningEvent(House house, IPlayer owner, byte warningNumber)` (drives the rent letter in Phase 3).
+  - `HouseEvictedEvent(House house)` (optional; or reuse owner-changed with new=0).
+- **Where:** `Houses/Events/`
+- **Depends on:** Step 1; the existing `EventAggregator` pattern.
+- **Done-when:** events compile; raised via `EventAggregator.Invoke(...)` from the aggregate.
+
+### Step 5 — Collaborator seams (for HouseService, not House aggregate)
+- **What:** Interfaces consumed by `HouseService` for game-world side effects. `House` aggregate
+  stays pure — no seam references. Phase 1 mocks these in `HouseService` tests.
+  - `IHouseDepotTransfer` → `void TransferToOwnerDepot(int ownerAccountId, ushort townId, IEnumerable<IItem> items)`.
+  - `IHouseEviction` → `void TeleportToExit(IPlayer player, Location exit)`.
+  - `IHouseBedWaker` → `void WakeAll(IEnumerable<IItem> beds)`.
+- **Where:** `Houses/Services/`
+- **Depends on:** Steps 1, 4.
+- **Done-when:** interfaces compile.
+
+### Step 6 — `House` state + linkage
+- **What:** `Houses/House.cs` (concrete class, no IHouse interface).
+  - **State:** `Id`, `Name`, `TownId`, `Rent`, `PaidUntil`, `PayRentWarnings` (property setter clamps 0..7),
+    `OwnerGuid` (0 = unowned), `OwnerName`, `OwnerAccountId`, `EntryPosition`;
+    private `_tiles` (List/Dict), `_doors` (`Dictionary<uint, IDoorItem>`), `_beds` (List), `_accessLists` (`Dictionary<uint, HouseAccessList>`).
+  - **Public read:** `Tiles`, `Doors`, `Beds`, `TileCount`, `DoorCount`, `BedCount` as read-only views.
+  - **Linkage:** `LinkTile(IDynamicTile)` → add; `tile.SetFlag(TileFlags.ProtectionZone)`; install
+    `tile.CanEnterFunction = c => c is IPlayer p && GetAccessLevel(p) != HouseAccessLevel.NotInvited`;
+    throw if the tile already belongs to another house. `LinkDoor(uint doorId, IDoorItem)`; `LinkBed(IBedItem)`.
+    `EntryPosition` defaults to the first linked tile if unset.
+- **Where:** `Houses/`
+- **Depends on:** Steps 2–5.
+- **Done-when:** `HouseTileAssociationTests` + `HouseDoorBedTests` pass.
+
+### Step 7 — Access resolution
+- **What:** On `House`:
+  - `HouseAccessLevel GetAccessLevel(IPlayer)` → Owner if guid match (and owner≠0); else SubOwner if in subowner list; else Guest if in guest list; else NotInvited.
+  - `bool IsInvited(IPlayer)` ⇒ `GetAccessLevel != NotInvited`.
+  - `bool CanEnter(ICreature)` ⇒ non-players true; players ⇒ `IsInvited`.
+  - `bool CanEditAccessList(uint listId, IPlayer)` ⇒ subowner list requires Owner; guest list / door lists require `>= SubOwner`.
+  - `string GetAccessList(uint listId)` / `void SetAccessList(uint listId, HouseAccessList list)` (store structured list; door listId updates only that door's list).
+- **Where:** `Houses/House.cs`
+- **Depends on:** Steps 3, 6.
+- **Done-when:** `HouseAccessLevelTests` pass.
+
+### Step 8 — `SetNewOwner` (pure domain)
+- **What:** `void SetNewOwner(uint guid, string name, int accountId, bool updatePaidUntil, DateTime now, uint rentPeriodSeconds)`
+  porting `House::setOwner`. Pure state mutation — no game-world I/O.
+  1. If currently owned **and** owner changes: clear all access + door lists.
+  2. Set owner fields (0/empty = unowned).
+  3. If `updatePaidUntil && guid != 0`: `PaidUntil = now + rentPeriod`; reset warnings to 0.
+  - Same-guid call is a no-op except optional paidUntil refresh.
+  - No eviction/wake/depot in aggregate. `HouseService` reads `Tiles`/`Players`/`Beds`/`AllItems`
+    after calling this and performs side effects via seams.
+- **Where:** `Houses/House.cs`
+- **Depends on:** Steps 6–7.
+- **Done-when:** `HouseOwnershipTests` pass (owner state changes, lists cleared).
+
+### Step 9 — Kick / eviction (pure check)
+- **What:** `bool CanKick(IPlayer caster, IPlayer target)` → returns true if caster `>= SubOwner`
+  and `level(caster) > level(target)`, never the owner, target must be in this house. Pure check —
+  no teleport inside aggregate. `HouseService` calls `IHouseEviction` on success.
+- **Where:** `Houses/House.cs`
+- **Depends on:** Steps 7.
+- **Done-when:** `HouseEvictionTests` pass.
+
+### Step 10 — `PayRent`
+- **What:** `HouseRentResult PayRent(IPlayer owner, ICoinTypeStore coins, DateTime now, uint rentPeriodSeconds)`
+  porting `payHouses`: rent 0 / unowned / not-yet-due ⇒ `NotDue`; due + sufficient bank ⇒ withdraw,
+  advance `PaidUntil`, reset warnings ⇒ `Paid`; insufficient ⇒ increment warnings ⇒ `Warned`;
+  on 7th warning ⇒ `SetNewOwner(0,...)` ⇒ `Evicted`. No events, no persistence inside aggregate.
+  `HouseService` raises notification events and calls `IHouseRepository` after this returns.
+- **Where:** `Houses/House.cs`
+- **Depends on:** Steps 4, 8.
+- **Done-when:** `HouseRentTests` pass.
+
+### Step 11 — `HouseService` (domain service, mirrors `MailService`)
+- **What:**
+  - `Houses/Services/IHouseService.cs` + `HouseService.cs`.
+  - Constructor: `IHouseRepository`, `IHouseEviction`, `IHouseBedWaker`, `IHouseDepotTransfer`.
+  - `SetOwner(House, guid, name, accountId, updatePaidUntil, now, rentPeriodSeconds)` → calls
+    `House.SetNewOwner(...)`, then iterates `House.Tiles` to evict now-uninvited players
+    (`IHouseEviction`), wake beds (`IHouseBedWaker`), transfer pickupable items
+    (`IHouseDepotTransfer`). Persists via `IHouseRepository`. Raises `HouseOwnerChangedEvent`.
+  - `PayRent(House, owner)` → calls `House.PayRent(...)`, persists via `IHouseRepository`,
+    raises `HouseRentWarningEvent` / `HouseEvictedEvent` based on result.
+  - `KickPlayer(House, caster, target)` → calls `House.KickPlayer(...)`, on success teleports
+    target via `IHouseEviction` and persists via `IHouseRepository`.
+- **Where:** `Houses/Services/`
+- **Depends on:** Steps 5, 8, 10, and `IHouseRepository` contract.
+- **Done-when:** service compiles; ownership/rent/eviction DB flow verified via mocks.
+- **Note:** `House` aggregate stays pure (no seam references). All game-world I/O happens here.
+
+### Step 12 — Store + factory + movement policy contracts
+- **What:**
+  - `Common/Contracts/DataStores/IHouseStore.cs : IDataStore<uint, House>` + `GetByTile(ITile)` (reads `(tile as IDynamicTile)?.HouseId`) + `GetByHouseId(uint)`.
+  - `HouseStore` impl in the in-memory data-store project, mirroring `GuildStore`.
+  - `Houses/IHouseFactory.cs` + `HouseFactory` → `Create(HouseEntity)` creates aggregate with empty access lists. In Phase 2, `HouseAccessListLoader` populates lists from `HouseListEntity` rows after factory call.
+  - `Houses/IHouseItemMovementPolicy.cs` → `bool CanMoveItem(IPlayer, ITile)` (consumed by the movement layer in Phase 2/3; ship the interface + a simple impl now so it's testable).
+- **Where:** as listed.
+- **Depends on:** Steps 6–10.
+- **Done-when:** `HouseFactoryTests` + the store association tests pass.
+- **Note:** `HouseFactory` references `HouseEntity` (a `NeoServer.Data` type) — confirm the domain
+  already references that assembly the way `GuildLoader`/factory paths do; if not, the factory may
+  belong in the loaders/data layer instead of `Domain`. **Resolve this boundary before coding Step 11.**
+
+### Step 13 — Test data builder + unit tests
+- **What:** `tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs` (fluent builder:
+  owner, rent, tiles, doors, beds, access lists, injected mock seams). Then the test classes under
+  `tests/NeoServer.Domain.Tests/Houses/`, one per area (full case list in the deliverable below).
+  Use `PlayerTestDataBuilder` and `EventAggregatorTestHelper.SetupEventAggregator<T>`; mock the Step-5 seams with Moq.
+  For `HouseService`, mock `IHouseRepository` and verify persistence calls.
+- **Where:** `tests/NeoServer.Domain.Tests/Houses/`
+- **Depends on:** Steps 2–12.
+- **Done-when:** all listed tests green.
+
+### Step 14 — Deliverable: `domain-tests.md`
+- **What:** Create `docs/house-system/domain-tests.md` enumerating every test with its **expected
+  output** (see template below). Keep it 1:1 with Step-13 tests.
+- **Where:** `docs/house-system/`
+- **Depends on:** Step 13.
+- **Done-when:** every implemented test appears with a matching expected-output line.
+
+### Step 15 — Close-out
+- [ ] `dotnet build` clean (no new warnings in `Houses/`).
+- [ ] `dotnet test tests/NeoServer.Domain.Tests` green.
+- [ ] Grep confirms no `Microsoft.EntityFrameworkCore` / Lua usings inside `Houses/` (except the factory's `HouseEntity` reference, if that boundary was accepted in Step 12).
+- [ ] Open PR1 with the domain + tests + `domain-tests.md` only.
+
+---
+
+## Deliverable template — `docs/house-system/domain-tests.md`
+
+Each row: **Test → Expected output**. Groups map to the Step-12 test classes.
+
+```markdown
+# House System — Domain Unit Tests (Expected Output)
+
+## HouseOwnershipTests
+- SetNewOwner_FromUnownedToPlayer_SetsOwnerGuidNameAccount → owner fields equal the supplied values.
+- SetNewOwner_WithUpdatePaidUntilTrue_SetsPaidUntilToNowPlusRentPeriod → PaidUntil == now + rentPeriod.
+- SetNewOwner_WithUpdatePaidUntilTrue_ResetsPayRentWarningsToZero → PayRentWarnings == 0.
+- SetNewOwner_ChangingOwner_ClearsGuestAndSubownerLists → both lists empty.
+- SetNewOwner_ChangingOwner_ClearsAllDoorAccessLists → every door list empty.
+- SetNewOwner_ToZeroGuid_MarksHouseUnowned → OwnerGuid == 0 and lists empty.
+- SetNewOwner_ToSameGuid_DoesNotClearLists → lists intact, no change to access/doors.
+- Note: eviction/wake/depot side effects tested in HouseServiceTests.
+
+## HouseAccessListTests
+- AddPlayer_AddsNameCaseInsensitive → IsInList true regardless of case.
+- AllowAll_MakesAnyPlayerInList → any player IsInList true.
+- AddGuild_AddsGuildId → guild member IsInList true.
+- AddGuildRank_MatchesRankLevelOrAbove → player with same/higher rank IsInList true.
+- Clear_ResetsAllEntries → IsInList false for all previously added entries.
+- IsInList_PlayerNotInList_ReturnsFalse → false.
+
+## HouseAccessLevelTests
+- GetAccessLevel_Owner_ReturnsOwner → Owner.
+- GetAccessLevel_PlayerInSubownerList_ReturnsSubOwner → SubOwner.
+- GetAccessLevel_PlayerInGuestListOnly_ReturnsGuest → Guest.
+- GetAccessLevel_PlayerInBothLists_ReturnsSubOwner → SubOwner (higher wins).
+- GetAccessLevel_UninvitedPlayer_ReturnsNotInvited → NotInvited.
+- IsInvited_GuestPlayer_ReturnsTrue → true.
+- IsInvited_UninvitedPlayer_ReturnsFalse → false.
+- CanEnter_InvitedPlayer_ReturnsTrue → true.
+- CanEnter_UninvitedPlayer_ReturnsFalse → false.
+- CanEnter_NonPlayerCreature_ReturnsFalse → false.
+- CanEditAccessList_OwnerEditsSubownerList_ReturnsTrue → true.
+- CanEditAccessList_SubownerEditsSubownerList_ReturnsFalse → false.
+- CanEditAccessList_SubownerEditsGuestList_ReturnsTrue → true.
+- CanEditAccessList_GuestEditsAnyList_ReturnsFalse → false.
+
+## HouseEvictionTests (pure aggregate checks)
+- CanKick_OwnerKicksGuest_ReturnsTrue → returns true.
+- CanKick_SubownerKicksGuest_ReturnsTrue → returns true.
+- CanKick_GuestKicksAnyone_ReturnsFalse → returns false.
+- CanKick_AnyoneKicksOwner_ReturnsFalse → returns false.
+- CanKick_TargetNotInHouse_ReturnsFalse → returns false.
+- Note: teleport side effect tested in HouseServiceTests.
+
+## HouseRentTests
+- PayRent_NotDue_ReturnsNotDue_NoDeduction → NotDue, bank unchanged.
+- PayRent_DueAndSufficientBank_DeductsRentAndAdvancesPaidUntil → Paid, bank -= rent, PaidUntil advanced.
+- PayRent_DueAndSufficientBank_ResetsWarningsToZero → warnings == 0.
+- PayRent_DueAndInsufficientBank_IncrementsWarnings → Warned, warnings += 1.
+- PayRent_SeventhWarning_ReturnsEvicted → Evicted, OwnerGuid == 0.
+- PayRent_RentZero_ReturnsNotDue → NotDue.
+- PayRent_Unowned_ReturnsNotDue → NotDue.
+- SetPayRentWarnings_AboveCap_ClampsToSeven → value == 7.
+- Note: warning/eviction events raised by HouseService, not aggregate.
+
+## HouseTileAssociationTests
+- LinkTile_SetsProtectionZoneFlag → tile.HasFlag(ProtectionZone) true.
+- LinkTile_InstallsCanEnterFunction_BlockingUninvitedPlayer → uninvited CanEnterFunction false.
+- LinkTile_CanEnterFunction_AllowsInvitedPlayer → invited CanEnterFunction true.
+- GetTileCount_AfterLinkingTiles_ReturnsCount → count matches linked tiles.
+- Store_GetByTile_ReturnsOwningHouse → returns the linked house.
+- Store_GetByTile_TileWithoutHouseId_ReturnsNull → null.
+- LinkTile_SameTileToTwoHouses_Throws → throws.
+
+## HouseDoorBedTests
+- GetDoorIdByPosition_KnownDoor_ReturnsDoorId → expected door id.
+- GetDoorIdByPosition_NoDoorAtPosition_ReturnsZeroOrNil → 0/none.
+- SetAccessList_DoorListId_UpdatesThatDoorOnly → only that door's list changes.
+- GetDoorCount_AfterLinking_ReturnsCount → count matches.
+- LinkBed_AddsBedToHouse_GetBedCountReflects → count matches.
+- SetNewOwner_WakesAllLinkedBeds → bed-waker seam called with all beds.
+
+## HouseFactoryTests
+- Create_FromEntity_MapsIdNameTownRentWarningsOwner → fields mapped from entity.
+- Create_FromEntity_SeedsGuestListFromListEntity_0x100 → guest list populated.
+- Create_FromEntity_SeedsSubownerListFromListEntity_0x101 → subowner list populated.
+- Create_FromEntity_SeedsDoorAccessListFromDoorListId → door list populated.
+- Create_UnownedEntity_ProducesUnownedHouseWithEmptyLists → OwnerGuid 0, lists empty.
+
+## HouseServiceTests
+- SetOwner_EvictsNowUninvitedPlayers → eviction seam called for each player on tiles who isn't new owner.
+- SetOwner_WakesAllBeds → bed-waker seam called with all house beds.
+- SetOwner_TransfersPickupableItemsToOldOwnerDepot → depot seam receives pickupable items from tiles.
+- SetOwner_LeavesNonPickupableItems → depot seam not called with fixed/bed/door items.
+- SetOwner_PersistsHouse → repository.Save called after aggregate updated.
+- SetOwner_RaisesHouseOwnerChangedEvent → event published for player notification.
+- PayRent_Warned_RaisesHouseRentWarningEvent → event published when PayRent returns Warned.
+- PayRent_Evicted_RaisesHouseEvictedEvent → event published when PayRent returns Evicted.
+- PayRent_Paid_PersistsHouseState → repository.Save called.
+- CanKick_Success_TeleportsTargetAndPersists → eviction seam called + repository.Save.
+- CanKick_Failure_NoSideEffects → no eviction or persist called.
+```
+
+---
+
+## Risks specific to Phase 1
+1. **Domain ↔ `HouseEntity` boundary** (Step 12) — if `Domain` shouldn't reference `NeoServer.Data`, move `HouseFactory` to the data/loaders layer and keep `Domain` clean. Decide before coding.
+2. **Bed/Door item APIs** may not expose sleeper/wakeup or door-id today — fall back to the Step-5 seams and finish real integration in Phase 2.
+3. **Clock determinism** — never read `DateTime.UtcNow` inside the aggregate; pass `now` in so rent/owner tests are deterministic.
+4. **Depot transfer for offline owner** is only *simulated* via a mock in Phase 1; the real town-depot lookup lands in Phase 2.
+5. **Repository interface in domain** — `IHouseRepository` lives in `NeoServer.Domain.Repositories` (same as `IPlayerMailRepository`). Confirm no EF dependency leaks through it.
+```

--- a/docs/house-system/review-fixes-spec.md
+++ b/docs/house-system/review-fixes-spec.md
@@ -1,0 +1,484 @@
+# House System Phase 1 — Code-Review Fix Spec
+
+> Executable spec for resolving the code-review findings on commit `a1d37fd55`
+> (branch `cvidal/house-system`). Companion to `House-System-Plan.md`,
+> `house-phase1-steps.md`, and `domain-tests.md`.
+>
+> **Scope rule:** Phase 1 stays pure domain — no EF, no Lua, no map loading.
+> The `House` aggregate stays pure (no I/O, clock passed in). Every change below
+> respects those boundaries.
+>
+> **Hard definition of done (whole spec):**
+> `dotnet test tests/NeoServer.Domain.Tests` runs **to completion** (no host
+> crash / "Test Run Aborted") and is **green**. Today the run aborts with a
+> StackOverflow — see C1.
+
+All file/line references below were verified against the working tree at the time
+of writing.
+
+---
+
+## Verified ground truth (read before editing)
+
+- `src/Core/NeoServer.Domain/Common/Location/Structs/Location.cs`
+  - `Equals(object obj)` at **line 403–406** is self-recursive: `obj is Location && Equals(obj)`
+    re-dispatches to `Equals(object)` (static type of `obj` is `object`), not to
+    `Equals(Location)`. Infinite recursion → StackOverflow (uncatchable, crashes host).
+  - `operator ==` at **line 100–110** and `operator !=` at **line 112–122** each wrap a
+    field comparison in `try { ... } catch (NullReferenceException) { return false; }`.
+    `Location` is a `struct` — its fields are value types — so the body cannot throw
+    `NullReferenceException`. The catch is dead code.
+  - `Equals(Location obj)` at **line 90–93** delegates to `operator ==` and is correct.
+  - This buggy `Equals(object)` shape exists **only** in `Location.cs` (grep confirmed).
+- `src/Core/NeoServer.Domain/Houses/House.cs`
+  - `LinkTile(IDynamicTile)` at **line 41–51**: adds tile, sets `CanEnterFunction`,
+    defaults `EntryPosition`. Does **not** set `TileFlags.ProtectionZone`.
+  - The only duplicate guard is `_tiles.Contains(tile)` at **line 43** — same-instance,
+    same-house only. No cross-house detection.
+  - `PayRent(IPlayer, ICoinTypeStore coinTypeStore, DateTime, uint)` at **line 159**:
+    `coinTypeStore` is never read; rent is taken via `owner.Bank.Debit(Rent)` at line 167.
+- `src/Core/NeoServer.Domain/Houses/HouseItemMovementPolicy.cs` **line 9–15**:
+  `CanMoveItem` has dead null-guards and unconditionally `return true`.
+- `src/Core/NeoServer.Domain/Houses/Services/HouseService.cs` **line 72–85** and
+  `IHouseService.cs` **line 13**: `PayRent` carries the same unused `coinTypeStore`.
+- Tile flag plumbing:
+  - `IDynamicTile` (`...Common/Contracts/World/Tiles/IDynamicTile.cs`) has **no** `HouseId`
+    and **no** flag-mutation member.
+  - `ITile` (`...Common/Contracts/World/Tiles/ITile.cs`) exposes `bool HasFlag(TileFlags)`
+    (line 33) and a read-only `bool ProtectionZone` getter (line 17).
+  - `BaseTile` (`...World/Models/Tiles/BaseTile.cs`) has `public bool HasFlag(TileFlags)`
+    (line 42) but `protected void SetFlag(TileFlags)` / `RemoveFlag` (line 80, 85).
+  - `DynamicTile` (`...World/Models/Tiles/DynamicTile.cs`) holds `uint? HouseId { get; private set; }`
+    (line 36). `HouseStore.GetByTile` already reads `(tile as DynamicTile)?.HouseId`
+    (`src/Database/NeoServer.Data.InMemory.DataStores/HouseStore.cs:15`).
+- `HouseTestDataBuilder.CreateTileMock` (`tests/.../Helpers/House/HouseTestDataBuilder.cs:75`)
+  sets up `HasFlag` → `false` and `SetupProperty(CanEnterFunction)`; it does **not** set up
+  any flag-setter. The builder is the seam to extend for M1/M2 tests.
+
+---
+
+## Execution order
+
+C1 is a host-crash and blocks the entire suite — **do it first and confirm the full
+suite completes before touching anything else.** Then M1, M2, m1, m2; finish with the
+doc reconciliation (m3) and the Phase-3 note (m4).
+
+| Phase | Issue | Title | Blocks |
+|-------|-------|-------|--------|
+| 1 | C1 | Fix `Location.Equals(object)` recursion (StackOverflow) | everything |
+| 2 | M1 | Set `ProtectionZone` flag in `LinkTile` | — |
+| 2 | M2 | Detect tile already owned by another house | — |
+| 3 | m1 | Implement `HouseItemMovementPolicy` invited-check | — |
+| 3 | m2 | Resolve unused `ICoinTypeStore` in rent path | — |
+| 4 | m3 | Reconcile `domain-tests.md` with landed changes | C1, M1, M2 |
+| 4 | m4 | `GetDoorIdByPosition` decision (Phase-3 dependency) | — |
+
+---
+
+## Phase 1 — C1: `Location.Equals(object)` infinite recursion (CRITICAL, blocks suite)
+
+**What:** Fix the self-recursive `Equals(object)` override so boxed/object-path
+equality (used by FluentAssertions `.Be()`, `Assert.Equal`, dictionary/set keys, etc.)
+works instead of overflowing the stack. Clean the dead `NullReferenceException`
+catches while in the file.
+
+**Where:** `src/Core/NeoServer.Domain/Common/Location/Structs/Location.cs`
+- `Equals(object)` line 403–406 (the bug).
+- `operator ==` line 100–110 and `operator !=` line 112–122 (dead catches).
+
+**Root cause:** `obj is Location && Equals(obj)` — the second operand binds to the
+`Equals(object)` overload (static type of `obj` is still `object`), so the method calls
+itself forever. The new test `HouseDoorBedTests.EntryPosition_DefaultsToFirstTileLocation`
+is the first to box a `Location` through `.Be()`, which routes through `object.Equals`,
+exposing the latent bug and aborting the run after ~54 tests.
+
+**Fix:**
+1. Replace the override body so it pattern-matches into the typed overload:
+   ```csharp
+   public override bool Equals(object obj)
+   {
+       return obj is Location other && Equals(other);
+   }
+   ```
+   `Equals(other)` now binds to `Equals(Location)` (line 90), which uses `operator ==`.
+2. Remove the dead `try/catch (NullReferenceException)` in `operator ==` (line 100–110)
+   and `operator !=` (line 112–122); keep the plain field comparisons:
+   ```csharp
+   public static bool operator ==(Location origin, Location targetLocation)
+       => origin.X == targetLocation.X && origin.Y == targetLocation.Y && origin.Z == targetLocation.Z;
+
+   public static bool operator !=(Location origin, Location targetLocation)
+       => !(origin == targetLocation);
+   ```
+   (Define `!=` in terms of `==` so the two operators cannot drift apart.)
+3. Do not change `GetHashCode` (line 95–98) — it already hashes `X,Y,Z` consistently
+   with the corrected equality.
+
+**Confirm no code depends on the buggy behavior:**
+- Grep for any caller that relied on `Location.Equals(object)` returning a wrong/recursive
+  result — none can exist, since calling it crashed the process. The pre-fix `operator ==`
+  semantics (field comparison) are unchanged by this fix, so equality results for code
+  already using `==`/`!=`/`Equals(Location)` are identical; only the previously-fatal
+  `object` path changes from "crash" to "correct".
+- The `!=` rewrite changes the default-struct edge only if `==` and the old hand-written
+  `!=` disagreed; they did not (both are field comparisons). No behavior change for
+  callers.
+
+**Test cases** (new file `tests/NeoServer.Domain.Tests/Common/Structs/LocationEqualityTests.cs`,
+or append to existing `LocationTest.cs`):
+- `Equals_BoxedEqualLocation_ReturnsTrue` → `((object)new Location(1,2,3)).Equals(new Location(1,2,3))` is `true` (and does not overflow).
+- `Equals_BoxedDifferentLocation_ReturnsFalse` → boxed compare of `(1,2,3)` vs `(1,2,4)` is `false`.
+- `Equals_BoxedNonLocation_ReturnsFalse` → `((object)new Location(1,2,3)).Equals("not a location")` is `false`.
+- `Equals_TypedOverload_MatchesOperator` → `loc.Equals(other) == (loc == other)` for equal and unequal pairs.
+- `Be_ViaFluentAssertions_DoesNotOverflow` → `new Location(1,2,3).Should().Be(new Location(1,2,3))` passes (regression guard for the exact crash path).
+- `GetHashCode_EqualLocations_AreEqual` → equal locations share a hash code.
+- `OperatorEquality_And_Inequality_AreConsistent` → for equal and unequal pairs, `(a == b) == !(a != b)`.
+
+**Done-when:**
+- The new equality tests pass.
+- `dotnet test tests/NeoServer.Domain.Tests` runs **to completion** (no "Test Run Aborted")
+  and is green. This is the gate for the whole spec — re-run the **full** suite, not just
+  the `Houses` filter, after this fix.
+
+---
+
+## Phase 2 — M1: `LinkTile` must set `TileFlags.ProtectionZone` (MAJOR)
+
+**What:** Per Plan decision #1 and Step 6, `House.LinkTile` must mark the tile a
+protection zone at attach time. Restore the dropped acceptance test
+`LinkTile_SetsProtectionZoneFlag`.
+
+**Where:**
+- `src/Core/NeoServer.Domain/Houses/House.cs` `LinkTile` (line 41–51).
+- Tile contract/impl (see decision below).
+- `tests/NeoServer.Domain.Tests/Houses/HouseTileAssociationTests.cs`.
+- `tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs` (`CreateTileMock`).
+
+**Root cause:** `LinkTile` only sets `CanEnterFunction` + `EntryPosition`. The flag was
+never wired because the aggregate sees only `IDynamicTile`, which has no flag-setter, and
+`BaseTile.SetFlag` is `protected`.
+
+**Decision — adopt option (a): expose a narrow flag-setting member on `IDynamicTile`.**
+Rationale: the aggregate already mutates tile state through the interface
+(`CanEnterFunction`), the world-attach (Phase 2) calls `LinkTile` on the same interface,
+and the change is small and low-risk. Option (b) (defer to Phase 2 with a TODO) is the
+fallback only if the team rejects widening the interface.
+
+**Fix (option a):**
+1. Add a minimal, explicit member to `IDynamicTile`
+   (`...Common/Contracts/World/Tiles/IDynamicTile.cs`). Prefer a purpose-named method over
+   exposing raw flag arithmetic, to keep the interface intent-revealing:
+   ```csharp
+   void SetAsProtectionZone();
+   ```
+   (Alternative if the team prefers symmetry with `HasFlag`: `void SetFlag(TileFlags flag);`
+   — but that widens the surface more than needed. Pick one and use it consistently.)
+2. Implement it on the concrete tile. `SetFlag` is already `protected` on `BaseTile`
+   (line 80); add the public wrapper on `DynamicTile`
+   (`...World/Models/Tiles/DynamicTile.cs`):
+   ```csharp
+   public void SetAsProtectionZone() => SetFlag(TileFlags.ProtectionZone);
+   ```
+   Do not change `BaseTile.SetFlag`'s `protected` visibility.
+3. In `House.LinkTile`, after adding the tile and before/after installing
+   `CanEnterFunction`, call `tile.SetAsProtectionZone();`. Keep it idempotent
+   (`SetFlag` ORs the bit, so re-linking is harmless).
+4. Update `HouseTestDataBuilder.CreateTileMock` so `SetAsProtectionZone` flips the
+   mocked `HasFlag(TileFlags.ProtectionZone)` to return `true` after it is called
+   (e.g. back the mock with a local bool the `HasFlag` setup reads, or
+   `tileMock.Setup(x => x.SetAsProtectionZone()).Callback(...)`). Keep the existing
+   default `HasFlag → false` for all other flags.
+
+**Test cases** (`HouseTileAssociationTests`):
+- `LinkTile_SetsProtectionZoneFlag` → after `LinkTile`, `tile.HasFlag(TileFlags.ProtectionZone)` is `true` (verify the member was invoked on the mock and the simulated flag reads true).
+- Keep existing `LinkTile_InstallsCanEnterFunction_*` tests green (no regression).
+
+**Done-when:**
+- `LinkTile_SetsProtectionZoneFlag` passes.
+- `domain-tests.md` re-lists the case under `HouseTileAssociationTests` (see m3).
+- No EF/Lua reference added to `Houses/`.
+
+---
+
+## Phase 2 — M2: `LinkTile` must reject a tile already owned by another house (MAJOR)
+
+**What:** Honor the plan rule "throw if a tile is linked to two houses." Real
+cross-house detection, plus a correctly-named test that actually covers the cross-house
+case.
+
+**Where:**
+- `src/Core/NeoServer.Domain/Houses/House.cs` `LinkTile` (line 41–51).
+- `tests/NeoServer.Domain.Tests/Houses/HouseTileAssociationTests.cs` (`LinkTile_SameTileToTwoHouses_Throws`, line 60–69 — currently mis-named/mis-scoped).
+- `tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs` if a tile-owner seam is needed.
+
+**Root cause:** `LinkTile` only checks `_tiles.Contains(tile)` (line 43), which detects
+the **same** `House` instance re-linking the **same** tile. Two different `House` objects
+can each link the same tile silently. The existing test links one tile to **one** house
+twice, so it never exercises the cross-house path.
+
+**Fix — detect ownership by a different house.** The aggregate sees only `IDynamicTile`,
+which currently exposes no `HouseId`. Two viable detectors; pick **(A)** as primary:
+
+- **(A) CanEnterFunction already installed.** `LinkTile` installs a `CanEnterFunction`
+  closure on every tile it links and it is the only code path that does so for houses.
+  So: if `tile.CanEnterFunction is not null` when a **different** house links it, that tile
+  is already owned. Combine with the existing same-instance guard:
+  ```csharp
+  public void LinkTile(IDynamicTile tile)
+  {
+      if (_tiles.Contains(tile))
+          throw new InvalidOperationException("Tile already belongs to this house.");
+
+      if (tile.CanEnterFunction is not null)
+          throw new InvalidOperationException("Tile already belongs to another house.");
+
+      _tiles.Add(tile);
+      tile.SetAsProtectionZone();              // M1
+      tile.CanEnterFunction = c => c is IPlayer p && GetAccessLevel(p) != HouseAccessLevel.NotInvited;
+
+      if (EntryPosition is null)
+          EntryPosition = tile.Location;
+  }
+  ```
+  This works without widening `IDynamicTile` for `HouseId`. Caveat to document: any
+  non-house feature that sets `CanEnterFunction` on a tile would also trip this; grep
+  confirms house linking is the writer in the domain, and the Phase-2 world-attach only
+  calls `CanEnterFunction` via `LinkTile`. Note this assumption in code comment + plan.
+
+- **(B) HouseId mismatch (stronger, needs interface widening).** Add `uint? HouseId { get; }`
+  to `IDynamicTile` (it already exists on `DynamicTile` with a private setter, line 36) and
+  throw when `tile.HouseId` is set to a **different** house id than `this.Id`. This is the
+  most semantically precise check, but the OTBM tile carries its own `HouseId` from the map
+  while `House.Id` comes from the DB; in Phase 1 these are decoupled, so id-equality cannot
+  be relied on yet. **Defer (B) to Phase 2** when world-attach reconciles map `HouseId`
+  with DB house id; record it as a TODO in the plan.
+
+  > **Decision:** implement **(A)** now (no interface change, no EF). Leave a code comment
+  > and a plan note that Phase-2 attach should upgrade to the `HouseId`-based check (B)
+  > once map↔DB house ids are reconciled.
+
+**Test changes** (`HouseTileAssociationTests`):
+- **Rename/rescope** `LinkTile_SameTileToTwoHouses_Throws` to two distinct tests:
+  - `LinkTile_SameTileToSameHouseTwice_Throws` → the existing same-instance behavior
+    (link one tile to one house twice → `InvalidOperationException`). Keep coverage.
+  - `LinkTile_SameTileToTwoDifferentHouses_Throws` → build two distinct `House` objects;
+    `houseA.LinkTile(tile)` then `houseB.LinkTile(tile)` throws `InvalidOperationException`.
+    Use a `CreateTileMock` whose `CanEnterFunction` is a real settable property
+    (the builder already does `SetupProperty(x => x.CanEnterFunction)`, so once house A
+    sets it the mock returns non-null for house B).
+
+**Done-when:**
+- Both cross-house and same-house tests pass.
+- `domain-tests.md` reflects the two cases (see m3).
+- No EF/Lua reference added to `Houses/`.
+
+---
+
+## Phase 3 — m1: Implement `HouseItemMovementPolicy` invited-check (MINOR)
+
+**What:** Replace the no-op stub with the documented invited-only movement rule, using
+the pieces that already exist (`IHouseStore.GetByTile`, `house.IsInvited`). Add tests.
+
+**Where:**
+- `src/Core/NeoServer.Domain/Houses/HouseItemMovementPolicy.cs` (line 9–15).
+- `tests/NeoServer.Domain.Tests/Houses/` — new `HouseItemMovementPolicyTests.cs`.
+
+**Root cause:** The stub unconditionally returns `true`; its XML doc promises invited-only
+movement but no logic exists and there is no test.
+
+**Fix:**
+1. Inject `IHouseStore` into the policy:
+   ```csharp
+   public class HouseItemMovementPolicy(IHouseStore houseStore) : IHouseItemMovementPolicy
+   {
+       public bool CanMoveItem(IPlayer player, ITile tile)
+       {
+           if (tile is null) return true;            // no tile context → don't block
+
+           var house = houseStore.GetByTile(tile);
+           if (house is null) return true;           // not a house tile → unrestricted
+
+           if (player is null) return false;         // house tile requires an acting player
+           return house.IsInvited(player);
+       }
+   }
+   ```
+   - `IHouseStore` is a domain contract (`...Common/Contracts/DataStores/IHouseStore.cs`),
+     so no EF leaks into `Houses/`.
+   - `GetByTile` already returns `null` for non-house tiles (reads
+     `(tile as DynamicTile)?.HouseId`), so the policy naturally no-ops off house tiles.
+2. Update the XML doc to describe the real behavior (invited players may move items on
+   house tiles; non-house tiles unrestricted; null player blocked on a house tile).
+3. Confirm DI: register `IHouseItemMovementPolicy → HouseItemMovementPolicy` in the
+   appropriate module if not already (Phase-1 may only ship the impl + interface; if the
+   policy is not yet DI-registered, leave registration to the movement-layer wiring in
+   Phase 2/3 and note it). Do **not** wire it into movement commands in Phase 1.
+
+**Test cases** (`HouseItemMovementPolicyTests`, Moq `IHouseStore`):
+- `CanMoveItem_NonHouseTile_ReturnsTrue` → `GetByTile` returns null → `true` for any player.
+- `CanMoveItem_HouseTile_InvitedPlayer_ReturnsTrue` → store returns a house where `IsInvited(player)` is true → `true`.
+- `CanMoveItem_HouseTile_UninvitedPlayer_ReturnsFalse` → store returns a house where `IsInvited` is false → `false`.
+- `CanMoveItem_HouseTile_NullPlayer_ReturnsFalse` → house tile + null player → `false`.
+- `CanMoveItem_NullTile_ReturnsTrue` → `true` (no tile context).
+
+**Done-when:**
+- All policy tests pass; the stub no longer unconditionally returns `true`.
+- `domain-tests.md` gains a `HouseItemMovementPolicyTests` group (see m3).
+- No EF/Lua reference in `Houses/`.
+
+---
+
+## Phase 3 — m2: Resolve the unused `ICoinTypeStore` in the rent path (MINOR)
+
+**What:** Decide whether rent needs a coin source. It does not today — rent is debited
+via `owner.Bank.Debit(Rent)`. Drop the unused parameter from both signatures, **or**
+wire it if the team confirms Phase-3 rent must consume specific coin types.
+
+**Where:**
+- `src/Core/NeoServer.Domain/Houses/House.cs` `PayRent` (line 159, param unused; debit at line 167).
+- `src/Core/NeoServer.Domain/Houses/Services/HouseService.cs` `PayRent` (line 72–85).
+- `src/Core/NeoServer.Domain/Houses/Services/IHouseService.cs` (line 13).
+- `tests/NeoServer.Domain.Tests/Houses/HouseRentTests.cs` and `HouseServiceTests.cs`
+  (callers pass the arg today).
+
+**Root cause:** `ICoinTypeStore coinTypeStore` was threaded through the rent API but the
+implementation takes rent from the bank balance, so the parameter is dead.
+
+**Decision — drop it (recommended).** The Phase-3 Lua/rent design (Plan §Phase 3,
+`getPaidUntil`/`setPaidUntil`, bank-based rent) collects rent from the player's **bank
+balance**, mirroring forgottenserver `payHouses`, with no coin-store lookup. Removing the
+parameter now keeps the aggregate minimal and the signatures honest.
+
+**Fix:**
+1. Remove `ICoinTypeStore coinTypeStore` from:
+   - `House.PayRent(IPlayer owner, DateTime now, uint rentPeriodSeconds)`.
+   - `IHouseService.PayRent(House, IPlayer owner, DateTime now, uint rentPeriodSeconds)`.
+   - `HouseService.PayRent(...)` (drop the field/forwarding).
+2. Update all callers in the tests to the new signature.
+3. Leave a one-line note in the plan (`House-System-Plan.md` Phase-1 PayRent bullet and
+   Phase-3 rent section) that rent is bank-balance based and a coin-store was intentionally
+   removed; if a future phase needs coin-specific rent, re-introduce it at the service
+   layer, not the aggregate.
+
+> **If the team instead wants coin-aware rent:** keep the parameter but actually use it in
+> `House.PayRent` (resolve the coin type, debit from coins, fall back to bank), and add a
+> `PayRent_UsesCoinTypeStore_*` test. Default to the drop unless explicitly told otherwise.
+
+**Test cases:**
+- Existing `HouseRentTests` / `HouseServiceTests` updated to the new signature — all
+  previously-listed rent cases still pass unchanged in behavior.
+
+**Done-when:**
+- No `ICoinTypeStore` reference remains in the house rent path (grep clean).
+- `dotnet test tests/NeoServer.Domain.Tests` green.
+
+---
+
+## Phase 4 — m3: Reconcile `domain-tests.md` with the landed changes (MINOR)
+
+**What:** Bring `docs/house-system/domain-tests.md` back in step with the plan and with
+whatever M1/M2/m1/m2/m4 decisions land. Annotate intentionally-deferred cases instead of
+silently dropping them.
+
+**Where:** `docs/house-system/domain-tests.md`.
+
+**Root cause:** The committed doc was trimmed to match the code, dropping planned cases
+(`LinkTile_SetsProtectionZoneFlag`, `GetDoorIdByPosition_*`, factory list-seeding,
+`SetNewOwner_WakesAllLinkedBeds`) without marking which were legitimately moved (to
+Phase 2 / `HouseServiceTests`) versus accidentally lost.
+
+**Fix:** Edit `domain-tests.md` so it is 1:1 with the implemented Phase-1 tests after this
+spec, and add an explicit **"Deferred to Phase 2/3"** sub-section listing moved cases with
+their target:
+- Add back under `HouseTileAssociationTests`:
+  - `LinkTile_SetsProtectionZoneFlag` (M1, now implemented).
+  - `LinkTile_SameTileToSameHouseTwice_Throws` and
+    `LinkTile_SameTileToTwoDifferentHouses_Throws` (M2, replace the old mis-named entry).
+- Add a `HouseItemMovementPolicyTests` group (m1) with its five cases.
+- Update the `HouseRentTests` / `HouseServiceTests` rows if the `PayRent` signature changed
+  (m2) — wording only, behavior identical.
+- Add a **Deferred** block, e.g.:
+  - `GetDoorIdByPosition_*` → deferred to Phase 3 (Lua `getDoorIdByPosition`); see m4.
+  - factory door/list seeding (`Create_FromEntity_SeedsGuestList/SubownerList/DoorList_*`)
+    → deferred to Phase 2 `HouseAccessListLoader` (factory creates empty lists in Phase 1).
+  - `SetNewOwner_WakesAllLinkedBeds` → covered by `HouseServiceTests.SetOwner_WakesAllBeds`
+    (the wake side effect lives in the service, not the aggregate) — cross-reference it.
+
+**Done-when:**
+- Every implemented Phase-1 test appears in `domain-tests.md` with an expected-output line.
+- Every plan-listed case that is *not* implemented appears under a clearly-labelled
+  Deferred section with its Phase-2/3 target. No silent omissions.
+
+---
+
+## Phase 4 — m4: `GetDoorIdByPosition` (MINOR, Phase-3 dependency)
+
+**What:** Decide whether to add the position→door-id lookup now or formally defer it.
+
+**Where:** `src/Core/NeoServer.Domain/Houses/House.cs` (doors keyed by door id in `_doors`,
+line 14); plan reference Phase 3 Lua `getDoorIdByPosition`.
+
+**Root cause:** Doors are stored as `Dictionary<uint doorId, IItem>` with no reverse
+position index; the plan lists `GetDoorIdByPosition` but it was never implemented and the
+test was dropped.
+
+**Decision — defer to Phase 3, document the dependency.** A position→id lookup requires a
+door item's tile/location, which is a world-attach concern (doors get their `Location` when
+linked from the map in Phase 2). Implementing it meaningfully in pure Phase-1 would require
+either storing a `Location` per door at link time or scanning items — premature before the
+attach step exists.
+
+**Fix (defer):**
+1. In `House-System-Plan.md` (Phase 3, `HouseFunctions` `getDoorIdByPosition`) and in the
+   m3 Deferred block, record that `GetDoorIdByPosition` is a **Phase-3 dependency** blocked
+   on Phase-2 door-location linkage.
+2. Optionally, if low-risk and desired now: have `LinkDoor(uint doorId, IItem door)` also
+   capture the door's position into a `Dictionary<Location, uint>` reverse map and expose
+   `uint GetDoorIdByPosition(Location position)` returning `0` when absent — **only** if the
+   door item already carries a usable `Location` in Phase 1 (verify before committing; if
+   not, defer per (1)). Add `GetDoorIdByPosition_KnownDoor_ReturnsDoorId` and
+   `GetDoorIdByPosition_NoDoorAtPosition_ReturnsZero` tests if implemented.
+
+> **Default:** defer (1). Only do (2) if a door's `Location` is reliably available in
+> Phase-1 mocks/tests.
+
+**Done-when:**
+- The deferral (or implementation) is recorded in the plan and `domain-tests.md`.
+- If implemented, the two lookup tests pass.
+
+---
+
+## Verification checklist (run in order)
+
+1. **C1 gate (must pass before anything else is considered done):**
+   `dotnet test tests/NeoServer.Domain.Tests`
+   - Run completes — **no** "Test Run Aborted" / StackOverflow.
+   - All tests green, including `LocationEqualityTests` and
+     `HouseDoorBedTests.EntryPosition_DefaultsToFirstTileLocation`.
+2. **Build:** `dotnet build` clean; no new warnings in `Houses/` or `Location.cs`.
+3. **M1:** `HouseTileAssociationTests.LinkTile_SetsProtectionZoneFlag` green.
+4. **M2:** `LinkTile_SameTileToSameHouseTwice_Throws` and
+   `LinkTile_SameTileToTwoDifferentHouses_Throws` green.
+5. **m1:** `HouseItemMovementPolicyTests` (5 cases) green.
+6. **m2:** grep confirms no `ICoinTypeStore` in the house rent path; rent tests green.
+7. **EF/Lua boundary:** grep `Houses/` for `Microsoft.EntityFrameworkCore` / Lua usings —
+   none (factory's `HouseEntity` reference excepted per existing Phase-1 boundary).
+8. **Docs:** `domain-tests.md` is 1:1 with implemented tests; Deferred section lists
+   m4 + factory-seeding + bed-wake with targets.
+9. **Full suite, final:** `dotnet test tests/NeoServer.Domain.Tests` green and complete.
+
+## Risks
+
+1. **C1 host-crash masking other failures.** Until C1 lands, the suite cannot report
+   downstream results — do C1 first and re-run the full suite before evaluating M1/M2.
+2. **M1 interface widening.** Adding `SetAsProtectionZone` to `IDynamicTile` touches a core
+   contract; ensure all `IDynamicTile` mocks across the test suite still compile (Moq
+   tolerates un-setup members, but compile-time the interface change is global). Grep for
+   `Mock<IDynamicTile>` usages.
+3. **M2 detector (A) false positives.** Relying on `CanEnterFunction != null` assumes house
+   linking is the sole writer of that closure. Verified true in the domain today; document
+   the assumption and upgrade to the `HouseId`-based check in Phase 2.
+4. **m1 DI timing.** The policy gains an `IHouseStore` dependency; if registered now it must
+   resolve `IHouseStore`. Keep movement-layer wiring out of Phase 1.
+5. **m2 signature churn.** Dropping the parameter touches the aggregate, service, interface,
+   and two test classes — update all in one change to keep the build green.

--- a/src/Core/NeoServer.Domain/Common/Contracts/DataStores/IHouseStore.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/DataStores/IHouseStore.cs
@@ -1,0 +1,10 @@
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Houses;
+
+namespace NeoServer.Domain.Common.Contracts.DataStores;
+
+public interface IHouseStore : IDataStore<uint, House>
+{
+    House GetByTile(ITile tile);
+    House GetByHouseId(uint houseId);
+}

--- a/src/Core/NeoServer.Domain/Common/Contracts/World/Tiles/IDynamicTile.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/World/Tiles/IDynamicTile.cs
@@ -53,4 +53,7 @@ public interface IDynamicTile : ITile, IHasItem
     /// </summary>
     /// <param name="item">The item to add, which will replace any existing items of the same group.</param>
     void ReplaceItemByGroup(IItem item);
+
+    /// <summary>Marks this tile as a protection zone. Called by <see cref="Houses.House.LinkTile"/> at attach time.</summary>
+    void SetAsProtectionZone();
 }

--- a/src/Core/NeoServer.Domain/Common/GameConfiguration.cs
+++ b/src/Core/NeoServer.Domain/Common/GameConfiguration.cs
@@ -16,7 +16,8 @@ public record GameConfiguration(
     PvPConfiguration PvP = null,
     CombatConfiguration Combat = null,
     ReportConfiguration Report = null,
-    YellConfiguration Yell = null
+    YellConfiguration Yell = null,
+    HouseConfiguration House = null
 );
 
 public record CombatConfiguration(
@@ -49,3 +50,5 @@ public record PvPConfiguration(
 public record YellConfiguration(int YellCooldownSeconds = 30, int YellMinimumLevel = 2, bool YellAllowedPremium = true);
 
 public record ReportConfiguration(uint ReportMaxTime = 60);
+
+public record HouseConfiguration(bool TransferItemsToDepotOnOwnershipChange = true);

--- a/src/Core/NeoServer.Domain/Common/Location/Structs/Location.cs
+++ b/src/Core/NeoServer.Domain/Common/Location/Structs/Location.cs
@@ -98,28 +98,10 @@ public struct Location(ushort x, ushort y, byte z) : IEquatable<Location>, IConv
     }
 
     public static bool operator ==(Location origin, Location targetLocation)
-    {
-        try
-        {
-            return origin.X == targetLocation.X && origin.Y == targetLocation.Y && origin.Z == targetLocation.Z;
-        }
-        catch (NullReferenceException)
-        {
-            return false;
-        }
-    }
+        => origin.X == targetLocation.X && origin.Y == targetLocation.Y && origin.Z == targetLocation.Z;
 
     public static bool operator !=(Location origin, Location targetLocation)
-    {
-        try
-        {
-            return origin.X != targetLocation.X || origin.Y != targetLocation.Y || origin.Z != targetLocation.Z;
-        }
-        catch (NullReferenceException)
-        {
-            return false;
-        }
-    }
+        => !(origin == targetLocation);
 
     public static bool operator >(Location first, Location second)
     {
@@ -402,7 +384,7 @@ public struct Location(ushort x, ushort y, byte z) : IEquatable<Location>, IConv
 
     public override bool Equals(object obj)
     {
-        return obj is Location && Equals(obj);
+        return obj is Location other && Equals(other);
     }
 
     public Coordinate Translate()

--- a/src/Core/NeoServer.Domain/Houses/AccessList/HouseAccessList.cs
+++ b/src/Core/NeoServer.Domain/Houses/AccessList/HouseAccessList.cs
@@ -12,7 +12,7 @@ public class HouseAccessList
     private readonly HashSet<string> _playerNames = new(StringComparer.OrdinalIgnoreCase);
     private readonly HashSet<ushort> _guildIds = new();
     private readonly List<(ushort GuildId, byte RankLevel)> _guildRanks = new();
-    private bool _wildcard;
+    private bool _allowEveryone;
 
     /// <summary>Let this player enter.</summary>
     public void AddPlayer(string name)
@@ -33,9 +33,9 @@ public class HouseAccessList
     }
 
     /// <summary>Open the house to everyone.</summary>
-    public void AllowAll()
+    public void AllowEveryone()
     {
-        _wildcard = true;
+        _allowEveryone = true;
     }
 
     /// <summary>Remove all entries. House becomes locked to everyone.</summary>
@@ -44,13 +44,13 @@ public class HouseAccessList
         _playerNames.Clear();
         _guildIds.Clear();
         _guildRanks.Clear();
-        _wildcard = false;
+        _allowEveryone = false;
     }
 
     /// <summary>Check if this player is on the access list.</summary>
     public bool IsInList(IPlayer player)
     {
-        if (_wildcard) return true;
+        if (_allowEveryone) return true;
 
         if (_playerNames.Contains(player.Name)) return true;
 

--- a/src/Core/NeoServer.Domain/Houses/AccessList/HouseAccessList.cs
+++ b/src/Core/NeoServer.Domain/Houses/AccessList/HouseAccessList.cs
@@ -1,0 +1,69 @@
+using NeoServer.Domain.Common.Contracts.Creatures;
+
+namespace NeoServer.Domain.Houses.AccessList;
+
+/// <summary>
+/// Who may enter the house. Lists invited players, guilds,
+/// guild ranks, or allows everyone. Each house door and access
+/// list (guest, sub-owner) has its own instance.
+/// </summary>
+public class HouseAccessList
+{
+    private readonly HashSet<string> _playerNames = new(StringComparer.OrdinalIgnoreCase);
+    private readonly HashSet<ushort> _guildIds = new();
+    private readonly List<(ushort GuildId, byte RankLevel)> _guildRanks = new();
+    private bool _wildcard;
+
+    /// <summary>Let this player enter.</summary>
+    public void AddPlayer(string name)
+    {
+        _playerNames.Add(name);
+    }
+
+    /// <summary>Let all members of this guild enter.</summary>
+    public void AddGuild(ushort guildId)
+    {
+        _guildIds.Add(guildId);
+    }
+
+    /// <summary>Let guild members at or above this rank enter.</summary>
+    public void AddGuildRank(ushort guildId, byte rankLevel)
+    {
+        _guildRanks.Add((guildId, rankLevel));
+    }
+
+    /// <summary>Open the house to everyone.</summary>
+    public void AllowAll()
+    {
+        _wildcard = true;
+    }
+
+    /// <summary>Remove all entries. House becomes locked to everyone.</summary>
+    public void Clear()
+    {
+        _playerNames.Clear();
+        _guildIds.Clear();
+        _guildRanks.Clear();
+        _wildcard = false;
+    }
+
+    /// <summary>Check if this player is on the access list.</summary>
+    public bool IsInList(IPlayer player)
+    {
+        if (_wildcard) return true;
+
+        if (_playerNames.Contains(player.Name)) return true;
+
+        if (player.HasGuild)
+        {
+            if (_guildIds.Contains(player.GuildId)) return true;
+
+            if (player.GuildRank is not null)
+            {
+                return _guildRanks.Any(r => r.GuildId == player.GuildId && player.GuildRank.Level >= r.RankLevel);
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Core/NeoServer.Domain/Houses/Events/HouseEvictedEvent.cs
+++ b/src/Core/NeoServer.Domain/Houses/Events/HouseEvictedEvent.cs
@@ -1,0 +1,6 @@
+using NeoServer.Domain.Common;
+
+namespace NeoServer.Domain.Houses.Events;
+
+/// <summary>Raised when a house is evicted after 7 unpaid rent warnings.</summary>
+public record HouseEvictedEvent(House House) : IEvent;

--- a/src/Core/NeoServer.Domain/Houses/Events/HouseOwnerChangedEvent.cs
+++ b/src/Core/NeoServer.Domain/Houses/Events/HouseOwnerChangedEvent.cs
@@ -1,0 +1,6 @@
+using NeoServer.Domain.Common;
+
+namespace NeoServer.Domain.Houses.Events;
+
+/// <summary>Raised when a house gains or loses an owner.</summary>
+public record HouseOwnerChangedEvent(House House, uint OldOwnerGuid, uint NewOwnerGuid) : IEvent;

--- a/src/Core/NeoServer.Domain/Houses/Events/HouseRentWarningEvent.cs
+++ b/src/Core/NeoServer.Domain/Houses/Events/HouseRentWarningEvent.cs
@@ -1,0 +1,7 @@
+using NeoServer.Domain.Common;
+using NeoServer.Domain.Common.Contracts.Creatures;
+
+namespace NeoServer.Domain.Houses.Events;
+
+/// <summary>Raised when rent is due and the owner lacks funds.</summary>
+public record HouseRentWarningEvent(House House, IPlayer Owner, byte WarningNumber) : IEvent;

--- a/src/Core/NeoServer.Domain/Houses/House.cs
+++ b/src/Core/NeoServer.Domain/Houses/House.cs
@@ -1,0 +1,183 @@
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.DataStores;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Common.Location;
+using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Houses.AccessList;
+
+namespace NeoServer.Domain.Houses;
+
+public class House
+{
+    private readonly List<IDynamicTile> _tiles = new();
+    private readonly Dictionary<uint, IItem> _doors = new();
+    private readonly List<IItem> _beds = new();
+    private readonly Dictionary<uint, HouseAccessList> _accessLists = new();
+
+    public uint Id { get; init; }
+    public string Name { get; set; }
+    public ushort TownId { get; set; }
+    public uint Rent { get; set; }
+    public DateTime? PaidUntil { get; set; }
+    private byte _payRentWarnings;
+    public byte PayRentWarnings
+    {
+        get => _payRentWarnings;
+        set => _payRentWarnings = Math.Min(value, (byte)7);
+    }
+    public uint OwnerGuid { get; set; }
+    public string OwnerName { get; set; }
+    public int OwnerAccountId { get; set; }
+    public Location? EntryPosition { get; set; }
+
+    public IReadOnlyCollection<IDynamicTile> Tiles => _tiles.AsReadOnly();
+    public IReadOnlyDictionary<uint, IItem> Doors => _doors.AsReadOnly();
+    public IReadOnlyCollection<IItem> Beds => _beds.AsReadOnly();
+    public int TileCount => _tiles.Count;
+    public int DoorCount => _doors.Count;
+    public int BedCount => _beds.Count;
+
+    public void LinkTile(IDynamicTile tile)
+    {
+        if (_tiles.Contains(tile))
+            throw new InvalidOperationException("Tile already belongs to this house.");
+
+        _tiles.Add(tile);
+        tile.CanEnterFunction = c => c is IPlayer p && GetAccessLevel(p) != HouseAccessLevel.NotInvited;
+
+        if (EntryPosition is null)
+            EntryPosition = tile.Location;
+    }
+
+    public void LinkDoor(uint doorId, IItem door)
+    {
+        _doors[doorId] = door;
+    }
+
+    public void LinkBed(IItem bed)
+    {
+        _beds.Add(bed);
+    }
+
+    public HouseAccessLevel GetAccessLevel(IPlayer player)
+    {
+        if (OwnerGuid != 0 && player.Id == OwnerGuid)
+            return HouseAccessLevel.Owner;
+
+        if (_accessLists.TryGetValue(HouseListId.SubOwnerList, out var subOwnerList) && subOwnerList.IsInList(player))
+            return HouseAccessLevel.SubOwner;
+
+        if (_accessLists.TryGetValue(HouseListId.GuestList, out var guestList) && guestList.IsInList(player))
+            return HouseAccessLevel.Guest;
+
+        return HouseAccessLevel.NotInvited;
+    }
+
+    public bool IsInvited(IPlayer player)
+    {
+        return GetAccessLevel(player) != HouseAccessLevel.NotInvited;
+    }
+
+    public bool CanEnter(ICreature creature)
+    {
+        return creature is IPlayer player && IsInvited(player);
+    }
+
+    public bool CanEditAccessList(uint listId, IPlayer player)
+    {
+        var level = GetAccessLevel(player);
+
+        if (listId == HouseListId.SubOwnerList)
+            return level == HouseAccessLevel.Owner;
+
+        if (listId == HouseListId.GuestList || HouseListId.IsDoorList(listId))
+            return level >= HouseAccessLevel.SubOwner;
+
+        return false;
+    }
+
+    public HouseAccessList GetAccessList(uint listId)
+    {
+        return _accessLists.GetValueOrDefault(listId);
+    }
+
+    public void SetAccessList(uint listId, HouseAccessList list)
+    {
+        if (list is not null)
+            _accessLists[listId] = list;
+        else
+            _accessLists.Remove(listId);
+    }
+
+    public void SetNewOwner(uint guid, string name, int accountId, bool updatePaidUntil, DateTime now, uint rentPeriodSeconds)
+    {
+        if (guid != 0 && guid == OwnerGuid)
+        {
+            if (updatePaidUntil)
+            {
+                PaidUntil = now.AddSeconds(rentPeriodSeconds);
+                PayRentWarnings = 0;
+            }
+            return;
+        }
+
+        if (OwnerGuid != 0)
+        {
+            _accessLists.Clear();
+            _doors.Clear();
+        }
+
+        OwnerGuid = guid;
+        OwnerName = guid != 0 ? name : string.Empty;
+        OwnerAccountId = guid != 0 ? accountId : 0;
+
+        if (updatePaidUntil && guid != 0)
+        {
+            PaidUntil = now.AddSeconds(rentPeriodSeconds);
+            PayRentWarnings = 0;
+        }
+    }
+
+    public bool CanKick(IPlayer caster, IPlayer target)
+    {
+        if (GetAccessLevel(caster) < HouseAccessLevel.SubOwner)
+            return false;
+
+        if (OwnerGuid != 0 && target.Id == OwnerGuid)
+            return false;
+
+        if (caster.Level <= target.Level)
+            return false;
+
+        if (!_tiles.Contains(target.Tile))
+            return false;
+
+        return true;
+    }
+
+    public HouseRentResult PayRent(IPlayer owner, ICoinTypeStore coinTypeStore, DateTime now, uint rentPeriodSeconds)
+    {
+        if (OwnerGuid == 0) return HouseRentResult.NotDue;
+        if (Rent == 0) return HouseRentResult.NotDue;
+        if (PaidUntil.HasValue && PaidUntil.Value > now) return HouseRentResult.NotDue;
+
+        if (owner.BankAmount >= Rent)
+        {
+            owner.Bank.Debit(Rent);
+            PaidUntil = now.AddSeconds(rentPeriodSeconds);
+            PayRentWarnings = 0;
+            return HouseRentResult.Paid;
+        }
+
+        PayRentWarnings = (byte)(PayRentWarnings + 1);
+
+        if (PayRentWarnings >= 7)
+        {
+            SetNewOwner(0, null, 0, false, now, rentPeriodSeconds);
+            return HouseRentResult.Evicted;
+        }
+
+        return HouseRentResult.Warned;
+    }
+}

--- a/src/Core/NeoServer.Domain/Houses/House.cs
+++ b/src/Core/NeoServer.Domain/Houses/House.cs
@@ -1,5 +1,4 @@
 using NeoServer.Domain.Common.Contracts.Creatures;
-using NeoServer.Domain.Common.Contracts.DataStores;
 using NeoServer.Domain.Common.Contracts.Items;
 using NeoServer.Domain.Common.Contracts.World.Tiles;
 using NeoServer.Domain.Common.Location;
@@ -43,7 +42,14 @@ public class House
         if (_tiles.Contains(tile))
             throw new InvalidOperationException("Tile already belongs to this house.");
 
+        // Assumption: house linking is the sole writer of CanEnterFunction on tiles.
+        // A non-null CanEnterFunction on a different house's tile means it was already claimed.
+        // Phase 2 should upgrade this to a HouseId-based check once map<->DB house ids are reconciled.
+        if (tile.CanEnterFunction is not null)
+            throw new InvalidOperationException("Tile already belongs to another house.");
+
         _tiles.Add(tile);
+        tile.SetAsProtectionZone();
         tile.CanEnterFunction = c => c is IPlayer p && GetAccessLevel(p) != HouseAccessLevel.NotInvited;
 
         if (EntryPosition is null)
@@ -156,7 +162,10 @@ public class House
         return true;
     }
 
-    public HouseRentResult PayRent(IPlayer owner, ICoinTypeStore coinTypeStore, DateTime now, uint rentPeriodSeconds)
+    // Rent is collected from the player's bank balance (owner.Bank.Debit). A coin-store parameter
+    // was intentionally removed (Phase 1); if a future phase needs coin-specific rent, re-introduce
+    // it at the service layer, not the aggregate.
+    public HouseRentResult PayRent(IPlayer owner, DateTime now, uint rentPeriodSeconds)
     {
         if (OwnerGuid == 0) return HouseRentResult.NotDue;
         if (Rent == 0) return HouseRentResult.NotDue;

--- a/src/Core/NeoServer.Domain/Houses/House.cs
+++ b/src/Core/NeoServer.Domain/Houses/House.cs
@@ -37,6 +37,24 @@ public class House
     public int DoorCount => _doors.Count;
     public int BedCount => _beds.Count;
 
+    public List<IItem> PickupableItems
+    {
+        get
+        {
+            var items = new List<IItem>();
+            foreach (var tile in _tiles)
+            {
+                if (tile.AllItems is null) continue;
+                foreach (var item in tile.AllItems)
+                {
+                    if (item is not null && item.IsPickupable)
+                        items.Add(item);
+                }
+            }
+            return items;
+        }
+    }
+
     public void LinkTile(IDynamicTile tile)
     {
         if (_tiles.Contains(tile))
@@ -50,7 +68,7 @@ public class House
 
         _tiles.Add(tile);
         tile.SetAsProtectionZone();
-        tile.CanEnterFunction = c => c is IPlayer p && GetAccessLevel(p) != HouseAccessLevel.NotInvited;
+        tile.CanEnterFunction = c => c is IPlayer p && IsInvited(p);
 
         if (EntryPosition is null)
             EntryPosition = tile.Location;

--- a/src/Core/NeoServer.Domain/Houses/HouseAccessLevel.cs
+++ b/src/Core/NeoServer.Domain/Houses/HouseAccessLevel.cs
@@ -1,0 +1,9 @@
+namespace NeoServer.Domain.Houses;
+
+public enum HouseAccessLevel : byte
+{
+    NotInvited = 0,
+    Guest = 1,
+    SubOwner = 2,
+    Owner = 3
+}

--- a/src/Core/NeoServer.Domain/Houses/HouseFactory.cs
+++ b/src/Core/NeoServer.Domain/Houses/HouseFactory.cs
@@ -1,0 +1,20 @@
+namespace NeoServer.Domain.Houses;
+
+public class HouseFactory : IHouseFactory
+{
+    public House Create(uint id, string name, ushort townId, uint rent, uint ownerGuid, string ownerName, int ownerAccountId, DateTime? paidUntil, byte payRentWarnings)
+    {
+        return new House
+        {
+            Id = id,
+            Name = name,
+            TownId = townId,
+            Rent = rent,
+            OwnerGuid = ownerGuid,
+            OwnerName = ownerGuid != 0 ? ownerName : string.Empty,
+            OwnerAccountId = ownerAccountId,
+            PaidUntil = paidUntil,
+            PayRentWarnings = payRentWarnings
+        };
+    }
+}

--- a/src/Core/NeoServer.Domain/Houses/HouseItemMovementPolicy.cs
+++ b/src/Core/NeoServer.Domain/Houses/HouseItemMovementPolicy.cs
@@ -1,0 +1,16 @@
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+
+namespace NeoServer.Domain.Houses;
+
+/// <summary>Default policy: player can only move items on house tiles if invited.</summary>
+public class HouseItemMovementPolicy : IHouseItemMovementPolicy
+{
+    public bool CanMoveItem(IPlayer player, ITile tile)
+    {
+        if (player is null) return true;
+        if (tile is null) return true;
+
+        return true;
+    }
+}

--- a/src/Core/NeoServer.Domain/Houses/HouseItemMovementPolicy.cs
+++ b/src/Core/NeoServer.Domain/Houses/HouseItemMovementPolicy.cs
@@ -1,16 +1,30 @@
 using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.DataStores;
 using NeoServer.Domain.Common.Contracts.World.Tiles;
 
 namespace NeoServer.Domain.Houses;
 
-/// <summary>Default policy: player can only move items on house tiles if invited.</summary>
-public class HouseItemMovementPolicy : IHouseItemMovementPolicy
+/// <summary>
+/// Movement policy for house tiles.
+/// Rules:
+/// <list type="bullet">
+///   <item>Non-house tile or null tile: unrestricted (return true).</item>
+///   <item>House tile with null player: blocked (return false).</item>
+///   <item>House tile with a player: allowed only if the player is invited.</item>
+/// </list>
+/// DI note: wire <see cref="IHouseItemMovementPolicy"/> → <see cref="HouseItemMovementPolicy"/>
+/// at the movement-layer registration (Phase 2/3); do not invoke movement commands from Phase 1.
+/// </summary>
+public class HouseItemMovementPolicy(IHouseStore houseStore) : IHouseItemMovementPolicy
 {
     public bool CanMoveItem(IPlayer player, ITile tile)
     {
-        if (player is null) return true;
-        if (tile is null) return true;
+        if (tile is null) return true;           // no tile context — don't block
 
-        return true;
+        var house = houseStore.GetByTile(tile);
+        if (house is null) return true;          // not a house tile — unrestricted
+
+        if (player is null) return false;        // house tile requires an acting player
+        return house.IsInvited(player);
     }
 }

--- a/src/Core/NeoServer.Domain/Houses/HouseItemMovementPolicy.cs
+++ b/src/Core/NeoServer.Domain/Houses/HouseItemMovementPolicy.cs
@@ -19,7 +19,7 @@ public class HouseItemMovementPolicy(IHouseStore houseStore) : IHouseItemMovemen
 {
     public bool CanMoveItem(IPlayer player, ITile tile)
     {
-        if (tile is null) return true;           // no tile context — don't block
+        if (tile is null) return false;           // no tile context — can't move anything
 
         var house = houseStore.GetByTile(tile);
         if (house is null) return true;          // not a house tile — unrestricted

--- a/src/Core/NeoServer.Domain/Houses/HouseListId.cs
+++ b/src/Core/NeoServer.Domain/Houses/HouseListId.cs
@@ -1,0 +1,11 @@
+namespace NeoServer.Domain.Houses;
+
+public static class HouseListId
+{
+    public const uint GuestList = 0x100;
+    
+    public const uint SubOwnerList = 0x101;
+
+    /// <summary>Which door this access list controls. Values 0-254 are door ids.</summary>
+    public static bool IsDoorList(uint listId) => listId <= 254;
+}

--- a/src/Core/NeoServer.Domain/Houses/HouseRentResult.cs
+++ b/src/Core/NeoServer.Domain/Houses/HouseRentResult.cs
@@ -1,0 +1,9 @@
+namespace NeoServer.Domain.Houses;
+
+public enum HouseRentResult
+{
+    NotDue,
+    Paid,
+    Warned,
+    Evicted
+}

--- a/src/Core/NeoServer.Domain/Houses/IHouseFactory.cs
+++ b/src/Core/NeoServer.Domain/Houses/IHouseFactory.cs
@@ -1,0 +1,7 @@
+namespace NeoServer.Domain.Houses;
+
+/// <summary>Creates a House aggregate from its stored representation.</summary>
+public interface IHouseFactory
+{
+    House Create(uint id, string name, ushort townId, uint rent, uint ownerGuid, string ownerName, int ownerAccountId, DateTime? paidUntil, byte payRentWarnings);
+}

--- a/src/Core/NeoServer.Domain/Houses/IHouseItemMovementPolicy.cs
+++ b/src/Core/NeoServer.Domain/Houses/IHouseItemMovementPolicy.cs
@@ -1,0 +1,10 @@
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+
+namespace NeoServer.Domain.Houses;
+
+/// <summary>Gates item throw/move operations on house tiles.</summary>
+public interface IHouseItemMovementPolicy
+{
+    bool CanMoveItem(IPlayer player, ITile tile);
+}

--- a/src/Core/NeoServer.Domain/Houses/Services/HouseService.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/HouseService.cs
@@ -16,7 +16,8 @@ public class HouseService(
     IHouseRepository houseRepository,
     IHouseEviction eviction,
     IHouseBedWaker bedWaker,
-    IHouseDepotTransfer depotTransfer) : IHouseService
+    IHouseDepotTransfer depotTransfer,
+    HouseConfiguration houseConfiguration) : IHouseService
 {
     /// <summary>Transfer house to a new owner. Evicts old occupants, wakes beds, moves items to old owner depot.</summary>
     public void SetOwner(House house, uint guid, string name, int accountId, bool updatePaidUntil, DateTime now, uint rentPeriodSeconds)
@@ -44,22 +45,11 @@ public class HouseService(
 
             bedWaker.WakeAll(house.Beds);
 
-            var pickupableItems = new List<IItem>();
-            foreach (var tile in house.Tiles)
+            if (houseConfiguration.TransferItemsToDepotOnOwnershipChange)
             {
-                if (tile.AllItems is null) continue;
-                foreach (var item in tile.AllItems)
-                {
-                    if (item is not null && item.IsPickupable)
-                    {
-                        pickupableItems.Add(item);
-                    }
-                }
-            }
-
-            if (pickupableItems.Count > 0)
-            {
-                depotTransfer.TransferToOwnerDepot(oldOwnerAccountId, house.TownId, pickupableItems);
+                var pickupableItems = house.PickupableItems;
+                if (pickupableItems.Count > 0)
+                    depotTransfer.TransferToOwnerDepot(oldOwnerAccountId, house.TownId, pickupableItems);
             }
         }
 
@@ -70,6 +60,7 @@ public class HouseService(
     /// <summary>Collect rent from owner's bank. Raises warning or eviction events based on result.</summary>
     public HouseRentResult PayRent(House house, IPlayer owner, DateTime now, uint rentPeriodSeconds)
     {
+        var oldOwnerAccountId = house.OwnerAccountId;
         var result = house.PayRent(owner, now, rentPeriodSeconds);
 
         houseRepository.Save(house);
@@ -78,7 +69,13 @@ public class HouseService(
             EventAggregator.Invoke(new HouseRentWarningEvent(house, owner, house.PayRentWarnings));
 
         if (result == HouseRentResult.Evicted)
+        {
+            var pickupableItems = house.PickupableItems;
+            if (pickupableItems.Count > 0)
+                depotTransfer.TransferToOwnerDepot(oldOwnerAccountId, house.TownId, pickupableItems);
+
             EventAggregator.Invoke(new HouseEvictedEvent(house));
+        }
 
         return result;
     }
@@ -93,4 +90,5 @@ public class HouseService(
         houseRepository.Save(house);
         return true;
     }
+
 }

--- a/src/Core/NeoServer.Domain/Houses/Services/HouseService.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/HouseService.cs
@@ -1,6 +1,5 @@
 using NeoServer.Domain.Common;
 using NeoServer.Domain.Common.Contracts.Creatures;
-using NeoServer.Domain.Common.Contracts.DataStores;
 using NeoServer.Domain.Common.Contracts.Items;
 using NeoServer.Domain.Common.Contracts.World.Tiles;
 using NeoServer.Domain.Common.Location.Structs;
@@ -69,9 +68,9 @@ public class HouseService(
     }
 
     /// <summary>Collect rent from owner's bank. Raises warning or eviction events based on result.</summary>
-    public HouseRentResult PayRent(House house, IPlayer owner, ICoinTypeStore coinTypeStore, DateTime now, uint rentPeriodSeconds)
+    public HouseRentResult PayRent(House house, IPlayer owner, DateTime now, uint rentPeriodSeconds)
     {
-        var result = house.PayRent(owner, coinTypeStore, now, rentPeriodSeconds);
+        var result = house.PayRent(owner, now, rentPeriodSeconds);
 
         houseRepository.Save(house);
 

--- a/src/Core/NeoServer.Domain/Houses/Services/HouseService.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/HouseService.cs
@@ -1,0 +1,97 @@
+using NeoServer.Domain.Common;
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.DataStores;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Houses.Events;
+using NeoServer.Domain.Repositories;
+
+namespace NeoServer.Domain.Houses.Services;
+
+/// <summary>Orchestrates house ownership changes, rent, and eviction.
+/// Calls the pure House aggregate for domain logic, then performs
+/// game-world side effects (teleport, bed wake, depot transfer)
+/// and persists via IHouseRepository.</summary>
+public class HouseService(
+    IHouseRepository houseRepository,
+    IHouseEviction eviction,
+    IHouseBedWaker bedWaker,
+    IHouseDepotTransfer depotTransfer) : IHouseService
+{
+    /// <summary>Transfer house to a new owner. Evicts old occupants, wakes beds, moves items to old owner depot.</summary>
+    public void SetOwner(House house, uint guid, string name, int accountId, bool updatePaidUntil, DateTime now, uint rentPeriodSeconds)
+    {
+        var oldOwnerGuid = house.OwnerGuid;
+        var oldOwnerAccountId = house.OwnerAccountId;
+
+        house.SetNewOwner(guid, name, accountId, updatePaidUntil, now, rentPeriodSeconds);
+
+        if (oldOwnerGuid != 0 && guid != oldOwnerGuid)
+        {
+            var entryPosition = house.EntryPosition.GetValueOrDefault();
+
+            foreach (var tile in house.Tiles)
+            {
+                if (tile.Players is not null)
+                {
+                    foreach (var player in tile.Players)
+                    {
+                        if (player.Id != guid)
+                            eviction.TeleportToExit(player, entryPosition);
+                    }
+                }
+            }
+
+            bedWaker.WakeAll(house.Beds);
+
+            var pickupableItems = new List<IItem>();
+            foreach (var tile in house.Tiles)
+            {
+                if (tile.AllItems is null) continue;
+                foreach (var item in tile.AllItems)
+                {
+                    if (item is not null && item.IsPickupable)
+                    {
+                        pickupableItems.Add(item);
+                    }
+                }
+            }
+
+            if (pickupableItems.Count > 0)
+            {
+                depotTransfer.TransferToOwnerDepot(oldOwnerAccountId, house.TownId, pickupableItems);
+            }
+        }
+
+        houseRepository.Save(house);
+        EventAggregator.Invoke(new HouseOwnerChangedEvent(house, oldOwnerGuid, guid));
+    }
+
+    /// <summary>Collect rent from owner's bank. Raises warning or eviction events based on result.</summary>
+    public HouseRentResult PayRent(House house, IPlayer owner, ICoinTypeStore coinTypeStore, DateTime now, uint rentPeriodSeconds)
+    {
+        var result = house.PayRent(owner, coinTypeStore, now, rentPeriodSeconds);
+
+        houseRepository.Save(house);
+
+        if (result == HouseRentResult.Warned)
+            EventAggregator.Invoke(new HouseRentWarningEvent(house, owner, house.PayRentWarnings));
+
+        if (result == HouseRentResult.Evicted)
+            EventAggregator.Invoke(new HouseEvictedEvent(house));
+
+        return result;
+    }
+
+    /// <summary>Kick a player from the house. Teleports them to the house exit on success.</summary>
+    public bool KickPlayer(House house, IPlayer caster, IPlayer target)
+    {
+        if (!house.CanKick(caster, target))
+            return false;
+
+        eviction.TeleportToExit(target, house.EntryPosition.GetValueOrDefault());
+        houseRepository.Save(house);
+        return true;
+    }
+}

--- a/src/Core/NeoServer.Domain/Houses/Services/IHouseBedWaker.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/IHouseBedWaker.cs
@@ -1,0 +1,9 @@
+using NeoServer.Domain.Common.Contracts.Items;
+
+namespace NeoServer.Domain.Houses.Services;
+
+/// <summary>Wakes players sleeping on beds inside a house.</summary>
+public interface IHouseBedWaker
+{
+    void WakeAll(IEnumerable<IItem> beds);
+}

--- a/src/Core/NeoServer.Domain/Houses/Services/IHouseDepotTransfer.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/IHouseDepotTransfer.cs
@@ -1,0 +1,9 @@
+using NeoServer.Domain.Common.Contracts.Items;
+
+namespace NeoServer.Domain.Houses.Services;
+
+/// <summary>Moves items from a house to the old owner's depot on ownership change.</summary>
+public interface IHouseDepotTransfer
+{
+    void TransferToOwnerDepot(int ownerAccountId, ushort townId, IEnumerable<IItem> items);
+}

--- a/src/Core/NeoServer.Domain/Houses/Services/IHouseEviction.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/IHouseEviction.cs
@@ -1,0 +1,10 @@
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Location.Structs;
+
+namespace NeoServer.Domain.Houses.Services;
+
+/// <summary>Teleports a player out of a house to the exit position.</summary>
+public interface IHouseEviction
+{
+    void TeleportToExit(IPlayer player, Location exit);
+}

--- a/src/Core/NeoServer.Domain/Houses/Services/IHouseService.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/IHouseService.cs
@@ -1,5 +1,4 @@
 using NeoServer.Domain.Common.Contracts.Creatures;
-using NeoServer.Domain.Common.Contracts.DataStores;
 
 namespace NeoServer.Domain.Houses.Services;
 
@@ -9,8 +8,12 @@ public interface IHouseService
     /// <summary>Transfer house to a new owner. Evicts old occupants, wakes beds, moves items to old owner depot.</summary>
     void SetOwner(House house, uint guid, string name, int accountId, bool updatePaidUntil, DateTime now, uint rentPeriodSeconds);
 
-    /// <summary>Collect rent from the owner's bank. Issues warnings or evicts on non-payment.</summary>
-    HouseRentResult PayRent(House house, IPlayer owner, ICoinTypeStore coinTypeStore, DateTime now, uint rentPeriodSeconds);
+    /// <summary>
+    /// Collect rent from the owner's bank. Issues warnings or evicts on non-payment.
+    /// Rent is bank-balance based; a coin-store was intentionally dropped in Phase 1.
+    /// If a future phase needs coin-specific rent, re-introduce it at the service layer.
+    /// </summary>
+    HouseRentResult PayRent(House house, IPlayer owner, DateTime now, uint rentPeriodSeconds);
 
     /// <summary>Kick a player out of the house. Only subowners or higher can kick lower-level players.</summary>
     bool KickPlayer(House house, IPlayer caster, IPlayer target);

--- a/src/Core/NeoServer.Domain/Houses/Services/IHouseService.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/IHouseService.cs
@@ -1,0 +1,17 @@
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.DataStores;
+
+namespace NeoServer.Domain.Houses.Services;
+
+/// <summary>Orchestrates house ownership changes, rent collection, and player eviction.</summary>
+public interface IHouseService
+{
+    /// <summary>Transfer house to a new owner. Evicts old occupants, wakes beds, moves items to old owner depot.</summary>
+    void SetOwner(House house, uint guid, string name, int accountId, bool updatePaidUntil, DateTime now, uint rentPeriodSeconds);
+
+    /// <summary>Collect rent from the owner's bank. Issues warnings or evicts on non-payment.</summary>
+    HouseRentResult PayRent(House house, IPlayer owner, ICoinTypeStore coinTypeStore, DateTime now, uint rentPeriodSeconds);
+
+    /// <summary>Kick a player out of the house. Only subowners or higher can kick lower-level players.</summary>
+    bool KickPlayer(House house, IPlayer caster, IPlayer target);
+}

--- a/src/Core/NeoServer.Domain/Repositories/IHouseRepository.cs
+++ b/src/Core/NeoServer.Domain/Repositories/IHouseRepository.cs
@@ -1,0 +1,8 @@
+using NeoServer.Domain.Houses;
+
+namespace NeoServer.Domain.Repositories;
+
+public interface IHouseRepository
+{
+    void Save(House house);
+}

--- a/src/Core/NeoServer.Domain/World/Models/Tiles/DynamicTile.cs
+++ b/src/Core/NeoServer.Domain/World/Models/Tiles/DynamicTile.cs
@@ -557,6 +557,9 @@ public class DynamicTile : BaseTile, IDynamicTile
         AddItem(item);
     }
 
+    /// <inheritdoc/>
+    public void SetAsProtectionZone() => SetFlag(TileFlags.ProtectionZone);
+
     public uint PossibleAmountToAdd(IItem thing, byte? toPosition = null)
     {
         var freeSpace = 10 - (DownItems?.Count ?? 0);

--- a/src/Database/NeoServer.Data.InMemory.DataStores/HouseStore.cs
+++ b/src/Database/NeoServer.Data.InMemory.DataStores/HouseStore.cs
@@ -1,0 +1,23 @@
+using NeoServer.Data.InMemory.DataStores;
+using NeoServer.Domain.Common.Contracts.DataStores;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Houses;
+using NeoServer.Domain.World.Models.Tiles;
+
+[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NeoServer.Domain.Tests")]
+
+namespace NeoServer.Data.InMemory.DataStores;
+
+public class HouseStore : DataStore<HouseStore, uint, House>, IHouseStore
+{
+    public House GetByTile(ITile tile)
+    {
+        var houseId = (tile as DynamicTile)?.HouseId;
+        return houseId.HasValue ? Get(houseId.Value) : null;
+    }
+
+    public House GetByHouseId(uint houseId)
+    {
+        return Get(houseId);
+    }
+}

--- a/src/Standalone/IoC/Modules/ConfigurationInjection.cs
+++ b/src/Standalone/IoC/Modules/ConfigurationInjection.cs
@@ -49,6 +49,7 @@ public static class ConfigurationInjection
         builder.AddSingleton(gameConfiguration.PvP);
         builder.AddSingleton(gameConfiguration.Combat);
         builder.AddSingleton(gameConfiguration.Yell);
+        builder.AddSingleton(gameConfiguration.House);
 
         builder.AddSingleton<IConfiguration>(configuration);
 

--- a/src/Standalone/appsettings.json
+++ b/src/Standalone/appsettings.json
@@ -71,6 +71,9 @@
       "yellCooldownSeconds": 30,
       "yellMinimumLevel": 2,
       "yellAllowedPremium": true
+    },
+    "house": {
+      "transferItemsToDepotOnOwnershipChange": true
     }
   },
   "client": {

--- a/tests/NeoServer.Domain.Tests/Common/Structs/LocationEqualityTests.cs
+++ b/tests/NeoServer.Domain.Tests/Common/Structs/LocationEqualityTests.cs
@@ -1,0 +1,77 @@
+using NeoServer.Domain.Common.Location.Structs;
+
+namespace NeoServer.Domain.Tests.Common.Structs;
+
+public class LocationEqualityTests
+{
+    [Fact]
+    public void Equals_BoxedEqualLocation_ReturnsTrue()
+    {
+        var a = new Location(1, 2, 3);
+        object boxed = new Location(1, 2, 3);
+
+        // Must not overflow — this is the regression guard for the C1 bug.
+        var result = a.Equals(boxed);
+
+        result.Should().BeTrue();
+    }
+
+    [Fact]
+    public void Equals_BoxedDifferentLocation_ReturnsFalse()
+    {
+        var a = new Location(1, 2, 3);
+        object boxed = new Location(1, 2, 4);
+
+        a.Equals(boxed).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_BoxedNonLocation_ReturnsFalse()
+    {
+        var a = new Location(1, 2, 3);
+
+        a.Equals("not a location").Should().BeFalse();
+    }
+
+    [Fact]
+    public void Equals_TypedOverload_MatchesOperator()
+    {
+        var a = new Location(1, 2, 3);
+        var b = new Location(1, 2, 3);
+        var c = new Location(9, 9, 9);
+
+        (a.Equals(b) == (a == b)).Should().BeTrue();
+        (a.Equals(c) == (a == c)).Should().BeTrue();
+    }
+
+    [Fact]
+    public void Be_ViaFluentAssertions_DoesNotOverflow()
+    {
+        // FluentAssertions .Be() boxes through object.Equals — this is the exact crash path.
+        var loc = new Location(1, 2, 3);
+        loc.Should().Be(new Location(1, 2, 3));
+    }
+
+    [Fact]
+    public void GetHashCode_EqualLocations_AreEqual()
+    {
+        var a = new Location(5, 10, 7);
+        var b = new Location(5, 10, 7);
+
+        a.GetHashCode().Should().Be(b.GetHashCode());
+    }
+
+    [Fact]
+    public void OperatorEquality_And_Inequality_AreConsistent()
+    {
+        var a = new Location(1, 2, 3);
+        var b = new Location(1, 2, 3);
+        var c = new Location(9, 9, 9);
+
+        // (a == b) must equal !(a != b) for equal pair.
+        (a == b).Should().Be(!(a != b));
+
+        // (a == c) must equal !(a != c) for unequal pair.
+        (a == c).Should().Be(!(a != c));
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs
+++ b/tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs
@@ -1,0 +1,128 @@
+using Moq;
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Common.Location;
+using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Guild;
+using NeoServer.Domain.Houses;
+using NeoServer.Domain.Houses.AccessList;
+
+namespace NeoServer.Domain.Tests.Helpers.House;
+
+public static class HouseTestDataBuilder
+{
+    public static Domain.Houses.House Build(
+        uint id = 1,
+        string name = "Test House",
+        ushort townId = 1,
+        uint rent = 1000,
+        uint ownerGuid = 0,
+        string ownerName = null,
+        int ownerAccountId = 0,
+        DateTime? paidUntil = null,
+        byte payRentWarnings = 0,
+        Location? entryPosition = null,
+        List<Mock<IDynamicTile>> tiles = null,
+        List<(uint DoorId, Mock<IItem> Item)> doors = null,
+        List<Mock<IItem>> beds = null,
+        Dictionary<uint, HouseAccessList> accessLists = null)
+    {
+        var house = new Domain.Houses.House
+        {
+            Id = id,
+            Name = name,
+            TownId = townId,
+            Rent = rent,
+            OwnerGuid = ownerGuid,
+            OwnerName = ownerName ?? string.Empty,
+            OwnerAccountId = ownerAccountId,
+            PaidUntil = paidUntil,
+            PayRentWarnings = payRentWarnings,
+            EntryPosition = entryPosition
+        };
+
+        if (tiles is not null)
+        {
+            foreach (var tileMock in tiles)
+            {
+                tileMock.Setup(x => x.Location).Returns(new Location(100, 100, 7));
+                house.LinkTile(tileMock.Object);
+            }
+        }
+
+        if (doors is not null)
+        {
+            foreach (var (doorId, doorMock) in doors)
+                house.LinkDoor(doorId, doorMock.Object);
+        }
+
+        if (beds is not null)
+        {
+            foreach (var bedMock in beds)
+                house.LinkBed(bedMock.Object);
+        }
+
+        if (accessLists is not null)
+        {
+            foreach (var (listId, list) in accessLists)
+                house.SetAccessList(listId, list);
+        }
+
+        return house;
+    }
+
+    public static Mock<IDynamicTile> CreateTileMock(List<IPlayer> players = null, List<IItem> items = null)
+    {
+        var tileMock = new Mock<IDynamicTile>();
+        tileMock.Setup(x => x.Location).Returns(new Location(100, 100, 7));
+        tileMock.Setup(x => x.Players).Returns(players ?? new List<IPlayer>());
+        tileMock.Setup(x => x.AllItems).Returns(items?.ToArray() ?? Array.Empty<IItem>());
+        tileMock.Setup(x => x.HasFlag(It.IsAny<TileFlags>())).Returns(false);
+        tileMock.SetupProperty(x => x.CanEnterFunction);
+        return tileMock;
+    }
+
+    public static Mock<IItem> CreateItemMock(bool isPickupable = true, ushort serverId = 100)
+    {
+        var itemMock = new Mock<IItem>();
+        itemMock.Setup(x => x.IsPickupable).Returns(isPickupable);
+        itemMock.Setup(x => x.ServerId).Returns(serverId);
+        return itemMock;
+    }
+
+    public static IPlayer CreatePlayer(uint id = 1, ushort level = 10, uint guildId = 0, GuildRankInfo guildRank = null, string name = "Player")
+    {
+        var playerMock = new Mock<IPlayer>();
+        playerMock.Setup(x => x.Id).Returns(id);
+        playerMock.Setup(x => x.Level).Returns(level);
+        playerMock.Setup(x => x.Name).Returns(name);
+        playerMock.Setup(x => x.HasGuild).Returns(guildId != 0);
+        playerMock.Setup(x => x.GuildId).Returns((ushort)guildId);
+        playerMock.Setup(x => x.GuildRank).Returns(guildRank);
+        playerMock.Setup(x => x.AccountId).Returns(id);
+        return playerMock.Object;
+    }
+
+    public static IPlayer CreatePlayerWithBank(uint id = 1, ulong bankAmount = 0, string name = "Player")
+    {
+        var bankMock = new Mock<IBank>();
+        bankMock.Setup(x => x.Amount).Returns(bankAmount);
+
+        var playerMock = new Mock<IPlayer>();
+        playerMock.Setup(x => x.Id).Returns(id);
+        playerMock.Setup(x => x.Name).Returns(name);
+        playerMock.Setup(x => x.Bank).Returns(bankMock.Object);
+        playerMock.Setup(x => x.BankAmount).Returns(bankAmount);
+        playerMock.Setup(x => x.AccountId).Returns(id);
+        return playerMock.Object;
+    }
+
+    public static HouseAccessList CreateAccessList(params string[] playerNames)
+    {
+        var list = new HouseAccessList();
+        foreach (var name in playerNames)
+            list.AddPlayer(name);
+        return list;
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs
+++ b/tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs
@@ -78,7 +78,14 @@ public static class HouseTestDataBuilder
         tileMock.Setup(x => x.Location).Returns(new Location(100, 100, 7));
         tileMock.Setup(x => x.Players).Returns(players ?? new List<IPlayer>());
         tileMock.Setup(x => x.AllItems).Returns(items?.ToArray() ?? Array.Empty<IItem>());
-        tileMock.Setup(x => x.HasFlag(It.IsAny<TileFlags>())).Returns(false);
+
+        // Track which flags have been set so HasFlag reads true after SetAsProtectionZone is called.
+        var setFlags = new HashSet<TileFlags>();
+        tileMock.Setup(x => x.HasFlag(It.IsAny<TileFlags>()))
+            .Returns((TileFlags f) => setFlags.Contains(f));
+        tileMock.Setup(x => x.SetAsProtectionZone())
+            .Callback(() => setFlags.Add(TileFlags.ProtectionZone));
+
         tileMock.SetupProperty(x => x.CanEnterFunction);
         return tileMock;
     }

--- a/tests/NeoServer.Domain.Tests/Houses/HouseAccessLevelTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseAccessLevelTests.cs
@@ -1,0 +1,159 @@
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Tests.Helpers.House;
+using NeoServer.Domain.Houses;
+using NeoServer.Domain.Houses.AccessList;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseAccessLevelTests
+{
+    [Fact]
+    public void GetAccessLevel_Owner_ReturnsOwner()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(id: 1);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+
+        house.GetAccessLevel(player).Should().Be(HouseAccessLevel.Owner);
+    }
+
+    [Fact]
+    public void GetAccessLevel_PlayerInSubownerList_ReturnsSubOwner()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Sub");
+        var house = HouseTestDataBuilder.Build(accessLists: new Dictionary<uint, HouseAccessList>
+        {
+            { HouseListId.SubOwnerList, HouseTestDataBuilder.CreateAccessList("Sub") }
+        });
+
+        house.GetAccessLevel(player).Should().Be(HouseAccessLevel.SubOwner);
+    }
+
+    [Fact]
+    public void GetAccessLevel_PlayerInGuestListOnly_ReturnsGuest()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Guest");
+        var house = HouseTestDataBuilder.Build(accessLists: new Dictionary<uint, HouseAccessList>
+        {
+            { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Guest") }
+        });
+
+        house.GetAccessLevel(player).Should().Be(HouseAccessLevel.Guest);
+    }
+
+    [Fact]
+    public void GetAccessLevel_PlayerInBothLists_ReturnsSubOwner()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Player");
+        var house = HouseTestDataBuilder.Build(accessLists: new Dictionary<uint, HouseAccessList>
+        {
+            { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Player") },
+            { HouseListId.SubOwnerList, HouseTestDataBuilder.CreateAccessList("Player") }
+        });
+
+        house.GetAccessLevel(player).Should().Be(HouseAccessLevel.SubOwner);
+    }
+
+    [Fact]
+    public void GetAccessLevel_UninvitedPlayer_ReturnsNotInvited()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Stranger");
+        var house = HouseTestDataBuilder.Build();
+
+        house.GetAccessLevel(player).Should().Be(HouseAccessLevel.NotInvited);
+    }
+
+    [Fact]
+    public void IsInvited_GuestPlayer_ReturnsTrue()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Guest");
+        var house = HouseTestDataBuilder.Build(accessLists: new Dictionary<uint, HouseAccessList>
+        {
+            { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Guest") }
+        });
+
+        house.IsInvited(player).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsInvited_UninvitedPlayer_ReturnsFalse()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Stranger");
+        var house = HouseTestDataBuilder.Build();
+
+        house.IsInvited(player).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanEnter_InvitedPlayer_ReturnsTrue()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(id: 1);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+
+        house.CanEnter(player).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanEnter_UninvitedPlayer_ReturnsFalse()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Stranger");
+        var house = HouseTestDataBuilder.Build();
+
+        house.CanEnter(player).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanEnter_NonPlayerCreature_ReturnsFalse()
+    {
+        var creatureMock = new Moq.Mock<ICreature>();
+        var house = HouseTestDataBuilder.Build();
+
+        house.CanEnter(creatureMock.Object).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanEditAccessList_OwnerEditsSubownerList_ReturnsTrue()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(id: 1);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+
+        house.CanEditAccessList(HouseListId.SubOwnerList, player).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanEditAccessList_SubownerEditsSubownerList_ReturnsFalse()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Sub");
+        var house = HouseTestDataBuilder.Build(accessLists: new Dictionary<uint, HouseAccessList>
+        {
+            { HouseListId.SubOwnerList, HouseTestDataBuilder.CreateAccessList("Sub") }
+        });
+
+        house.CanEditAccessList(HouseListId.SubOwnerList, player).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanEditAccessList_SubownerEditsGuestList_ReturnsTrue()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Sub");
+        var house = HouseTestDataBuilder.Build(accessLists: new Dictionary<uint, HouseAccessList>
+        {
+            { HouseListId.SubOwnerList, HouseTestDataBuilder.CreateAccessList("Sub") }
+        });
+
+        house.CanEditAccessList(HouseListId.GuestList, player).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanEditAccessList_GuestEditsAnyList_ReturnsFalse()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Guest");
+        var house = HouseTestDataBuilder.Build(accessLists: new Dictionary<uint, HouseAccessList>
+        {
+            { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Guest") }
+        });
+
+        house.CanEditAccessList(HouseListId.GuestList, player).Should().BeFalse();
+        house.CanEditAccessList(HouseListId.SubOwnerList, player).Should().BeFalse();
+        house.CanEditAccessList(1, player).Should().BeFalse();
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Houses/HouseAccessListTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseAccessListTests.cs
@@ -1,0 +1,94 @@
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Guild;
+using NeoServer.Domain.Houses.AccessList;
+using NeoServer.Domain.Tests.Helpers.House;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseAccessListTests
+{
+    [Fact]
+    public void AddPlayer_AddsNameCaseInsensitive()
+    {
+        var list = new HouseAccessList();
+        list.AddPlayer("Rookgaard");
+
+        var player = HouseTestDataBuilder.CreatePlayer(name: "ROOKGAARD");
+        list.IsInList(player).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AllowAll_MakesAnyPlayerInList()
+    {
+        var list = new HouseAccessList();
+        list.AllowAll();
+
+        var player = HouseTestDataBuilder.CreatePlayer(name: "AnyPlayer");
+        list.IsInList(player).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddGuild_AddsGuildId()
+    {
+        var list = new HouseAccessList();
+        list.AddGuild(100);
+
+        var player = HouseTestDataBuilder.CreatePlayer(guildId: 100);
+        list.IsInList(player).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddGuildRank_MatchesRankLevelOrAbove()
+    {
+        var list = new HouseAccessList();
+        list.AddGuildRank(100, 3);
+
+        var rank = new GuildRankInfo(1, "Leader", 5);
+        var player = HouseTestDataBuilder.CreatePlayer(guildId: 100, guildRank: rank);
+        list.IsInList(player).Should().BeTrue();
+    }
+
+    [Fact]
+    public void AddGuildRank_LowerRankDoesNotMatch()
+    {
+        var list = new HouseAccessList();
+        list.AddGuildRank(100, 5);
+
+        var rank = new GuildRankInfo(1, "Member", 3);
+        var player = HouseTestDataBuilder.CreatePlayer(guildId: 100, guildRank: rank);
+        list.IsInList(player).Should().BeFalse();
+    }
+
+    [Fact]
+    public void Clear_ResetsAllEntries()
+    {
+        var list = new HouseAccessList();
+        list.AddPlayer("PlayerA");
+        list.AllowAll();
+        list.Clear();
+
+        var player = HouseTestDataBuilder.CreatePlayer(name: "PlayerA");
+        list.IsInList(player).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsInList_PlayerNotInList_ReturnsFalse()
+    {
+        var list = new HouseAccessList();
+        list.AddPlayer("Alice");
+
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Bob");
+        list.IsInList(player).Should().BeFalse();
+    }
+
+    [Fact]
+    public void AddPlayer_MultipleNames_AllMatch()
+    {
+        var list = new HouseAccessList();
+        list.AddPlayer("Alice");
+        list.AddPlayer("Bob");
+
+        list.IsInList(HouseTestDataBuilder.CreatePlayer(name: "Alice")).Should().BeTrue();
+        list.IsInList(HouseTestDataBuilder.CreatePlayer(name: "Bob")).Should().BeTrue();
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Houses/HouseAccessListTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseAccessListTests.cs
@@ -18,10 +18,10 @@ public class HouseAccessListTests
     }
 
     [Fact]
-    public void AllowAll_MakesAnyPlayerInList()
+    public void AllowEveryone_MakesAnyPlayerInList()
     {
         var list = new HouseAccessList();
-        list.AllowAll();
+        list.AllowEveryone();
 
         var player = HouseTestDataBuilder.CreatePlayer(name: "AnyPlayer");
         list.IsInList(player).Should().BeTrue();
@@ -64,7 +64,7 @@ public class HouseAccessListTests
     {
         var list = new HouseAccessList();
         list.AddPlayer("PlayerA");
-        list.AllowAll();
+        list.AllowEveryone();
         list.Clear();
 
         var player = HouseTestDataBuilder.CreatePlayer(name: "PlayerA");

--- a/tests/NeoServer.Domain.Tests/Houses/HouseDoorBedTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseDoorBedTests.cs
@@ -1,0 +1,58 @@
+using Moq;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Tests.Helpers.House;
+using NeoServer.Domain.Houses.AccessList;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseDoorBedTests
+{
+    [Fact]
+    public void GetDoorCount_AfterLinking_ReturnsCount()
+    {
+        var house = HouseTestDataBuilder.Build();
+        house.LinkDoor(1, new Mock<IItem>().Object);
+        house.LinkDoor(2, new Mock<IItem>().Object);
+
+        house.DoorCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void LinkBed_AddsBedToHouse_GetBedCountReflects()
+    {
+        var house = HouseTestDataBuilder.Build();
+        house.LinkBed(new Mock<IItem>().Object);
+        house.LinkBed(new Mock<IItem>().Object);
+
+        house.BedCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void SetAccessList_DoorListId_UpdatesThatDoorOnly()
+    {
+        var list1 = HouseTestDataBuilder.CreateAccessList("PlayerA");
+        var list2 = HouseTestDataBuilder.CreateAccessList("PlayerB");
+
+        var house = HouseTestDataBuilder.Build();
+        house.SetAccessList(1, list1);
+        house.SetAccessList(2, list2);
+
+        var newListForDoor1 = HouseTestDataBuilder.CreateAccessList("PlayerC");
+        house.SetAccessList(1, newListForDoor1);
+
+        house.GetAccessList(1).Should().BeSameAs(newListForDoor1);
+        house.GetAccessList(2).Should().BeSameAs(list2);
+    }
+
+    [Fact]
+    public void EntryPosition_DefaultsToFirstTileLocation()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var house = HouseTestDataBuilder.Build();
+
+        house.LinkTile(tileMock.Object);
+
+        house.EntryPosition.Should().Be(tileMock.Object.Location);
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Houses/HouseEvictionTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseEvictionTests.cs
@@ -1,0 +1,94 @@
+using Moq;
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Houses;
+using NeoServer.Domain.Houses.AccessList;
+using NeoServer.Domain.Tests.Helpers.House;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseEvictionTests
+{
+    [Fact]
+    public void CanKick_OwnerKicksGuest_ReturnsTrue()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var guest = HouseTestDataBuilder.CreatePlayer(id: 2, level: 5);
+        var guestMock = Mock.Get(guest);
+        guestMock.Setup(x => x.Tile).Returns(tileMock.Object);
+
+        var house = HouseTestDataBuilder.Build(
+            ownerGuid: 1,
+            tiles: new List<Mock<IDynamicTile>> { tileMock });
+
+        var owner = HouseTestDataBuilder.CreatePlayer(id: 1, level: 100);
+
+        house.CanKick(owner, guest).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanKick_SubownerKicksGuest_ReturnsTrue()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var guest = HouseTestDataBuilder.CreatePlayer(id: 3, level: 5);
+        var guestMock = Mock.Get(guest);
+        guestMock.Setup(x => x.Tile).Returns(tileMock.Object);
+
+        var house = HouseTestDataBuilder.Build(
+            tiles: new List<Mock<IDynamicTile>> { tileMock },
+            accessLists: new Dictionary<uint, HouseAccessList>
+            {
+                { HouseListId.SubOwnerList, HouseTestDataBuilder.CreateAccessList("Sub") }
+            });
+
+        var subowner = HouseTestDataBuilder.CreatePlayer(id: 2, level: 50, name: "Sub");
+
+        house.CanKick(subowner, guest).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanKick_GuestKicksAnyone_ReturnsFalse()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var target = HouseTestDataBuilder.CreatePlayer(id: 2, level: 5);
+        var targetMock = Mock.Get(target);
+        targetMock.Setup(x => x.Tile).Returns(tileMock.Object);
+
+        var house = HouseTestDataBuilder.Build(
+            tiles: new List<Mock<IDynamicTile>> { tileMock },
+            accessLists: new Dictionary<uint, HouseAccessList>
+            {
+                { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Guest") }
+            });
+
+        var guestKicker = HouseTestDataBuilder.CreatePlayer(id: 3, level: 10, name: "Guest");
+
+        house.CanKick(guestKicker, target).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanKick_AnyoneKicksOwner_ReturnsFalse()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var owner = HouseTestDataBuilder.CreatePlayer(id: 1, level: 100);
+
+        var house = HouseTestDataBuilder.Build(
+            ownerGuid: 1,
+            tiles: new List<Mock<IDynamicTile>> { tileMock });
+
+        var subowner = HouseTestDataBuilder.CreatePlayer(id: 2, level: 50, name: "Sub");
+
+        house.CanKick(subowner, owner).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanKick_TargetNotInHouse_ReturnsFalse()
+    {
+        var target = HouseTestDataBuilder.CreatePlayer(id: 3, level: 5);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+        var owner = HouseTestDataBuilder.CreatePlayer(id: 1, level: 100);
+
+        house.CanKick(owner, target).Should().BeFalse();
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Houses/HouseFactoryTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseFactoryTests.cs
@@ -1,0 +1,39 @@
+using NeoServer.Domain.Tests.Helpers.House;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseFactoryTests
+{
+    [Fact]
+    public void Create_FromEntity_MapsIdNameTownRentWarningsOwner()
+    {
+        var factory = new Domain.Houses.HouseFactory();
+
+        var house = factory.Create(1, "Test House", 2, 500, 10, "Owner", 100, null, 3);
+
+        house.Id.Should().Be(1);
+        house.Name.Should().Be("Test House");
+        house.TownId.Should().Be(2);
+        house.Rent.Should().Be(500u);
+        house.OwnerGuid.Should().Be(10);
+        house.OwnerName.Should().Be("Owner");
+        house.OwnerAccountId.Should().Be(100);
+        house.PayRentWarnings.Should().Be(3);
+        house.PaidUntil.Should().BeNull();
+        house.TileCount.Should().Be(0);
+    }
+
+    [Fact]
+    public void Create_UnownedEntity_ProducesUnownedHouseWithEmptyLists()
+    {
+        var factory = new Domain.Houses.HouseFactory();
+
+        var house = factory.Create(1, "Empty", 1, 0, 0, null, 0, null, 0);
+
+        house.OwnerGuid.Should().Be(0);
+        house.OwnerName.Should().BeEmpty();
+        house.TileCount.Should().Be(0);
+        house.DoorCount.Should().Be(0);
+        house.BedCount.Should().Be(0);
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Houses/HouseItemMovementPolicyTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseItemMovementPolicyTests.cs
@@ -1,0 +1,79 @@
+using Moq;
+using NeoServer.Domain.Common.Contracts.DataStores;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Houses;
+using NeoServer.Domain.Tests.Helpers.House;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseItemMovementPolicyTests
+{
+    [Fact]
+    public void CanMoveItem_NonHouseTile_ReturnsTrue()
+    {
+        var storeMock = new Mock<IHouseStore>();
+        var tileMock = new Mock<ITile>();
+        storeMock.Setup(s => s.GetByTile(tileMock.Object)).Returns((House)null);
+
+        var policy = new HouseItemMovementPolicy(storeMock.Object);
+        var player = HouseTestDataBuilder.CreatePlayer();
+
+        policy.CanMoveItem(player, tileMock.Object).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanMoveItem_HouseTile_InvitedPlayer_ReturnsTrue()
+    {
+        var storeMock = new Mock<IHouseStore>();
+        var tileMock = new Mock<ITile>();
+
+        var ownerPlayer = HouseTestDataBuilder.CreatePlayer(id: 1);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+
+        storeMock.Setup(s => s.GetByTile(tileMock.Object)).Returns(house);
+
+        var policy = new HouseItemMovementPolicy(storeMock.Object);
+
+        policy.CanMoveItem(ownerPlayer, tileMock.Object).Should().BeTrue();
+    }
+
+    [Fact]
+    public void CanMoveItem_HouseTile_UninvitedPlayer_ReturnsFalse()
+    {
+        var storeMock = new Mock<IHouseStore>();
+        var tileMock = new Mock<ITile>();
+
+        var stranger = HouseTestDataBuilder.CreatePlayer(id: 99);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);  // owner is id=1, not id=99
+
+        storeMock.Setup(s => s.GetByTile(tileMock.Object)).Returns(house);
+
+        var policy = new HouseItemMovementPolicy(storeMock.Object);
+
+        policy.CanMoveItem(stranger, tileMock.Object).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanMoveItem_HouseTile_NullPlayer_ReturnsFalse()
+    {
+        var storeMock = new Mock<IHouseStore>();
+        var tileMock = new Mock<ITile>();
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+
+        storeMock.Setup(s => s.GetByTile(tileMock.Object)).Returns(house);
+
+        var policy = new HouseItemMovementPolicy(storeMock.Object);
+
+        policy.CanMoveItem(null, tileMock.Object).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanMoveItem_NullTile_ReturnsTrue()
+    {
+        var storeMock = new Mock<IHouseStore>();
+        var policy = new HouseItemMovementPolicy(storeMock.Object);
+        var player = HouseTestDataBuilder.CreatePlayer();
+
+        policy.CanMoveItem(player, null).Should().BeTrue();
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Houses/HouseItemMovementPolicyTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseItemMovementPolicyTests.cs
@@ -68,12 +68,12 @@ public class HouseItemMovementPolicyTests
     }
 
     [Fact]
-    public void CanMoveItem_NullTile_ReturnsTrue()
+    public void CanMoveItem_NullTile_ReturnsFalse()
     {
         var storeMock = new Mock<IHouseStore>();
         var policy = new HouseItemMovementPolicy(storeMock.Object);
         var player = HouseTestDataBuilder.CreatePlayer();
 
-        policy.CanMoveItem(player, null).Should().BeTrue();
+        policy.CanMoveItem(player, null).Should().BeFalse();
     }
 }

--- a/tests/NeoServer.Domain.Tests/Houses/HouseOwnershipTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseOwnershipTests.cs
@@ -1,0 +1,126 @@
+using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Houses;
+using NeoServer.Domain.Houses.AccessList;
+using NeoServer.Domain.Tests.Helpers.House;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseOwnershipTests
+{
+    [Fact]
+    public void SetNewOwner_FromUnownedToPlayer_SetsOwnerGuidNameAccount()
+    {
+        var house = HouseTestDataBuilder.Build();
+
+        house.SetNewOwner(10, "NewOwner", 100, false, DateTime.UtcNow, 86400);
+
+        house.OwnerGuid.Should().Be(10);
+        house.OwnerName.Should().Be("NewOwner");
+        house.OwnerAccountId.Should().Be(100);
+    }
+
+    [Fact]
+    public void SetNewOwner_WithUpdatePaidUntilTrue_SetsPaidUntilToNowPlusRentPeriod()
+    {
+        var house = HouseTestDataBuilder.Build();
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        house.SetNewOwner(10, "Owner", 100, true, now, 86400);
+
+        house.PaidUntil.Should().Be(now.AddSeconds(86400));
+    }
+
+    [Fact]
+    public void SetNewOwner_WithUpdatePaidUntilTrue_ResetsPayRentWarningsToZero()
+    {
+        var house = HouseTestDataBuilder.Build(payRentWarnings: 5);
+
+        house.SetNewOwner(10, "Owner", 100, true, DateTime.UtcNow, 86400);
+
+        house.PayRentWarnings.Should().Be(0);
+    }
+
+    [Fact]
+    public void SetNewOwner_ChangingOwner_ClearsGuestAndSubownerLists()
+    {
+        var house = HouseTestDataBuilder.Build(
+            ownerGuid: 1,
+            accessLists: new Dictionary<uint, HouseAccessList>
+            {
+                { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Guest") },
+                { HouseListId.SubOwnerList, HouseTestDataBuilder.CreateAccessList("SubOwner") }
+            });
+
+        house.SetNewOwner(10, "NewOwner", 100, false, DateTime.UtcNow, 86400);
+
+        house.GetAccessList(HouseListId.GuestList).Should().BeNull();
+        house.GetAccessList(HouseListId.SubOwnerList).Should().BeNull();
+    }
+
+    [Fact]
+    public void SetNewOwner_ChangingOwner_ClearsAllDoorAccessLists()
+    {
+        var house = HouseTestDataBuilder.Build(
+            ownerGuid: 1,
+            accessLists: new Dictionary<uint, HouseAccessList>
+            {
+                { 1, HouseTestDataBuilder.CreateAccessList("Door1") },
+                { 2, HouseTestDataBuilder.CreateAccessList("Door2") }
+            });
+
+        house.SetNewOwner(10, "NewOwner", 100, false, DateTime.UtcNow, 86400);
+
+        house.GetAccessList(1).Should().BeNull();
+        house.GetAccessList(2).Should().BeNull();
+    }
+
+    [Fact]
+    public void SetNewOwner_ToZeroGuid_MarksHouseUnowned()
+    {
+        var house = HouseTestDataBuilder.Build(
+            ownerGuid: 1,
+            ownerName: "OldOwner",
+            ownerAccountId: 50,
+            accessLists: new Dictionary<uint, HouseAccessList>
+            {
+                { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Guest") }
+            });
+
+        house.SetNewOwner(0, null, 0, false, DateTime.UtcNow, 86400);
+
+        house.OwnerGuid.Should().Be(0);
+        house.OwnerName.Should().BeEmpty();
+        house.OwnerAccountId.Should().Be(0);
+        house.GetAccessList(HouseListId.GuestList).Should().BeNull();
+    }
+
+    [Fact]
+    public void SetNewOwner_ToSameGuid_DoesNotClearLists()
+    {
+        var accessList = HouseTestDataBuilder.CreateAccessList("Guest");
+        var house = HouseTestDataBuilder.Build(
+            ownerGuid: 1,
+            ownerName: "Owner",
+            ownerAccountId: 50,
+            accessLists: new Dictionary<uint, HouseAccessList>
+            {
+                { HouseListId.GuestList, accessList }
+            });
+
+        house.SetNewOwner(1, "Owner", 50, false, DateTime.UtcNow, 86400);
+
+        house.OwnerGuid.Should().Be(1);
+        house.GetAccessList(HouseListId.GuestList).Should().BeSameAs(accessList);
+    }
+
+    [Fact]
+    public void SetNewOwner_SameGuidWithUpdatePaidUntil_RefreshesPaidUntil()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now);
+
+        house.SetNewOwner(1, "Owner", 50, true, now, 86400);
+
+        house.PaidUntil.Should().Be(now.AddSeconds(86400));
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Houses/HouseRentTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseRentTests.cs
@@ -1,6 +1,5 @@
 using Moq;
 using NeoServer.Domain.Common.Contracts.Creatures;
-using NeoServer.Domain.Common.Contracts.DataStores;
 using NeoServer.Domain.Houses;
 using NeoServer.Domain.Tests.Helpers.House;
 
@@ -15,7 +14,7 @@ public class HouseRentTests
         var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 10000);
         var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(10));
 
-        var result = house.PayRent(player, new Mock<ICoinTypeStore>().Object, now, 86400);
+        var result = house.PayRent(player, now, 86400);
 
         result.Should().Be(HouseRentResult.NotDue);
     }
@@ -34,7 +33,7 @@ public class HouseRentTests
 
         var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(-1));
 
-        var result = house.PayRent(playerMock.Object, new Mock<ICoinTypeStore>().Object, now, 86400);
+        var result = house.PayRent(playerMock.Object, now, 86400);
 
         result.Should().Be(HouseRentResult.Paid);
         bankMock.Verify(x => x.Debit(1000), Times.Once);
@@ -48,7 +47,7 @@ public class HouseRentTests
         var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 10000);
         var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(-1), payRentWarnings: 3);
 
-        var result = house.PayRent(player, new Mock<ICoinTypeStore>().Object, now, 86400);
+        var result = house.PayRent(player, now, 86400);
 
         result.Should().Be(HouseRentResult.Paid);
         house.PayRentWarnings.Should().Be(0);
@@ -61,7 +60,7 @@ public class HouseRentTests
         var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 0);
         var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(-1));
 
-        var result = house.PayRent(player, new Mock<ICoinTypeStore>().Object, now, 86400);
+        var result = house.PayRent(player, now, 86400);
 
         result.Should().Be(HouseRentResult.Warned);
         house.PayRentWarnings.Should().Be(1);
@@ -74,7 +73,7 @@ public class HouseRentTests
         var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 0);
         var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(-1), payRentWarnings: 6);
 
-        var result = house.PayRent(player, new Mock<ICoinTypeStore>().Object, now, 86400);
+        var result = house.PayRent(player, now, 86400);
 
         result.Should().Be(HouseRentResult.Evicted);
         house.OwnerGuid.Should().Be(0);
@@ -87,7 +86,7 @@ public class HouseRentTests
         var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 0);
         var house = HouseTestDataBuilder.Build(ownerGuid: 1, rent: 0, paidUntil: now.AddDays(-1));
 
-        var result = house.PayRent(player, new Mock<ICoinTypeStore>().Object, now, 86400);
+        var result = house.PayRent(player, now, 86400);
 
         result.Should().Be(HouseRentResult.NotDue);
     }
@@ -99,7 +98,7 @@ public class HouseRentTests
         var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 0);
         var house = HouseTestDataBuilder.Build();
 
-        var result = house.PayRent(player, new Mock<ICoinTypeStore>().Object, now, 86400);
+        var result = house.PayRent(player, now, 86400);
 
         result.Should().Be(HouseRentResult.NotDue);
     }

--- a/tests/NeoServer.Domain.Tests/Houses/HouseRentTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseRentTests.cs
@@ -1,0 +1,116 @@
+using Moq;
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.DataStores;
+using NeoServer.Domain.Houses;
+using NeoServer.Domain.Tests.Helpers.House;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseRentTests
+{
+    [Fact]
+    public void PayRent_NotDue_ReturnsNotDue_NoDeduction()
+    {
+        var now = DateTime.UtcNow;
+        var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 10000);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(10));
+
+        var result = house.PayRent(player, new Mock<ICoinTypeStore>().Object, now, 86400);
+
+        result.Should().Be(HouseRentResult.NotDue);
+    }
+
+    [Fact]
+    public void PayRent_DueAndSufficientBank_DeductsRentAndAdvancesPaidUntil()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var bankMock = new Mock<IBank>();
+        bankMock.Setup(x => x.Amount).Returns(10000);
+
+        var playerMock = new Mock<IPlayer>();
+        playerMock.Setup(x => x.Id).Returns(1u);
+        playerMock.Setup(x => x.Bank).Returns(bankMock.Object);
+        playerMock.Setup(x => x.BankAmount).Returns(10000);
+
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(-1));
+
+        var result = house.PayRent(playerMock.Object, new Mock<ICoinTypeStore>().Object, now, 86400);
+
+        result.Should().Be(HouseRentResult.Paid);
+        bankMock.Verify(x => x.Debit(1000), Times.Once);
+        house.PaidUntil.Should().Be(now.AddSeconds(86400));
+    }
+
+    [Fact]
+    public void PayRent_DueAndSufficientBank_ResetsWarningsToZero()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 10000);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(-1), payRentWarnings: 3);
+
+        var result = house.PayRent(player, new Mock<ICoinTypeStore>().Object, now, 86400);
+
+        result.Should().Be(HouseRentResult.Paid);
+        house.PayRentWarnings.Should().Be(0);
+    }
+
+    [Fact]
+    public void PayRent_DueAndInsufficientBank_IncrementsWarnings()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 0);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(-1));
+
+        var result = house.PayRent(player, new Mock<ICoinTypeStore>().Object, now, 86400);
+
+        result.Should().Be(HouseRentResult.Warned);
+        house.PayRentWarnings.Should().Be(1);
+    }
+
+    [Fact]
+    public void PayRent_SeventhWarning_ReturnsEvicted()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 0);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(-1), payRentWarnings: 6);
+
+        var result = house.PayRent(player, new Mock<ICoinTypeStore>().Object, now, 86400);
+
+        result.Should().Be(HouseRentResult.Evicted);
+        house.OwnerGuid.Should().Be(0);
+    }
+
+    [Fact]
+    public void PayRent_RentZero_ReturnsNotDue()
+    {
+        var now = DateTime.UtcNow;
+        var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 0);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1, rent: 0, paidUntil: now.AddDays(-1));
+
+        var result = house.PayRent(player, new Mock<ICoinTypeStore>().Object, now, 86400);
+
+        result.Should().Be(HouseRentResult.NotDue);
+    }
+
+    [Fact]
+    public void PayRent_Unowned_ReturnsNotDue()
+    {
+        var now = DateTime.UtcNow;
+        var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 0);
+        var house = HouseTestDataBuilder.Build();
+
+        var result = house.PayRent(player, new Mock<ICoinTypeStore>().Object, now, 86400);
+
+        result.Should().Be(HouseRentResult.NotDue);
+    }
+
+    [Fact]
+    public void SetPayRentWarnings_AboveCap_ClampsToSeven()
+    {
+        var house = HouseTestDataBuilder.Build();
+
+        house.PayRentWarnings = 10;
+
+        house.PayRentWarnings.Should().Be(7);
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Houses/HouseServiceTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseServiceTests.cs
@@ -1,7 +1,6 @@
 using Moq;
 using NeoServer.Domain.Common;
 using NeoServer.Domain.Common.Contracts.Creatures;
-using NeoServer.Domain.Common.Contracts.DataStores;
 using NeoServer.Domain.Common.Contracts.Items;
 using NeoServer.Domain.Common.Contracts.World.Tiles;
 using NeoServer.Domain.Common.Location.Structs;
@@ -150,7 +149,7 @@ public class HouseServiceTests
 
         var service = CreateService();
 
-        service.PayRent(house, player, new Mock<ICoinTypeStore>().Object, now, 86400);
+        service.PayRent(house, player, now, 86400);
 
         capturedEvent.Should().NotBeNull();
         capturedEvent.House.Should().Be(house);
@@ -169,7 +168,7 @@ public class HouseServiceTests
 
         var service = CreateService();
 
-        service.PayRent(house, player, new Mock<ICoinTypeStore>().Object, now, 86400);
+        service.PayRent(house, player, now, 86400);
 
         capturedEvent.Should().NotBeNull();
         capturedEvent.House.Should().Be(house);
@@ -185,7 +184,7 @@ public class HouseServiceTests
         var repoMock = new Mock<IHouseRepository>();
         var service = CreateService(repo: repoMock);
 
-        service.PayRent(house, player, new Mock<ICoinTypeStore>().Object, now, 86400);
+        service.PayRent(house, player, now, 86400);
 
         repoMock.Verify(x => x.Save(house), Times.Once);
     }

--- a/tests/NeoServer.Domain.Tests/Houses/HouseServiceTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseServiceTests.cs
@@ -1,0 +1,250 @@
+using Moq;
+using NeoServer.Domain.Common;
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.DataStores;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Houses;
+using NeoServer.Domain.Houses.Events;
+using NeoServer.Domain.Houses.Services;
+using NeoServer.Domain.Repositories;
+using NeoServer.Domain.Tests.Helpers;
+using NeoServer.Domain.Tests.Helpers.House;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseServiceTests
+{
+    [Fact]
+    public void SetOwner_EvictsNowUninvitedPlayers()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var guest = HouseTestDataBuilder.CreatePlayer(id: 2, level: 5);
+
+        var tileMock = HouseTestDataBuilder.CreateTileMock(players: new List<IPlayer> { guest });
+        var house = HouseTestDataBuilder.Build(
+            ownerGuid: 1,
+            tiles: new List<Mock<IDynamicTile>> { tileMock },
+            entryPosition: new Location(100, 100, 7));
+
+        var evictionMock = new Mock<IHouseEviction>();
+        var service = CreateService(eviction: evictionMock);
+
+        service.SetOwner(house, 10, "NewOwner", 100, false, now, 86400);
+
+        evictionMock.Verify(x => x.TeleportToExit(guest,
+            It.Is<Location>(l => l.X == 100 && l.Y == 100 && l.Z == 7)), Times.Once);
+    }
+
+    [Fact]
+    public void SetOwner_WakesAllBeds()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var bedMock = HouseTestDataBuilder.CreateItemMock();
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+
+        var house = HouseTestDataBuilder.Build(
+            ownerGuid: 1,
+            tiles: new List<Mock<IDynamicTile>> { tileMock },
+            beds: new List<Mock<IItem>> { bedMock });
+
+        var bedWakerMock = new Mock<IHouseBedWaker>();
+        var service = CreateService(bedWaker: bedWakerMock);
+
+        service.SetOwner(house, 10, "NewOwner", 100, false, now, 86400);
+
+        bedWakerMock.Verify(x => x.WakeAll(It.Is<IEnumerable<IItem>>(b => b.Contains(bedMock.Object))), Times.Once);
+    }
+
+    [Fact]
+    public void SetOwner_TransfersPickupableItemsToOldOwnerDepot()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var pickupableItem = HouseTestDataBuilder.CreateItemMock(isPickupable: true);
+        var nonPickupableItem = HouseTestDataBuilder.CreateItemMock(isPickupable: false);
+
+        var tileMock = HouseTestDataBuilder.CreateTileMock(items: new List<IItem>
+        {
+            pickupableItem.Object,
+            nonPickupableItem.Object
+        });
+
+        var house = HouseTestDataBuilder.Build(
+            ownerGuid: 1,
+            ownerAccountId: 50,
+            townId: 2,
+            tiles: new List<Mock<IDynamicTile>> { tileMock });
+
+        var depotMock = new Mock<IHouseDepotTransfer>();
+        var service = CreateService(depotTransfer: depotMock);
+
+        service.SetOwner(house, 10, "NewOwner", 100, false, now, 86400);
+
+        depotMock.Verify(x => x.TransferToOwnerDepot(50, 2,
+            It.Is<IEnumerable<IItem>>(items => items.Contains(pickupableItem.Object) && !items.Contains(nonPickupableItem.Object))),
+            Times.Once);
+    }
+
+    [Fact]
+    public void SetOwner_LeavesNonPickupableItems()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var nonPickupableItem = HouseTestDataBuilder.CreateItemMock(isPickupable: false);
+        var tileMock = HouseTestDataBuilder.CreateTileMock(items: new List<IItem> { nonPickupableItem.Object });
+
+        var house = HouseTestDataBuilder.Build(
+            ownerGuid: 1,
+            ownerAccountId: 50,
+            tiles: new List<Mock<IDynamicTile>> { tileMock });
+
+        var depotMock = new Mock<IHouseDepotTransfer>();
+        var service = CreateService(depotTransfer: depotMock);
+
+        service.SetOwner(house, 10, "NewOwner", 100, false, now, 86400);
+
+        depotMock.Verify(x => x.TransferToOwnerDepot(It.IsAny<int>(), It.IsAny<ushort>(),
+            It.IsAny<IEnumerable<IItem>>()), Times.Never);
+    }
+
+    [Fact]
+    public void SetOwner_PersistsHouse()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+
+        var repoMock = new Mock<IHouseRepository>();
+        var service = CreateService(repo: repoMock);
+
+        service.SetOwner(house, 10, "NewOwner", 100, false, now, 86400);
+
+        repoMock.Verify(x => x.Save(house), Times.Once);
+    }
+
+    [Fact]
+    public void SetOwner_RaisesHouseOwnerChangedEvent()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        HouseOwnerChangedEvent capturedEvent = null;
+        EventAggregatorTestHelper.SetupEventAggregator<HouseOwnerChangedEvent>(e => capturedEvent = e);
+
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+        var service = CreateService();
+
+        service.SetOwner(house, 10, "NewOwner", 100, false, now, 86400);
+
+        capturedEvent.Should().NotBeNull();
+        capturedEvent.OldOwnerGuid.Should().Be(1);
+        capturedEvent.NewOwnerGuid.Should().Be(10);
+    }
+
+    [Fact]
+    public void PayRent_Warned_RaisesHouseRentWarningEvent()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        HouseRentWarningEvent capturedEvent = null;
+        EventAggregatorTestHelper.SetupEventAggregator<HouseRentWarningEvent>(e => capturedEvent = e);
+
+        var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 0);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(-1));
+
+        var service = CreateService();
+
+        service.PayRent(house, player, new Mock<ICoinTypeStore>().Object, now, 86400);
+
+        capturedEvent.Should().NotBeNull();
+        capturedEvent.House.Should().Be(house);
+        capturedEvent.WarningNumber.Should().Be(1);
+    }
+
+    [Fact]
+    public void PayRent_Evicted_RaisesHouseEvictedEvent()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        HouseEvictedEvent capturedEvent = null;
+        EventAggregatorTestHelper.SetupEventAggregator<HouseEvictedEvent>(e => capturedEvent = e);
+
+        var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 0);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(-1), payRentWarnings: 6);
+
+        var service = CreateService();
+
+        service.PayRent(house, player, new Mock<ICoinTypeStore>().Object, now, 86400);
+
+        capturedEvent.Should().NotBeNull();
+        capturedEvent.House.Should().Be(house);
+    }
+
+    [Fact]
+    public void PayRent_Paid_PersistsHouseState()
+    {
+        var now = new DateTime(2025, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        var player = HouseTestDataBuilder.CreatePlayerWithBank(id: 1, bankAmount: 10000);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: now.AddDays(-1));
+
+        var repoMock = new Mock<IHouseRepository>();
+        var service = CreateService(repo: repoMock);
+
+        service.PayRent(house, player, new Mock<ICoinTypeStore>().Object, now, 86400);
+
+        repoMock.Verify(x => x.Save(house), Times.Once);
+    }
+
+    [Fact]
+    public void CanKick_Success_TeleportsTargetAndPersists()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var target = HouseTestDataBuilder.CreatePlayer(id: 2, level: 5);
+        var targetMock = Mock.Get(target);
+        targetMock.Setup(x => x.Tile).Returns(tileMock.Object);
+
+        tileMock.Setup(x => x.Players).Returns(new List<IPlayer> { target });
+
+        var house = HouseTestDataBuilder.Build(
+            ownerGuid: 1,
+            tiles: new List<Mock<IDynamicTile>> { tileMock },
+            entryPosition: new Location(100, 100, 7));
+
+        var caster = HouseTestDataBuilder.CreatePlayer(id: 1, level: 100);
+
+        var evictionMock = new Mock<IHouseEviction>();
+        var repoMock = new Mock<IHouseRepository>();
+        var service = CreateService(eviction: evictionMock, repo: repoMock);
+
+        service.KickPlayer(house, caster, target).Should().BeTrue();
+
+        evictionMock.Verify(x => x.TeleportToExit(target,
+            It.Is<Location>(l => l.X == 100 && l.Y == 100 && l.Z == 7)), Times.Once);
+        repoMock.Verify(x => x.Save(house), Times.Once);
+    }
+
+    [Fact]
+    public void CanKick_Failure_NoSideEffects()
+    {
+        var target = HouseTestDataBuilder.CreatePlayer(id: 3, level: 5);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+        var caster = HouseTestDataBuilder.CreatePlayer(id: 1, level: 100);
+
+        var evictionMock = new Mock<IHouseEviction>();
+        var repoMock = new Mock<IHouseRepository>();
+        var service = CreateService(eviction: evictionMock, repo: repoMock);
+
+        service.KickPlayer(house, caster, target).Should().BeFalse();
+
+        evictionMock.Verify(x => x.TeleportToExit(It.IsAny<IPlayer>(), It.IsAny<Location>()), Times.Never);
+        repoMock.Verify(x => x.Save(It.IsAny<House>()), Times.Never);
+    }
+
+    private static HouseService CreateService(
+        Mock<IHouseRepository> repo = null,
+        Mock<IHouseEviction> eviction = null,
+        Mock<IHouseBedWaker> bedWaker = null,
+        Mock<IHouseDepotTransfer> depotTransfer = null)
+    {
+        return new HouseService(
+            repo?.Object ?? new Mock<IHouseRepository>().Object,
+            eviction?.Object ?? new Mock<IHouseEviction>().Object,
+            bedWaker?.Object ?? new Mock<IHouseBedWaker>().Object,
+            depotTransfer?.Object ?? new Mock<IHouseDepotTransfer>().Object);
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Houses/HouseServiceTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseServiceTests.cs
@@ -238,12 +238,14 @@ public class HouseServiceTests
         Mock<IHouseRepository> repo = null,
         Mock<IHouseEviction> eviction = null,
         Mock<IHouseBedWaker> bedWaker = null,
-        Mock<IHouseDepotTransfer> depotTransfer = null)
+        Mock<IHouseDepotTransfer> depotTransfer = null,
+        HouseConfiguration houseConfiguration = null)
     {
         return new HouseService(
             repo?.Object ?? new Mock<IHouseRepository>().Object,
             eviction?.Object ?? new Mock<IHouseEviction>().Object,
             bedWaker?.Object ?? new Mock<IHouseBedWaker>().Object,
-            depotTransfer?.Object ?? new Mock<IHouseDepotTransfer>().Object);
+            depotTransfer?.Object ?? new Mock<IHouseDepotTransfer>().Object,
+            houseConfiguration ?? new HouseConfiguration());
     }
 }

--- a/tests/NeoServer.Domain.Tests/Houses/HouseTileAssociationTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseTileAssociationTests.cs
@@ -58,13 +58,38 @@ public class HouseTileAssociationTests
     }
 
     [Fact]
-    public void LinkTile_SameTileToTwoHouses_Throws()
+    public void LinkTile_SetsProtectionZoneFlag()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var house = HouseTestDataBuilder.Build();
+
+        house.LinkTile(tileMock.Object);
+
+        tileMock.Object.HasFlag(TileFlags.ProtectionZone).Should().BeTrue();
+    }
+
+    [Fact]
+    public void LinkTile_SameTileToSameHouseTwice_Throws()
     {
         var tileMock = HouseTestDataBuilder.CreateTileMock();
         var house = HouseTestDataBuilder.Build();
         house.LinkTile(tileMock.Object);
 
         Action act = () => house.LinkTile(tileMock.Object);
+        act.Should().Throw<InvalidOperationException>();
+    }
+
+    [Fact]
+    public void LinkTile_SameTileToTwoDifferentHouses_Throws()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var houseA = HouseTestDataBuilder.Build(id: 1);
+        var houseB = HouseTestDataBuilder.Build(id: 2);
+
+        houseA.LinkTile(tileMock.Object);
+
+        // CanEnterFunction is now set by houseA; houseB must reject this tile.
+        Action act = () => houseB.LinkTile(tileMock.Object);
         act.Should().Throw<InvalidOperationException>();
     }
 }

--- a/tests/NeoServer.Domain.Tests/Houses/HouseTileAssociationTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseTileAssociationTests.cs
@@ -1,0 +1,70 @@
+using Moq;
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Common.Location;
+using NeoServer.Domain.Tests.Helpers.House;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseTileAssociationTests
+{
+    [Fact]
+    public void LinkTile_InstallsCanEnterFunction_BlockingUninvitedPlayer()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var house = HouseTestDataBuilder.Build();
+
+        house.LinkTile(tileMock.Object);
+
+        var uninvited = HouseTestDataBuilder.CreatePlayer(name: "Stranger");
+        var canEnter = tileMock.Object.CanEnterFunction(uninvited);
+        canEnter.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LinkTile_CanEnterFunction_AllowsInvitedPlayer()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+
+        house.LinkTile(tileMock.Object);
+
+        var owner = HouseTestDataBuilder.CreatePlayer(id: 1);
+        var canEnter = tileMock.Object.CanEnterFunction(owner);
+        canEnter.Should().BeTrue();
+    }
+
+    [Fact]
+    public void LinkTile_NonPlayerCreature_CanEnterFalse()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var house = HouseTestDataBuilder.Build();
+        house.LinkTile(tileMock.Object);
+
+        var creatureMock = new Mock<ICreature>();
+        var canEnter = tileMock.Object.CanEnterFunction(creatureMock.Object);
+        canEnter.Should().BeFalse();
+    }
+
+    [Fact]
+    public void GetTileCount_AfterLinkingTiles_ReturnsCount()
+    {
+        var house = HouseTestDataBuilder.Build();
+
+        house.LinkTile(HouseTestDataBuilder.CreateTileMock().Object);
+        house.LinkTile(HouseTestDataBuilder.CreateTileMock().Object);
+
+        house.TileCount.Should().Be(2);
+    }
+
+    [Fact]
+    public void LinkTile_SameTileToTwoHouses_Throws()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var house = HouseTestDataBuilder.Build();
+        house.LinkTile(tileMock.Object);
+
+        Action act = () => house.LinkTile(tileMock.Object);
+        act.Should().Throw<InvalidOperationException>();
+    }
+}


### PR DESCRIPTION
### Description
Implements Phase 1 of the house system: domain aggregate, value objects, in-memory store, service layer, and full test suite. Houses now support ownership transfer, access lists (guest/subowner/door), rent collection with 7-warning eviction, and player kick validation.

### Key Changes
- **House aggregate** — pure domain entity with ownership state, tile/door/bed linkage, and access resolution (Owner > SubOwner > Guest > NotInvited)
- **HouseAccessList** — structured access list (players, guilds, guild+rank, wildcard) with case-insensitive matching
- **HouseService** — orchestrates ownership changes (eviction, bed wake, depot transfer), rent cycle, and kick with persistence via `IHouseRepository`
- **Domain events** — `HouseOwnerChangedEvent`, `HouseRentWarningEvent`, `HouseEvictedEvent` for player notifications
- **64 unit tests** — ownership, access levels, rent, eviction, tile association, door/bed, factory, and service orchestration

### Types of Changes
- [x] New feature (non-breaking change which adds functionality)

### Test Case
`dotnet test tests/NeoServer.Domain.Tests` — 1379 passed, 0 failed (64 new house tests)