### PR TITLE
feat: make premium account requirement for house ownership configurable

### DIFF
--- a/src/Core/NeoServer.Domain/Common/GameConfiguration.cs
+++ b/src/Core/NeoServer.Domain/Common/GameConfiguration.cs
@@ -51,4 +51,4 @@ public record YellConfiguration(int YellCooldownSeconds = 30, int YellMinimumLev
 
 public record ReportConfiguration(uint ReportMaxTime = 60);
 
-public record HouseConfiguration(bool TransferItemsToDepotOnOwnershipChange = true);
+public record HouseConfiguration(bool TransferItemsToDepotOnOwnershipChange = true, bool RequirePremiumAccount = true);

--- a/src/Core/NeoServer.Domain/Houses/Services/HouseService.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/HouseService.cs
@@ -91,4 +91,13 @@ public class HouseService(
         return true;
     }
 
+    /// <summary>Returns false when premium is required and the player lacks premium time.</summary>
+    public bool CanPlayerOwnHouse(IPlayer player)
+    {
+        if (!houseConfiguration.RequirePremiumAccount)
+            return true;
+
+        return player.HasPremiumTime;
+    }
+
 }

--- a/src/Core/NeoServer.Domain/Houses/Services/IHouseService.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/IHouseService.cs
@@ -17,4 +17,7 @@ public interface IHouseService
 
     /// <summary>Kick a player out of the house. Only subowners or higher can kick lower-level players.</summary>
     bool KickPlayer(House house, IPlayer caster, IPlayer target);
+
+    /// <summary>Returns false when premium is required and the player lacks premium time.</summary>
+    bool CanPlayerOwnHouse(IPlayer player);
 }

--- a/src/Standalone/appsettings.json
+++ b/src/Standalone/appsettings.json
@@ -73,7 +73,8 @@
       "yellAllowedPremium": true
     },
     "house": {
-      "transferItemsToDepotOnOwnershipChange": true
+      "transferItemsToDepotOnOwnershipChange": true,
+      "requirePremiumAccount": true
     }
   },
   "client": {


### PR DESCRIPTION
### Description
Adds a configurable `RequirePremiumAccount` flag to `HouseConfiguration` so server operators can control whether premium time is required for house ownership without modifying code.

### Key Changes
- Added `RequirePremiumAccount` (default `true`) to `HouseConfiguration` record
- Added `CanPlayerOwnHouse(IPlayer)` method to `IHouseService` and `HouseService` — returns `true` when the flag is `false`, otherwise checks `player.HasPremiumTime`
- Added `"requirePremiumAccount": true` to `appsettings.json` under `"house"`

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
`dotnet test tests/` — 302 passed, existing behavior preserved (default `true` matches previous hardcoded behavior)