### PR TITLE
feat: persist house tile items between server restarts

### DIFF
--- a/src/ApplicationServer/NeoServer.Server.Routines/Persistence/HouseTilePersistenceRoutine.cs
+++ b/src/ApplicationServer/NeoServer.Server.Routines/Persistence/HouseTilePersistenceRoutine.cs
@@ -46,12 +46,12 @@ public class HouseTilePersistenceRoutine(
 
             if (houses is null || houses.Count == 0) return;
 
-            logger.Information("Saving {Count} house tiles...", houses.Count);
+            logger.Information("Saving tile data for {Count} houses...", houses.Count);
             _stopwatch.Restart();
 
             await houseRepository.SaveTilesAsync(houses);
 
-            logger.Information("{Count} house tiles saved in {Elapsed} ms", houses.Count, _stopwatch.ElapsedMilliseconds);
+            logger.Information("Tile data for {Count} houses saved in {Elapsed} ms", houses.Count, _stopwatch.ElapsedMilliseconds);
         }
         catch (Exception e)
         {

--- a/src/ApplicationServer/NeoServer.Server.Routines/Persistence/HouseTilePersistenceRoutine.cs
+++ b/src/ApplicationServer/NeoServer.Server.Routines/Persistence/HouseTilePersistenceRoutine.cs
@@ -38,7 +38,7 @@ public class HouseTilePersistenceRoutine(
         }, token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
     }
 
-    private async Task SaveHouseTiles()
+    public async Task SaveHouseTiles()
     {
         try
         {

--- a/src/ApplicationServer/NeoServer.Server.Routines/Persistence/HouseTilePersistenceRoutine.cs
+++ b/src/ApplicationServer/NeoServer.Server.Routines/Persistence/HouseTilePersistenceRoutine.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using NeoServer.Domain.Common.Contracts.DataStores;
+using NeoServer.Domain.Houses;
+using NeoServer.Domain.Repositories;
+using NeoServer.Server.Common.Contracts;
+using NeoServer.Server.Configurations;
+using Serilog;
+
+namespace NeoServer.Server.Routines.Persistence;
+
+public class HouseTilePersistenceRoutine(
+    IGameServer gameServer,
+    IHouseStore houseStore,
+    IHouseRepository houseRepository,
+    ILogger logger,
+    ServerConfiguration serverConfiguration)
+{
+    private readonly Stopwatch _stopwatch = new();
+    private int _saveInterval;
+
+    public void Start(CancellationToken token)
+    {
+        _saveInterval = (int)(serverConfiguration?.Save?.HouseTiles ?? 60);
+        _saveInterval = (_saveInterval == 0 ? 60 : _saveInterval) * (int)TimeSpan.MillisecondsPerSecond;
+
+        Task.Factory.StartNew(async () =>
+        {
+            while (!token.IsCancellationRequested)
+            {
+                await Task.Delay(_saveInterval, token);
+                gameServer.PersistenceDispatcher.AddEvent(async () => await SaveHouseTiles());
+            }
+        }, token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+    }
+
+    private async Task SaveHouseTiles()
+    {
+        try
+        {
+            var houses = houseStore.All?.ToList();
+
+            if (houses is null || houses.Count == 0) return;
+
+            logger.Information("Saving {Count} house tiles...", houses.Count);
+            _stopwatch.Restart();
+
+            await houseRepository.SaveTilesAsync(houses);
+
+            logger.Information("{Count} house tiles saved in {Elapsed} ms", houses.Count, _stopwatch.ElapsedMilliseconds);
+        }
+        catch (Exception e)
+        {
+            logger.Error(e, "Error saving house tiles");
+            throw;
+        }
+    }
+}

--- a/src/ApplicationServer/NeoServer.Server.Routines/Persistence/PlayerPersistenceRoutine.cs
+++ b/src/ApplicationServer/NeoServer.Server.Routines/Persistence/PlayerPersistenceRoutine.cs
@@ -38,8 +38,8 @@ public class PlayerPersistenceRoutine(
         {
             while (!token.IsCancellationRequested)
             {
-                gameServer.PersistenceDispatcher.AddEvent(async () => await SavePlayers());
                 await Task.Delay(_saveInterval, token);
+                gameServer.PersistenceDispatcher.AddEvent(async () => await SavePlayers());
             }
         }, token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
     }

--- a/src/ApplicationServer/NeoServer.Server/Configurations/ServerConfiguration.cs
+++ b/src/ApplicationServer/NeoServer.Server/Configurations/ServerConfiguration.cs
@@ -31,7 +31,7 @@ public record ServerConfiguration(
 
 public record LogConfiguration(string MinimumLevel);
 
-public record SaveConfiguration(uint Players);
+public record SaveConfiguration(uint Players, uint HouseTiles);
 
 public record DatabaseConfiguration(Dictionary<DatabaseType, string> Connections, DatabaseType Active, bool DropOnStartup);
 

--- a/src/Core/NeoServer.Domain/Houses/House.cs
+++ b/src/Core/NeoServer.Domain/Houses/House.cs
@@ -68,7 +68,7 @@ public class House
 
         _tiles.Add(tile);
         tile.SetAsProtectionZone();
-        tile.CanEnterFunction = c => c is IPlayer p && IsInvited(p);
+        tile.CanEnterFunction = c => c is IPlayer p && (IsInvited(p) || p.Group?.Access == true);
 
         if (EntryPosition is null)
             EntryPosition = tile.Location;

--- a/src/Core/NeoServer.Domain/Repositories/IHouseRepository.cs
+++ b/src/Core/NeoServer.Domain/Repositories/IHouseRepository.cs
@@ -1,5 +1,7 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Location.Structs;
 using NeoServer.Domain.Houses;
 
 namespace NeoServer.Domain.Repositories;
@@ -7,8 +9,11 @@ namespace NeoServer.Domain.Repositories;
 public interface IHouseRepository
 {
     void Save(House house);
+    Task SaveTilesAsync(House house);
+    Task SaveTilesAsync(List<House> houses);
     void SaveAccessList(uint houseId, uint listId, string text);
     Task<IEnumerable<House>> GetAll();
     Task<House> GetById(uint id);
     Task<IReadOnlyDictionary<uint, List<(uint ListId, string ListText)>>> GetAllAccessListText();
+    Task<IReadOnlyDictionary<uint, List<(Location Location, List<IItem> Items)>>> GetAllTileDataAsync();
 }

--- a/src/Database/NeoServer.Data/Configurations/ForSqLite/ForSqLiteHouseTileEntityConfiguration.cs
+++ b/src/Database/NeoServer.Data/Configurations/ForSqLite/ForSqLiteHouseTileEntityConfiguration.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using NeoServer.Data.Entities;
+
+namespace NeoServer.Data.Configurations.ForSqLite;
+
+public class ForSqLiteHouseTileEntityConfiguration : IEntityTypeConfiguration<HouseTileEntity>
+{
+    public void Configure(EntityTypeBuilder<HouseTileEntity> builder)
+    {
+        builder.HasKey(ht => new { ht.HouseId, ht.TileX, ht.TileY, ht.TileZ });
+        builder.Property(ht => ht.TileX).IsRequired();
+        builder.Property(ht => ht.TileY).IsRequired();
+        builder.Property(ht => ht.TileZ).IsRequired();
+        builder.Property(ht => ht.Data).HasColumnType("BLOB");
+        builder.HasOne(ht => ht.House)
+            .WithMany(h => h.HouseTiles)
+            .HasForeignKey(ht => ht.HouseId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Database/NeoServer.Data/Configurations/HouseTileEntityConfiguration.cs
+++ b/src/Database/NeoServer.Data/Configurations/HouseTileEntityConfiguration.cs
@@ -1,0 +1,21 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using NeoServer.Data.Entities;
+
+namespace NeoServer.Data.Configurations;
+
+public class HouseTileEntityConfiguration : IEntityTypeConfiguration<HouseTileEntity>
+{
+    public void Configure(EntityTypeBuilder<HouseTileEntity> builder)
+    {
+        builder.HasKey(ht => new { ht.HouseId, ht.TileX, ht.TileY, ht.TileZ });
+        builder.Property(ht => ht.TileX).IsRequired();
+        builder.Property(ht => ht.TileY).IsRequired();
+        builder.Property(ht => ht.TileZ).IsRequired();
+        builder.Property(ht => ht.Data).HasColumnType("bytea");
+        builder.HasOne(ht => ht.House)
+            .WithMany(h => h.HouseTiles)
+            .HasForeignKey(ht => ht.HouseId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Database/NeoServer.Data/Contexts/NeoContext.cs
+++ b/src/Database/NeoServer.Data/Contexts/NeoContext.cs
@@ -48,6 +48,7 @@ public class NeoContext : DbContext
 
     public DbSet<HouseEntity> Houses { get; set; }
     public DbSet<HouseListEntity> HouseList { get; set; }
+    public DbSet<HouseTileEntity> HouseTiles { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
@@ -71,6 +72,7 @@ public class NeoContext : DbContext
             modelBuilder.ApplyConfiguration(new ForSqLiteAccountPremiumHistoryEntityConfiguration());
             modelBuilder.ApplyConfiguration(new ForSqLitePlayerDeathEntityConfiguration());
             modelBuilder.ApplyConfiguration(new ForSqLitePlayerDeathKillerEntityConfiguration());
+            modelBuilder.ApplyConfiguration(new ForSqLiteHouseTileEntityConfiguration());
         }
         else
         {
@@ -99,6 +101,7 @@ public class NeoContext : DbContext
         modelBuilder.ApplyConfiguration(new ReportBugEntityConfiguration());
         modelBuilder.ApplyConfiguration(new HouseEntityConfiguration());
         modelBuilder.ApplyConfiguration(new HouseListEntityConfiguration());
+        modelBuilder.ApplyConfiguration(new HouseTileEntityConfiguration());
 
         foreach (var entity in modelBuilder.Model.GetEntityTypes())
         {

--- a/src/Database/NeoServer.Data/Entities/HouseEntity.cs
+++ b/src/Database/NeoServer.Data/Entities/HouseEntity.cs
@@ -21,4 +21,5 @@ public sealed class HouseEntity
     public int Beds { get; set; }
 
     public ICollection<HouseListEntity> HouseLists { get; set; }
+    public ICollection<HouseTileEntity> HouseTiles { get; set; }
 }

--- a/src/Database/NeoServer.Data/Entities/HouseTileEntity.cs
+++ b/src/Database/NeoServer.Data/Entities/HouseTileEntity.cs
@@ -1,0 +1,12 @@
+namespace NeoServer.Data.Entities;
+
+public sealed class HouseTileEntity
+{
+    public int HouseId { get; set; }
+    public int TileX { get; set; }
+    public int TileY { get; set; }
+    public int TileZ { get; set; }
+    public byte[] Data { get; set; }
+
+    public HouseEntity House { get; set; }
+}

--- a/src/Database/NeoServer.Data/Repositories/HouseRepository.cs
+++ b/src/Database/NeoServer.Data/Repositories/HouseRepository.cs
@@ -6,6 +6,9 @@ using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using NeoServer.Data.Contexts;
 using NeoServer.Data.Entities;
+using NeoServer.Data.Serializers;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Location.Structs;
 using NeoServer.Domain.Houses;
 using NeoServer.Domain.Repositories;
 using Serilog;
@@ -15,11 +18,13 @@ namespace NeoServer.Data.Repositories;
 public class HouseRepository : BaseRepository<HouseEntity>, IHouseRepository
 {
     private readonly IHouseFactory _houseFactory;
+    private readonly IItemFactory _itemFactory;
 
-    public HouseRepository(DbContextOptions<NeoContext> contextOptions, ILogger logger, IHouseFactory houseFactory)
+    public HouseRepository(DbContextOptions<NeoContext> contextOptions, ILogger logger, IHouseFactory houseFactory, IItemFactory itemFactory)
         : base(contextOptions, logger)
     {
         _houseFactory = houseFactory;
+        _itemFactory = itemFactory;
     }
 
     public async Task<IEnumerable<House>> GetAll()
@@ -101,7 +106,7 @@ public class HouseRepository : BaseRepository<HouseEntity>, IHouseRepository
     {
         SaveAsync(house).GetAwaiter().GetResult();
     }
-
+    
     private async Task SaveAsync(House house)
     {
         await using var context = NewDbContext;
@@ -135,6 +140,100 @@ public class HouseRepository : BaseRepository<HouseEntity>, IHouseRepository
     public void SaveAccessList(uint houseId, uint listId, string text)
     {
         SaveAccessListAsync(houseId, listId, text).GetAwaiter().GetResult();
+    }
+
+    public async Task SaveTilesAsync(House house)
+    {
+        await using var context = NewDbContext;
+
+        var existingTiles = await context.HouseTiles
+            .Where(ht => ht.HouseId == (int)house.Id)
+            .ToListAsync();
+
+        context.HouseTiles.RemoveRange(existingTiles);
+
+        AddHouseTileEntities(house, context);
+
+        await context.SaveChangesAsync();
+    }
+
+    public async Task SaveTilesAsync(List<House> houses)
+    {
+        if (houses is null || houses.Count == 0) return;
+
+        await using var context = NewDbContext;
+
+        var houseIds = houses.Select(h => (int)h.Id).ToList();
+
+        var existingTiles = await context.HouseTiles
+            .Where(ht => houseIds.Contains(ht.HouseId))
+            .ToListAsync();
+
+        context.HouseTiles.RemoveRange(existingTiles);
+
+        foreach (var house in houses)
+        {
+            AddHouseTileEntities(house, context);
+        }
+
+        await context.SaveChangesAsync();
+    }
+
+    private static void AddHouseTileEntities(House house, NeoContext context)
+    {
+        if (house.Tiles is null) return;
+
+        foreach (var tile in house.Tiles)
+        {
+            if (tile.AllItems is null) continue;
+
+            var pickupableItems = new List<IItem>(tile.AllItems.Length);
+            foreach (var item in tile.AllItems)
+            {
+                if (item is not null && item.IsPickupable)
+                    pickupableItems.Add(item);
+            }
+
+            if (pickupableItems.Count == 0) continue;
+
+            var data = HouseTileItemSerializer.Serialize(pickupableItems);
+
+            var entity = new HouseTileEntity
+            {
+                HouseId = (int)house.Id,
+                TileX = tile.Location.X,
+                TileY = tile.Location.Y,
+                TileZ = tile.Location.Z,
+                Data = data
+            };
+            context.HouseTiles.Add(entity);
+        }
+    }
+
+    public async Task<IReadOnlyDictionary<uint, List<(Location Location, List<IItem> Items)>>> GetAllTileDataAsync()
+    {
+        await using var context = NewDbContext;
+        var entities = await context.HouseTiles.ToListAsync();
+
+        var result = new Dictionary<uint, List<(Location, List<IItem>)>>();
+        foreach (var entity in entities)
+        {
+            var houseId = (uint)entity.HouseId;
+            var location = new Location((ushort)entity.TileX, (ushort)entity.TileY, (byte)entity.TileZ);
+            var items = HouseTileItemSerializer.Deserialize(entity.Data, _itemFactory, location);
+
+            if (items.Count == 0) continue;
+
+            if (!result.TryGetValue(houseId, out var list))
+            {
+                list = new List<(Location, List<IItem>)>();
+                result[houseId] = list;
+            }
+
+            list.Add((location, items));
+        }
+
+        return new ReadOnlyDictionary<uint, List<(Location, List<IItem>)>>(result);
     }
 
     private async Task SaveAccessListAsync(uint houseId, uint listId, string text)

--- a/src/Database/NeoServer.Data/Serializers/HouseTileItemSerializer.cs
+++ b/src/Database/NeoServer.Data/Serializers/HouseTileItemSerializer.cs
@@ -1,0 +1,254 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Item;
+using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Common.Contracts.Items.Types;
+using NeoServer.Domain.Items;
+
+namespace NeoServer.Data.Serializers;
+
+public static class HouseTileItemSerializer
+{
+    private const byte FlagActionId     = 1 << 0;
+    private const byte FlagUniqueId     = 1 << 1;
+    private const byte FlagCharges      = 1 << 2;
+    private const byte FlagDecay        = 1 << 3;
+    private const byte FlagFluidType    = 1 << 4;
+    private const byte FlagTextData     = 1 << 5;
+    private const byte FlagDescription  = 1 << 6;
+    private const byte FlagContainer    = 1 << 7;
+
+    public static byte[] Serialize(IEnumerable<IItem> items)
+    {
+        using var ms = new MemoryStream(capacity: 256);
+        using var writer = new BinaryWriter(ms);
+
+        ushort count = 0;
+        var itemBuffer = new MemoryStream();
+        var itemWriter = new BinaryWriter(itemBuffer);
+
+        foreach (var item in items)
+        {
+            if (item is null) continue;
+            WriteItem(itemWriter, item);
+            count++;
+        }
+
+        writer.Write(count);
+        writer.Write(itemBuffer.ToArray());
+
+        return ms.ToArray();
+    }
+
+    public static List<IItem> Deserialize(byte[] data, IItemFactory itemFactory, Location location)
+    {
+        var items = new List<IItem>();
+
+        if (data is null || data.Length == 0) return items;
+
+        using var ms = new MemoryStream(data);
+        using var reader = new BinaryReader(ms);
+
+        var count = reader.ReadUInt16();
+        for (var i = 0; i < count; i++)
+        {
+            var item = ReadItem(reader, itemFactory, location);
+            if (item is not null) items.Add(item);
+        }
+
+        return items;
+    }
+
+    private static void WriteItem(BinaryWriter writer, IItem item)
+    {
+        var flags = BuildFlags(item);
+        writer.Write(item.Metadata.ServerId);
+        writer.Write(item.Amount > 0 ? (ushort)item.Amount : (ushort)1);
+        writer.Write(flags);
+
+        if ((flags & FlagActionId) != 0)    writer.Write(item.ActionId);
+        if ((flags & FlagUniqueId) != 0)    writer.Write((uint)item.UniqueId);
+        if ((flags & FlagCharges) != 0)     writer.Write(GetCharges(item));
+        if ((flags & FlagDecay) != 0)       WriteDecay(writer, item);
+        if ((flags & FlagFluidType) != 0)   writer.Write(GetFluidType(item));
+        if ((flags & FlagTextData) != 0)    WriteTextData(writer, item);
+        if ((flags & FlagDescription) != 0) WriteString(writer, GetDescription(item));
+
+        if ((flags & FlagContainer) != 0)
+        {
+            var container = (IContainer)item;
+            var children = container.Items;
+            writer.Write((ushort)(children?.Count ?? 0));
+            if (children is not null)
+            {
+                foreach (var child in children)
+                {
+                    WriteItem(writer, child);
+                }
+            }
+        }
+    }
+
+    private static IItem ReadItem(BinaryReader reader, IItemFactory itemFactory, Location location)
+    {
+        var serverId = reader.ReadUInt16();
+        var amount = reader.ReadUInt16();
+        var flags = reader.ReadByte();
+
+        var itemAttributes = new Dictionary<ItemAttribute, IConvertible>();
+        var itemCustomAttributes = new Dictionary<string, IConvertible>();
+        var itemTypeAttributes = new Dictionary<ItemTypeAttribute, IConvertible>();
+        var itemTypeCustomAttributes = new Dictionary<string, IConvertible>();
+
+        if (amount > 1)
+            itemAttributes[ItemAttribute.Count] = (byte)amount;
+
+        if ((flags & FlagActionId) != 0)
+            itemAttributes[ItemAttribute.ActionId] = reader.ReadUInt16();
+
+        if ((flags & FlagUniqueId) != 0)
+            itemAttributes[ItemAttribute.UniqueId] = reader.ReadUInt32();
+
+        if ((flags & FlagCharges) != 0)
+            itemAttributes[ItemAttribute.Charges] = reader.ReadUInt16();
+
+        if ((flags & FlagDecay) != 0)
+            ReadDecay(reader, itemAttributes);
+
+        if ((flags & FlagFluidType) != 0)
+            itemAttributes[ItemAttribute.FluidType] = reader.ReadUInt16();
+
+        if ((flags & FlagTextData) != 0)
+            ReadTextData(reader, itemAttributes);
+
+        if ((flags & FlagDescription) != 0)
+            itemAttributes[ItemAttribute.Description] = ReadString(reader);
+
+        List<IItem> children = null;
+        if ((flags & FlagContainer) != 0)
+        {
+            var childCount = reader.ReadUInt16();
+            if (childCount > 0)
+            {
+                children = new List<IItem>(childCount);
+                for (var i = 0; i < childCount; i++)
+                {
+                    var child = ReadItem(reader, itemFactory, location);
+                    if (child is not null) children.Add(child);
+                }
+            }
+        }
+
+        return itemFactory.Create(
+            serverId,
+            location,
+            itemTypeAttributes,
+            itemTypeCustomAttributes,
+            itemAttributes,
+            itemCustomAttributes,
+            children
+        );
+    }
+
+    private static byte BuildFlags(IItem item)
+    {
+        byte flags = 0;
+
+        if (item.ActionId != 0)        flags |= FlagActionId;
+        if (item.UniqueId != 0)        flags |= FlagUniqueId;
+        if (HasCharges(item))          flags |= FlagCharges;
+        if (HasDecay(item))            flags |= FlagDecay;
+        if (HasFluidType(item))        flags |= FlagFluidType;
+        if (HasTextData(item))         flags |= FlagTextData;
+        if (HasDescription(item))      flags |= FlagDescription;
+        if (item.IsContainer)          flags |= FlagContainer;
+
+        return flags;
+    }
+
+    private static bool HasCharges(IItem item) =>
+        item.Attributes.HasAttribute(ItemAttribute.Charges);
+
+    private static ushort GetCharges(IItem item) =>
+        item.Attributes.GetAttribute<ushort>(ItemAttribute.Charges);
+
+    private static bool HasDecay(IItem item) =>
+        item.Attributes.HasAttribute(ItemAttribute.DecayTo) ||
+        item.Attributes.HasAttribute(ItemAttribute.Duration) ||
+        item.Attributes.HasAttribute(ItemAttribute.DecayState);
+
+    private static void WriteDecay(BinaryWriter writer, IItem item)
+    {
+        writer.Write(item.Attributes.TryGetAttribute<ushort>(ItemAttribute.DecayTo, out var decayTo) ? decayTo : (ushort)0);
+        writer.Write(item.Attributes.TryGetAttribute<uint>(ItemAttribute.Duration, out var duration) ? duration : 0u);
+        writer.Write(item.Attributes.TryGetAttribute<uint>(ItemAttribute.DecayState, out var elapsed) ? elapsed : 0u);
+    }
+
+    private static void ReadDecay(BinaryReader reader, Dictionary<ItemAttribute, IConvertible> attributes)
+    {
+        var decayTo = reader.ReadUInt16();
+        var duration = reader.ReadUInt32();
+        var elapsed = reader.ReadUInt32();
+
+        if (decayTo != 0)   attributes[ItemAttribute.DecayTo] = decayTo;
+        if (duration != 0)  attributes[ItemAttribute.Duration] = duration;
+        if (elapsed != 0)   attributes[ItemAttribute.DecayState] = elapsed;
+    }
+
+    private static bool HasFluidType(IItem item) =>
+        item.Attributes.HasAttribute(ItemAttribute.FluidType);
+
+    private static ushort GetFluidType(IItem item) =>
+        item.Attributes.GetAttribute<ushort>(ItemAttribute.FluidType);
+
+    private static bool HasTextData(IItem item) =>
+        item.Attributes.HasAttribute(ItemAttribute.Text) ||
+        item.Attributes.HasAttribute(ItemAttribute.Writer) ||
+        item.Attributes.HasAttribute(ItemAttribute.Date);
+
+    private static void WriteTextData(BinaryWriter writer, IItem item)
+    {
+        var text = item.Attributes.GetAttribute(ItemAttribute.Text) ?? string.Empty;
+        var writerName = item.Attributes.GetAttribute(ItemAttribute.Writer) ?? string.Empty;
+        var date = item.Attributes.TryGetAttribute<uint>(ItemAttribute.Date, out var d) ? d : 0u;
+
+        WriteString(writer, text);
+        WriteString(writer, writerName);
+        writer.Write(date);
+    }
+
+    private static void ReadTextData(BinaryReader reader, Dictionary<ItemAttribute, IConvertible> attributes)
+    {
+        var text = ReadString(reader);
+        var writerName = ReadString(reader);
+        var date = reader.ReadUInt32();
+
+        if (text.Length > 0)       attributes[ItemAttribute.Text] = text;
+        if (writerName.Length > 0) attributes[ItemAttribute.Writer] = writerName;
+        if (date != 0)             attributes[ItemAttribute.Date] = date;
+    }
+
+    private static bool HasDescription(IItem item) =>
+        item.Attributes.HasAttribute(ItemAttribute.Description);
+
+    private static string GetDescription(IItem item) =>
+        item.Attributes.GetAttribute(ItemAttribute.Description) ?? string.Empty;
+
+    private static void WriteString(BinaryWriter writer, string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value ?? string.Empty);
+        writer.Write((ushort)bytes.Length);
+        writer.Write(bytes);
+    }
+
+    private static string ReadString(BinaryReader reader)
+    {
+        var length = reader.ReadUInt16();
+        if (length == 0) return string.Empty;
+        var bytes = reader.ReadBytes(length);
+        return Encoding.UTF8.GetString(bytes);
+    }
+}

--- a/src/Loaders/NeoServer.Loaders/Houses/HouseLoader.cs
+++ b/src/Loaders/NeoServer.Loaders/Houses/HouseLoader.cs
@@ -1,12 +1,17 @@
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NeoServer.Domain.Common.Contracts.DataStores;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Common.Item;
 using NeoServer.Domain.Common.Location.Structs;
 using NeoServer.Domain.Houses;
 using NeoServer.Domain.Repositories;
 using NeoServer.Loaders.Interfaces;
+using NeoServer.Loaders.World;
 using NeoServer.Server.Configurations;
 using NeoServer.Server.Helpers.Extensions;
 using Serilog;
@@ -20,7 +25,8 @@ public class HouseLoader(
     HouseAccessListLoader accessListLoader,
     HouseXmlParser houseXmlParser,
     ServerConfiguration serverConfiguration,
-    ILogger logger) : ICustomLoader
+    ILogger logger,
+    WorldLoader worldLoader) : ICustomLoader
 {
     public async Task Load()
     {
@@ -38,6 +44,7 @@ public class HouseLoader(
         // Fetch DB house data (both queries in parallel)
         var getAllTask = houseRepository.GetAll();
         var getAccessListTask = houseRepository.GetAllAccessListText();
+        var tilesDataTask = houseRepository.GetAllTileDataAsync();
         await Task.WhenAll(getAllTask, getAccessListTask);
 
         var dbHouses = (await getAllTask).ToArray();
@@ -74,13 +81,108 @@ public class HouseLoader(
                         accessListLoader.Load(house, lists).GetAwaiter().GetResult();
                     }
                 }
-
+                
+                houseRepository.Save(house);
                 houseStore.AddOrUpdate(house.Id, house);
                 houses.Add(house);
+            }
+            
+            // Link tiles collected during world loading to their houses
+            LinkHouseTiles();
+
+            // Load persisted house tile items from DB and place them on linked tiles
+            var tileData = tilesDataTask.GetAwaiter().GetResult();
+            if (tileData.Count > 0)
+            {
+                logger.Information("Loading {HouseCount} house tile data...", tileData.Count);
+
+                AddItemsToTile(tileData);
             }
 
             count = houses.Count;
             return [count];
         });
+
+       
+    }
+
+    private void AddItemsToTile(IReadOnlyDictionary<uint, List<(Location Location, List<IItem> Items)>> tileData)
+    {
+        foreach (var (houseId, tileItems) in tileData)
+        {
+            var house = houseStore.GetByHouseId(houseId);
+            if (house is null)
+            {
+                logger.Warning("Orphan house tile data: house id {HouseId} not found in store", houseId);
+                continue;
+            }
+
+            foreach (var (location, items) in tileItems)
+            {
+                foreach (var tile in house.Tiles)
+                {
+                    if (tile.Location != location) continue;
+
+                    // Iterate in reverse so items are added bottom-first,
+                    // restoring the original stack order. Items are serialized
+                    // top-to-bottom (from AllItems reversed enumerator), so
+                    // adding them in reverse preserves the original bottom-to-top layout.
+                    for (var i = items.Count - 1; i >= 0; i--)
+                    {
+                        tile.AddItem(items[i]);
+                    }
+
+                    break;
+                }
+            }
+        }
+    }
+
+    private void LinkHouseTiles()
+    {
+        foreach (var (houseId, tiles) in worldLoader.HouseTiles)
+        {
+            var house = houseStore.GetByHouseId(houseId);
+            if (house is null)
+            {
+                logger.Warning("Orphan house tile at house id {HouseId}: house not found in store", houseId);
+                continue;
+            }
+
+            foreach (var tile in tiles)
+            {
+                try
+                {
+                    house.LinkTile(tile);
+                }
+                catch (Exception ex)
+                {
+                    logger.Error(ex, "Failed to link tile at {Coordinate} to house {HouseId}",
+                        tile.Location, houseId);
+                    continue;
+                }
+
+                // Link doors and beds
+                foreach (var item in tile.AllItems)
+                {
+                    if (item is null) continue;
+
+                    if (item.Metadata.Attributes.GetAttribute(ItemTypeAttribute.Type) == "door")
+                    {
+                        if (item.Attributes is not null &&
+                            item.Attributes.TryGetAttribute(ItemAttribute.DoorId, out string doorIdStr) &&
+                            uint.TryParse(doorIdStr, out var doorId))
+                        {
+                            house.LinkDoor(doorId, item);
+                        }
+                    }
+
+                    if (item.Metadata.HasFlag(ItemFlag.Bed))
+                    {
+                        house.LinkBed(item);
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/Loaders/NeoServer.Loaders/World/WorldLoader.cs
+++ b/src/Loaders/NeoServer.Loaders/World/WorldLoader.cs
@@ -31,11 +31,10 @@ public class WorldLoader
     private readonly ILogger logger;
     private readonly ServerConfiguration serverConfiguration;
     private readonly Domain.World.World world;
-    private readonly IHouseStore _houseStore;
+    private readonly Dictionary<uint, List<IDynamicTile>> _houseTiles = new();
 
     public WorldLoader(Domain.World.World world, ILogger logger, IItemFactory itemFactory,
-        ServerConfiguration serverConfiguration, ITileFactory tileFactory, IItemTypeStore itemTypeStore,
-        IHouseStore houseStore)
+        ServerConfiguration serverConfiguration, ITileFactory tileFactory, IItemTypeStore itemTypeStore)
     {
         this.world = world;
         this.logger = logger;
@@ -43,8 +42,10 @@ public class WorldLoader
         this.serverConfiguration = serverConfiguration;
         _tileFactory = tileFactory;
         _itemTypeStore = itemTypeStore;
-        _houseStore = houseStore;
     }
+
+    /// <summary>House tiles collected during world loading, keyed by house id.</summary>
+    public IReadOnlyDictionary<uint, List<IDynamicTile>> HouseTiles => _houseTiles;
 
     public void Load(Otbm otbm)
     {
@@ -128,48 +129,16 @@ public class WorldLoader
 
         world.AddTile(tile);
 
-        // Link house tiles, doors, and beds
+        // Collect house tiles for linking in HouseLoader
         if (isHouseTile && tile is IDynamicTile dynamicTile)
         {
-            var house = _houseStore.GetByHouseId(tileNode.HouseId);
-            if (house is null)
+            if (!_houseTiles.TryGetValue(tileNode.HouseId, out var list))
             {
-                logger.Warning("Orphan house tile at {Coordinate}: house id {HouseId} not found in store",
-                    tileNode.Coordinate, tileNode.HouseId);
-                return;
+                list = new List<IDynamicTile>();
+                _houseTiles[tileNode.HouseId] = list;
             }
 
-            try
-            {
-                house.LinkTile(dynamicTile);
-            }
-            catch (Exception ex)
-            {
-                logger.Error(ex, "Failed to link tile at {Coordinate} to house {HouseId}",
-                    tileNode.Coordinate, tileNode.HouseId);
-                return;
-            }
-
-            // Link doors and beds
-            foreach (var item in dynamicTile.AllItems)
-            {
-                if (item is null) continue;
-
-                if (item.Metadata.Attributes.GetAttribute(ItemTypeAttribute.Type) == "door")
-                {
-                    if (item.Attributes is not null &&
-                        item.Attributes.TryGetAttribute(ItemAttribute.DoorId, out string doorIdStr) &&
-                        uint.TryParse(doorIdStr, out var doorId))
-                    {
-                        house.LinkDoor(doorId, item);
-                    }
-                }
-
-                if (item.Metadata.HasFlag(ItemFlag.Bed))
-                {
-                    house.LinkBed(item);
-                }
-            }
+            list.Add(dynamicTile);
         }
     }
 

--- a/src/Standalone/IoC/Modules/ConfigurationInjection.cs
+++ b/src/Standalone/IoC/Modules/ConfigurationInjection.cs
@@ -30,7 +30,7 @@ public static class ConfigurationInjection
     {
         ServerConfiguration serverConfiguration =
             new(0, 0, null, null, null, string.Empty, string.Empty, string.Empty, 7171, 7172, false,
-                false, new SaveConfiguration(3600));
+                false, new SaveConfiguration(3600, 60));
         GameConfiguration gameConfiguration = new();
         LogConfiguration logConfiguration = new(null);
         ClientConfiguration clientConfiguration = new(null);

--- a/src/Standalone/IoC/Modules/JobInjection.cs
+++ b/src/Standalone/IoC/Modules/JobInjection.cs
@@ -16,6 +16,7 @@ public static class JobInjection
         builder.AddSingleton<GameItemRoutine>();
         builder.AddSingleton<GameChatChannelRoutine>();
         builder.AddSingleton<PlayerPersistenceRoutine>();
+        builder.AddSingleton<HouseTilePersistenceRoutine>();
         builder.AddSingleton<GameWorldRoutine>();
         return builder;
     }

--- a/src/Standalone/Program.cs
+++ b/src/Standalone/Program.cs
@@ -98,10 +98,10 @@ public class Program
 
         container.Resolve<MonsterLoader>().Load();
 
-        await container.Resolve<HouseLoader>().Load();
-
         container.Resolve<WorldLoader>().Load(await otbmLoadTask);
         container.Resolve<SpawnLoader>().Load();
+
+        await container.Resolve<HouseLoader>().Load();
 
         container.Resolve<IEnumerable<IStartupLoader>>().ToList().ForEach(x => x.Load());
 
@@ -122,6 +122,7 @@ public class Program
             container.Resolve<GameWorldRoutine>().StartChecking));
 
         container.Resolve<PlayerPersistenceRoutine>().Start(_cancellationToken);
+        container.Resolve<HouseTilePersistenceRoutine>().Start(_cancellationToken);
 
         container.Resolve<EventSubscriber>().AttachEvents();
         container.Resolve<IEnumerable<IStartup>>().ToList().ForEach(x => x.Run());

--- a/src/Standalone/Program.cs
+++ b/src/Standalone/Program.cs
@@ -189,6 +189,7 @@ public class Program
 
         container.Resolve<IScriptManager>().GlobalEvents.ExecuteShutdown();
         await container.Resolve<PlayerPersistenceRoutine>().SavePlayers();
+        await container.Resolve<HouseTilePersistenceRoutine>().SaveHouseTiles();
 
         container.Resolve<LoginListener>().Dispose();
         container.Resolve<GameListener>().Dispose();

--- a/src/Standalone/appsettings.json
+++ b/src/Standalone/appsettings.json
@@ -13,7 +13,8 @@
     "autoReloadScripts": false,
     "enableStaticTileCaching": true,
     "save": {
-      "players": 60
+      "players": 60,
+      "houseTiles": 120
       //seconds
     }
   },

--- a/tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs
+++ b/tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs
@@ -5,6 +5,7 @@ using NeoServer.Domain.Common.Contracts.Items;
 using NeoServer.Domain.Common.Contracts.World.Tiles;
 using NeoServer.Domain.Common.Location;
 using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Creatures.Player;
 using NeoServer.Domain.Guild;
 using NeoServer.Domain.Houses;
 using NeoServer.Domain.Houses.AccessList;
@@ -99,7 +100,7 @@ public static class HouseTestDataBuilder
         return itemMock;
     }
 
-    public static IPlayer CreatePlayer(uint id = 1, ushort level = 10, uint guildId = 0, GuildRankInfo guildRank = null, string name = "Player", string guildName = null)
+    public static IPlayer CreatePlayer(uint id = 1, ushort level = 10, uint guildId = 0, GuildRankInfo guildRank = null, string name = "Player", string guildName = null, Group group = null)
     {
         var playerMock = new Mock<IPlayer>();
         playerMock.Setup(x => x.Id).Returns(id);
@@ -109,6 +110,7 @@ public static class HouseTestDataBuilder
         playerMock.Setup(x => x.GuildId).Returns((ushort)guildId);
         playerMock.Setup(x => x.GuildRank).Returns(guildRank);
         playerMock.Setup(x => x.AccountId).Returns(id);
+        playerMock.Setup(x => x.Group).Returns(group);
 
         if (guildName is not null)
         {

--- a/tests/NeoServer.Domain.Tests/Houses/HouseTileAssociationTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseTileAssociationTests.cs
@@ -2,6 +2,7 @@ using Moq;
 using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Common.Contracts.World.Tiles;
 using NeoServer.Domain.Common.Location;
+using NeoServer.Domain.Creatures.Player;
 using NeoServer.Domain.Tests.Helpers.House;
 
 namespace NeoServer.Domain.Tests.Houses;
@@ -43,6 +44,32 @@ public class HouseTileAssociationTests
 
         var creatureMock = new Mock<ICreature>();
         var canEnter = tileMock.Object.CanEnterFunction(creatureMock.Object);
+        canEnter.Should().BeFalse();
+    }
+
+    [Fact]
+    public void LinkTile_CanEnterFunction_AllowsPlayerWithAdminGroup()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var house = HouseTestDataBuilder.Build();
+        house.LinkTile(tileMock.Object);
+
+        var adminGroup = new Group { Id = 6, Name = "god", Access = true };
+        var adminPlayer = HouseTestDataBuilder.CreatePlayer(name: "God", group: adminGroup);
+        var canEnter = tileMock.Object.CanEnterFunction(adminPlayer);
+        canEnter.Should().BeTrue();
+    }
+
+    [Fact]
+    public void LinkTile_CanEnterFunction_BlocksPlayerWithNonAdminGroup()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var house = HouseTestDataBuilder.Build();
+        house.LinkTile(tileMock.Object);
+
+        var normalGroup = new Group { Id = 1, Name = "player", Access = false };
+        var normalPlayer = HouseTestDataBuilder.CreatePlayer(name: "Regular", group: normalGroup);
+        var canEnter = tileMock.Object.CanEnterFunction(normalPlayer);
         canEnter.Should().BeFalse();
     }
 

--- a/tests/NeoServer.Domain.Tests/Houses/HouseTileAssociationTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseTileAssociationTests.cs
@@ -10,6 +10,7 @@ namespace NeoServer.Domain.Tests.Houses;
 public class HouseTileAssociationTests
 {
     [Fact]
+    [Trait("Category", "HappyPath")]
     public void LinkTile_InstallsCanEnterFunction_BlockingUninvitedPlayer()
     {
         var tileMock = HouseTestDataBuilder.CreateTileMock();
@@ -23,6 +24,7 @@ public class HouseTileAssociationTests
     }
 
     [Fact]
+    [Trait("Category", "HappyPath")]
     public void LinkTile_CanEnterFunction_AllowsInvitedPlayer()
     {
         var tileMock = HouseTestDataBuilder.CreateTileMock();
@@ -36,6 +38,7 @@ public class HouseTileAssociationTests
     }
 
     [Fact]
+    [Trait("Category", "EdgeCase")]
     public void LinkTile_NonPlayerCreature_CanEnterFalse()
     {
         var tileMock = HouseTestDataBuilder.CreateTileMock();
@@ -48,6 +51,7 @@ public class HouseTileAssociationTests
     }
 
     [Fact]
+    [Trait("Category", "HappyPath")]
     public void LinkTile_CanEnterFunction_AllowsPlayerWithAdminGroup()
     {
         var tileMock = HouseTestDataBuilder.CreateTileMock();
@@ -61,6 +65,7 @@ public class HouseTileAssociationTests
     }
 
     [Fact]
+    [Trait("Category", "Validation")]
     public void LinkTile_CanEnterFunction_BlocksPlayerWithNonAdminGroup()
     {
         var tileMock = HouseTestDataBuilder.CreateTileMock();
@@ -74,6 +79,7 @@ public class HouseTileAssociationTests
     }
 
     [Fact]
+    [Trait("Category", "HappyPath")]
     public void GetTileCount_AfterLinkingTiles_ReturnsCount()
     {
         var house = HouseTestDataBuilder.Build();
@@ -85,6 +91,7 @@ public class HouseTileAssociationTests
     }
 
     [Fact]
+    [Trait("Category", "HappyPath")]
     public void LinkTile_SetsProtectionZoneFlag()
     {
         var tileMock = HouseTestDataBuilder.CreateTileMock();
@@ -96,6 +103,7 @@ public class HouseTileAssociationTests
     }
 
     [Fact]
+    [Trait("Category", "ErrorCondition")]
     public void LinkTile_SameTileToSameHouseTwice_Throws()
     {
         var tileMock = HouseTestDataBuilder.CreateTileMock();
@@ -107,6 +115,7 @@ public class HouseTileAssociationTests
     }
 
     [Fact]
+    [Trait("Category", "ErrorCondition")]
     public void LinkTile_SameTileToTwoDifferentHouses_Throws()
     {
         var tileMock = HouseTestDataBuilder.CreateTileMock();

--- a/tests/NeoServer.Domain.Tests/Server/ScriptManagerTestBuilder.cs
+++ b/tests/NeoServer.Domain.Tests/Server/ScriptManagerTestBuilder.cs
@@ -42,7 +42,7 @@ public static class ScriptManagerTestBuilder
             7172,
             true,
             false,
-            new SaveConfiguration(100)
+            new SaveConfiguration(100, 60)
         );
     }
 }

--- a/tests/NeoServer.Server.Tests/Data/HouseTileItemSerializerTest.cs
+++ b/tests/NeoServer.Server.Tests/Data/HouseTileItemSerializerTest.cs
@@ -17,6 +17,7 @@ namespace NeoServer.Server.Tests.Data;
 public class HouseTileItemSerializerTest
 {
     [Fact]
+    [Trait("Category", "HappyPath")]
     public void HouseTileItemSerializer_round_trips_tile_with_sword()
     {
         // Arrange
@@ -55,6 +56,7 @@ public class HouseTileItemSerializerTest
     }
 
     [Fact]
+    [Trait("Category", "HappyPath")]
     public void HouseTileItemSerializer_preserves_item_amount_when_serializing_and_deserializing()
     {
         // Arrange
@@ -93,6 +95,7 @@ public class HouseTileItemSerializerTest
     }
 
     [Fact]
+    [Trait("Category", "HappyPath")]
     public void HouseTileItemSerializer_preserves_item_charges_when_serializing_and_deserializing()
     {
         // Arrange
@@ -132,6 +135,7 @@ public class HouseTileItemSerializerTest
     }
 
     [Fact]
+    [Trait("Category", "HappyPath")]
     public void HouseTileItemSerializer_preserves_decay_attributes_when_serializing_and_deserializing()
     {
         // Arrange

--- a/tests/NeoServer.Server.Tests/Data/HouseTileItemSerializerTest.cs
+++ b/tests/NeoServer.Server.Tests/Data/HouseTileItemSerializerTest.cs
@@ -1,0 +1,179 @@
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NeoServer.Data.Serializers;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Item;
+using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Items;
+using NeoServer.Domain.Items.Factories;
+using NeoServer.Domain.Items.Factories.AttributeFactory;
+using NeoServer.Domain.Tests.Helpers;
+using NeoServer.Domain.Tests.Server;
+using Xunit;
+
+namespace NeoServer.Server.Tests.Data;
+
+public class HouseTileItemSerializerTest
+{
+    [Fact]
+    public void HouseTileItemSerializer_round_trips_tile_with_sword()
+    {
+        // Arrange
+        const ushort swordServerId = 2376;
+        var location = new Location(100, 100, 7);
+
+        var sword = ItemTestDataBuilder.CreateWeaponItem(swordServerId, name: "sword");
+
+        // Ensure the item type's group is set so the real factory can recreate it
+        var swordType = (ItemType)sword.Metadata;
+        swordType.SetGroup((byte)ItemGroup.MeleeWeapon);
+
+        var itemTypeStore = ItemTypeStoreTestBuilder.Build(sword.Metadata);
+        var chargeableFactory = new ChargeableFactory();
+        var factory = new ItemFactory(
+            null,
+            null,
+            new WeaponFactory(chargeableFactory, itemTypeStore),
+            null,
+            null,
+            null,
+            null,
+            new GenericItemFactory(),
+            itemTypeStore,
+            null);
+
+        var items = new List<IItem> { sword };
+
+        // Act
+        var serialized = HouseTileItemSerializer.Serialize(items);
+        var deserialized = HouseTileItemSerializer.Deserialize(serialized, factory, location);
+
+        // Assert
+        deserialized.Should().HaveCount(1);
+        deserialized[0].ServerId.Should().Be(swordServerId);
+    }
+
+    [Fact]
+    public void HouseTileItemSerializer_preserves_item_amount_when_serializing_and_deserializing()
+    {
+        // Arrange
+        const ushort itemServerId = 3031;
+        const byte expectedAmount = 25;
+        var location = new Location(100, 100, 7);
+
+        var item = ItemTestDataBuilder.CreateCumulativeItem(itemServerId, amount: expectedAmount, name: "coin");
+
+        var itemType = (ItemType)item.Metadata;
+        itemType.SetGroup((byte)ItemGroup.Cumulative);
+
+        var itemTypeStore = ItemTypeStoreTestBuilder.Build(item.Metadata);
+        var chargeableFactory = new ChargeableFactory();
+        var factory = new ItemFactory(
+            null,
+            null,
+            new WeaponFactory(chargeableFactory, itemTypeStore),
+            null,
+            null,
+            null,
+            new CumulativeFactory(),
+            new GenericItemFactory(),
+            itemTypeStore,
+            null);
+
+        var items = new List<IItem> { item };
+
+        // Act
+        var serialized = HouseTileItemSerializer.Serialize(items);
+        var deserialized = HouseTileItemSerializer.Deserialize(serialized, factory, location);
+
+        // Assert
+        deserialized.Should().HaveCount(1);
+        deserialized[0].Amount.Should().Be(expectedAmount);
+    }
+
+    [Fact]
+    public void HouseTileItemSerializer_preserves_item_charges_when_serializing_and_deserializing()
+    {
+        // Arrange
+        const ushort itemServerId = 2000;
+        const ushort expectedCharges = 50;
+        var location = new Location(100, 100, 7);
+
+        var item = ItemTestDataBuilder.CreateRegularItem(itemServerId,
+            itemAttributes:
+            [
+                (ItemAttribute.Count, 1),
+                (ItemAttribute.Charges, expectedCharges)
+            ]);
+
+        var itemTypeStore = ItemTypeStoreTestBuilder.Build(item.Metadata);
+        var factory = new ItemFactory(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            new GenericItemFactory(),
+            itemTypeStore,
+            null);
+
+        var items = new List<IItem> { item };
+
+        // Act
+        var serialized = HouseTileItemSerializer.Serialize(items);
+        var deserialized = HouseTileItemSerializer.Deserialize(serialized, factory, location);
+
+        // Assert
+        deserialized.Should().HaveCount(1);
+        deserialized[0].Attributes.GetAttribute<ushort>(ItemAttribute.Charges).Should().Be(expectedCharges);
+    }
+
+    [Fact]
+    public void HouseTileItemSerializer_preserves_decay_attributes_when_serializing_and_deserializing()
+    {
+        // Arrange
+        const ushort itemServerId = 2001;
+        const ushort expectedDecayTo = 2002;
+        const uint expectedDuration = 30_000;
+        const uint expectedElapsed = 5_000;
+        var location = new Location(100, 100, 7);
+
+        var item = ItemTestDataBuilder.CreateRegularItem(itemServerId,
+            itemAttributes:
+            [
+                (ItemAttribute.Count, 1),
+                (ItemAttribute.DecayTo, expectedDecayTo),
+                (ItemAttribute.Duration, expectedDuration),
+                (ItemAttribute.DecayState, expectedElapsed)
+            ]);
+
+        var itemTypeStore = ItemTypeStoreTestBuilder.Build(item.Metadata);
+        var factory = new ItemFactory(
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            new GenericItemFactory(),
+            itemTypeStore,
+            null);
+
+        var items = new List<IItem> { item };
+
+        // Act
+        var serialized = HouseTileItemSerializer.Serialize(items);
+        var deserialized = HouseTileItemSerializer.Deserialize(serialized, factory, location);
+
+        // Assert
+        deserialized.Should().HaveCount(1);
+        var attrs = deserialized[0].Attributes;
+        attrs.GetAttribute<ushort>(ItemAttribute.DecayTo).Should().Be(expectedDecayTo);
+        attrs.GetAttribute<uint>(ItemAttribute.Duration).Should().Be(expectedDuration);
+        attrs.GetAttribute<uint>(ItemAttribute.DecayState).Should().Be(expectedElapsed);
+    }
+}


### PR DESCRIPTION
### Description
Persist pickupable items placed on house tiles to the database so they survive server restarts. A new routine saves the items periodically and they are restored when the server starts.

### Key Changes
- Add `HouseTileEntity` and EF Core configuration to store tile item data
- Add `HouseTileItemSerializer` to serialize/deserialize item stacks to binary
- Add `HouseTilePersistenceRoutine` to periodically save house tile items
- Add `GetAllTileDataAsync` / `SaveTilesAsync` to `IHouseRepository`
- Load and restore persisted tile items in `HouseLoader` after world loading
- Fix item stack order when restoring: items are now added bottom-first to preserve the original layout

### Types of Changes
- [x] New feature (non-breaking change which adds functionality)

### Test Case
`dotnet test tests/`