### PR TITLE
fix: persist item charges through save/load cycle

### DIFF
--- a/src/Core/NeoServer.Domain/Common/Contracts/Items/IItem.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Items/IItem.cs
@@ -122,6 +122,9 @@ public interface IItem : IThing, IHasDecay
             return count;
         }
 
+        if (this is IChargeable chargeable)
+            return chargeable.Charges;
+
         var charges = Metadata.Attributes.GetAttribute<ushort>(ItemTypeAttribute.Charges);
         return charges;
     }

--- a/src/Core/NeoServer.Domain/Items/Factories/AttributeFactory/ChargeableFactory.cs
+++ b/src/Core/NeoServer.Domain/Items/Factories/AttributeFactory/ChargeableFactory.cs
@@ -7,9 +7,18 @@ namespace NeoServer.Domain.Items.Factories.AttributeFactory;
 
 public class ChargeableFactory : IFactory
 {
-    public IChargeable Create(IItemType itemType)
+    public IChargeable Create(IItemType itemType, ushort? overrideCharges = null)
     {
-        if (!itemType.Attributes.TryGetAttribute<ushort>(ItemTypeAttribute.Charges, out var charges)) return null;
+        ushort charges;
+        if (overrideCharges.HasValue)
+        {
+            charges = overrideCharges.Value;
+        }
+        else
+        {
+            if (!itemType.Attributes.TryGetAttribute<ushort>(ItemTypeAttribute.Charges, out charges)) return null;
+        }
+
         if (!itemType.Attributes.TryGetAttribute<ushort>(ItemTypeAttribute.ShowCharges, out var showCharges))
             return new Chargeable(charges, true);
 

--- a/src/Core/NeoServer.Domain/Items/Factories/DefenseEquipmentFactory.cs
+++ b/src/Core/NeoServer.Domain/Items/Factories/DefenseEquipmentFactory.cs
@@ -18,11 +18,11 @@ public class DefenseEquipmentFactory : IFactory
         _chargeableFactory = chargeableFactory;
     }
 
-    public BodyDefenseEquipment Create(IItemType itemType, Location location)
+    public BodyDefenseEquipment Create(IItemType itemType, Location location, ushort? overrideCharges = null)
     {
         if (!BodyDefenseEquipment.IsApplicable(itemType)) return null;
 
-        var chargeable = _chargeableFactory.Create(itemType);
+        var chargeable = _chargeableFactory.Create(itemType, overrideCharges);
 
         return new BodyDefenseEquipment(itemType, location)
         {

--- a/src/Core/NeoServer.Domain/Items/Factories/ItemFactory.cs
+++ b/src/Core/NeoServer.Domain/Items/Factories/ItemFactory.cs
@@ -227,8 +227,15 @@ public class ItemFactory : IItemFactory
             if (ItemFromScriptFactory.Create(itemType, location, itemTypeAttributes, script) is { } instance)
                 return instance;
 
-        if (DefenseEquipmentFactory?.Create(itemType, location) is { } equipment) return equipment;
-        if (WeaponFactory?.Create(itemType, location, itemAttributes) is { } weapon) return weapon;
+        ushort? chargesOverride = null;
+        if (itemTypeAttributes?.TryGetValue(ItemTypeAttribute.Charges, out var chargesVal) == true)
+        {
+            chargesOverride = Convert.ToUInt16(chargesVal);
+            itemTypeAttributes.Remove(ItemTypeAttribute.Charges);
+        }
+
+        if (DefenseEquipmentFactory?.Create(itemType, location, chargesOverride) is { } equipment) return equipment;
+        if (WeaponFactory?.Create(itemType, location, itemAttributes, chargesOverride) is { } weapon) return weapon;
         if (ContainerFactory?.Create(itemType, location, children) is { } container) return container;
         if (RuneFactory?.Create(itemType, location) is { } rune) return rune;
         if (GroundFactory?.Create(itemType, location) is { } ground) return ground;

--- a/src/Core/NeoServer.Domain/Items/Factories/ItemFactory.cs
+++ b/src/Core/NeoServer.Domain/Items/Factories/ItemFactory.cs
@@ -231,7 +231,6 @@ public class ItemFactory : IItemFactory
         if (itemTypeAttributes?.TryGetValue(ItemTypeAttribute.Charges, out var chargesVal) == true)
         {
             chargesOverride = Convert.ToUInt16(chargesVal);
-            itemTypeAttributes.Remove(ItemTypeAttribute.Charges);
         }
 
         if (DefenseEquipmentFactory?.Create(itemType, location, chargesOverride) is { } equipment) return equipment;

--- a/src/Core/NeoServer.Domain/Items/Factories/WeaponFactory.cs
+++ b/src/Core/NeoServer.Domain/Items/Factories/WeaponFactory.cs
@@ -23,11 +23,12 @@ public class WeaponFactory : IFactory
     public IItem Create(
         IItemType itemType,
         Location location,
-        IDictionary<ItemAttribute, IConvertible> itemAttributes)
+        IDictionary<ItemAttribute, IConvertible> itemAttributes,
+        ushort? overrideCharges = null)
     {
         if (MeleeWeapon.IsApplicable(itemType))
         {
-            var chargeable = _chargeableFactory.Create(itemType);
+            var chargeable = _chargeableFactory.Create(itemType, overrideCharges);
             return new MeleeWeapon(itemType, location, itemAttributes)
             {
                 Chargeable = chargeable,
@@ -37,7 +38,7 @@ public class WeaponFactory : IFactory
 
         if (DistanceWeapon.IsApplicable(itemType))
         {
-            var chargeable = _chargeableFactory.Create(itemType);
+            var chargeable = _chargeableFactory.Create(itemType, overrideCharges);
             return new DistanceWeapon(itemType, location)
             {
                 ItemTypeFinder = _itemTypeStore.Get,
@@ -47,7 +48,7 @@ public class WeaponFactory : IFactory
 
         if (MagicWeapon.IsApplicable(itemType))
         {
-            var chargeable = _chargeableFactory.Create(itemType);
+            var chargeable = _chargeableFactory.Create(itemType, overrideCharges);
             return new MagicWeapon(itemType, location)
             {
                 ItemTypeFinder = _itemTypeStore.Get,

--- a/src/Database/NeoServer.Data/Configurations/ForSqLite/ForSqLitePlayerInventoryItemEntityConfiguration.cs
+++ b/src/Database/NeoServer.Data/Configurations/ForSqLite/ForSqLitePlayerInventoryItemEntityConfiguration.cs
@@ -22,6 +22,9 @@ public class ForSqLitePlayerInventoryItemEntityConfiguration : IEntityTypeConfig
             .IsRequired()
             .HasDefaultValueSql("1");
 
+        entity.Property(e => e.Charges)
+            .HasColumnType("int");
+
         entity.Property(e => e.SlotId)
             .IsRequired();
 

--- a/src/Database/NeoServer.Data/Configurations/PlayerInventoryItemEntityConfiguration.cs
+++ b/src/Database/NeoServer.Data/Configurations/PlayerInventoryItemEntityConfiguration.cs
@@ -35,6 +35,9 @@ public class PlayerInventoryItemEntityConfiguration : IEntityTypeConfiguration<P
             .HasColumnType("smallint")
             .HasDefaultValueSql("1");
 
+        entity.Property(e => e.Charges)
+            .HasColumnType("int");
+
         entity.Property(e => e.Attributes)
             .HasColumnType("jsonb")
             .HasConversion(

--- a/src/Database/NeoServer.Data/Entities/PlayerInventoryItemEntity.cs
+++ b/src/Database/NeoServer.Data/Entities/PlayerInventoryItemEntity.cs
@@ -9,6 +9,7 @@ public sealed class PlayerInventoryItemEntity
     public int ServerId { get; set; }
     public int SlotId { get; set; }
     public short Amount { get; set; }
+    public ushort? Charges { get; set; }
 
     public Dictionary<string, string> Attributes { get; set; } = new();
 

--- a/src/Database/NeoServer.Data/Parsers/ItemEntityParser.cs
+++ b/src/Database/NeoServer.Data/Parsers/ItemEntityParser.cs
@@ -1,9 +1,11 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using NeoServer.Data.Entities;
 using NeoServer.Data.Extensions;
 using NeoServer.Domain.Common.Contracts.Items;
 using NeoServer.Domain.Common.Contracts.Items.Types;
+using NeoServer.Domain.Common.Item;
 using NeoServer.Domain.Common.Location.Structs;
 
 namespace NeoServer.Data.Parsers;
@@ -43,7 +45,14 @@ public static class ItemEntityParser
             foreach (var itemRecord in containerItemsRecords)
             {
                 //todo: check this, if need pass Metadata to itemFactory.Create
-                var item = itemFactory.Create((ushort)itemRecord.ServerId, location, null, null,
+                var itemTypeAttributes = itemRecord.Charges.HasValue
+                    ? new Dictionary<ItemTypeAttribute, IConvertible>
+                    {
+                        { ItemTypeAttribute.Charges, itemRecord.Charges.Value }
+                    }
+                    : null;
+
+                var item = itemFactory.Create((ushort)itemRecord.ServerId, location, itemTypeAttributes, null,
                     itemRecord.GetAttributes(), itemRecord.GetCustomAttributes());
 
                 if (item is ICumulative cumulativeItem && itemRecord.Amount > 1)

--- a/src/Database/NeoServer.Data/Repositories/Player/InventoryManager.cs
+++ b/src/Database/NeoServer.Data/Repositories/Player/InventoryManager.cs
@@ -5,6 +5,7 @@ using NeoServer.Data.Contexts;
 using NeoServer.Data.Entities;
 using NeoServer.Data.Extensions;
 using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.Items;
 using NeoServer.Domain.Common.Helpers;
 using NeoServer.Domain.Creatures.Player.Inventory;
 
@@ -45,6 +46,7 @@ internal static class InventoryManager
                 playerInventoryItemEntity.PlayerId = (int)player.Id;
                 playerInventoryItemEntity.SlotId = (int)slot;
                 playerInventoryItemEntity.Attributes = item.ExtractAllAttributes();
+                playerInventoryItemEntity.Charges = (item as IChargeable)?.Charges;
 
                 neoContext.PlayerInventoryItems.Update(playerInventoryItemEntity);
                 continue;
@@ -56,7 +58,8 @@ internal static class InventoryManager
                 PlayerId = (int)player.Id,
                 SlotId = (int)slot,
                 ServerId = item?.Metadata?.ServerId ?? 0,
-                Attributes = item.ExtractAllAttributes()
+                Attributes = item.ExtractAllAttributes(),
+                Charges = (item as IChargeable)?.Charges
             });
         }
     }

--- a/src/Loaders/NeoServer.Loaders/Players/PlayerLoader.cs
+++ b/src/Loaders/NeoServer.Loaders/Players/PlayerLoader.cs
@@ -271,15 +271,20 @@ public class PlayerLoader(
     protected IInventory ConvertToInventory(IPlayer player, PlayerEntity playerRecord)
     {
         var inventory = new Dictionary<Slot, (IItem Item, ushort Id)>();
-        var attrs = new Dictionary<ItemTypeAttribute, IConvertible> { { ItemTypeAttribute.Count, 0 } };
 
         foreach (var item in playerRecord.PlayerInventoryItems)
         {
-            attrs[ItemTypeAttribute.Count] = (byte)item.Amount;
             var location = item.SlotId <= 10 ? Location.Inventory((Slot)item.SlotId) : Location.Container(0, 0);
 
+            var itemTypeAttributes = item.Charges.HasValue
+                ? new Dictionary<ItemTypeAttribute, IConvertible>
+                {
+                    { ItemTypeAttribute.Charges, item.Charges.Value }
+                }
+                : null;
+
             //todo: check this, if need pass Metadata to itemFactory.Create
-            var createdItem = ItemFactory.Create((ushort)item.ServerId, location, null, null, item.GetAttributes(),
+            var createdItem = ItemFactory.Create((ushort)item.ServerId, location, itemTypeAttributes, null, item.GetAttributes(),
                 item.GetCustomAttributes());
 
             var createdItemIsPickupable = createdItem?.IsPickupable ?? false;

--- a/tests/NeoServer.Domain.Tests/Items/Factories/ChargeableFactoryTests.cs
+++ b/tests/NeoServer.Domain.Tests/Items/Factories/ChargeableFactoryTests.cs
@@ -1,0 +1,133 @@
+using NeoServer.Domain.Common.Item;
+using NeoServer.Domain.Items;
+using NeoServer.Domain.Items.Factories.AttributeFactory;
+using NeoServer.Domain.Items.Items.Attributes;
+
+namespace NeoServer.Domain.Tests.Items.Factories;
+
+public class ChargeableFactoryTests
+{
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void ChargeableFactory_creates_chargeable_with_metadata_charges_when_no_override()
+    {
+        // Arrange
+        var itemType = new ItemType();
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.Charges, (ushort)200);
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.ShowCharges, (ushort)1);
+        var sut = new ChargeableFactory();
+
+        // Act
+        var chargeable = sut.Create(itemType);
+
+        // Assert
+        chargeable.Should().NotBeNull();
+        chargeable.Charges.Should().Be(200);
+        chargeable.ShowCharges.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void ChargeableFactory_creates_chargeable_with_override_charges_when_provided()
+    {
+        // Arrange
+        var itemType = new ItemType();
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.Charges, (ushort)200);
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.ShowCharges, (ushort)1);
+        var sut = new ChargeableFactory();
+
+        // Act
+        var chargeable = sut.Create(itemType, overrideCharges: 150);
+
+        // Assert
+        chargeable.Should().NotBeNull();
+        chargeable.Charges.Should().Be(150);
+        chargeable.ShowCharges.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void ChargeableFactory_returns_null_when_no_charges_attribute_and_no_override()
+    {
+        // Arrange
+        var itemType = new ItemType();
+        var sut = new ChargeableFactory();
+
+        // Act
+        var chargeable = sut.Create(itemType);
+
+        // Assert
+        chargeable.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void ChargeableFactory_creates_chargeable_with_override_when_item_type_has_no_charges_attribute()
+    {
+        // Arrange
+        var itemType = new ItemType();
+        var sut = new ChargeableFactory();
+
+        // Act
+        var chargeable = sut.Create(itemType, overrideCharges: 99);
+
+        // Assert
+        chargeable.Should().NotBeNull();
+        chargeable.Charges.Should().Be(99);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void ChargeableFactory_creates_chargeable_with_hidden_charges_when_showcharges_is_zero()
+    {
+        // Arrange
+        var itemType = new ItemType();
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.Charges, (ushort)50);
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.ShowCharges, (ushort)0);
+        var sut = new ChargeableFactory();
+
+        // Act
+        var chargeable = sut.Create(itemType);
+
+        // Assert
+        chargeable.Should().NotBeNull();
+        chargeable.Charges.Should().Be(50);
+        chargeable.ShowCharges.Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void ChargeableFactory_creates_chargeable_with_showcharges_default_when_showcharges_attribute_missing()
+    {
+        // Arrange
+        var itemType = new ItemType();
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.Charges, (ushort)50);
+        var sut = new ChargeableFactory();
+
+        // Act
+        var chargeable = sut.Create(itemType);
+
+        // Assert
+        chargeable.Should().NotBeNull();
+        chargeable.Charges.Should().Be(50);
+        chargeable.ShowCharges.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void ChargeableFactory_creates_chargeable_with_zero_override_charges()
+    {
+        // Arrange
+        var itemType = new ItemType();
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.Charges, (ushort)200);
+        var sut = new ChargeableFactory();
+
+        // Act
+        var chargeable = sut.Create(itemType, overrideCharges: 0);
+
+        // Assert
+        chargeable.Should().NotBeNull();
+        chargeable.Charges.Should().Be(0);
+        chargeable.NoCharges.Should().BeTrue();
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Items/Factories/ItemFactoryChargesTests.cs
+++ b/tests/NeoServer.Domain.Tests/Items/Factories/ItemFactoryChargesTests.cs
@@ -1,0 +1,218 @@
+using NeoServer.Data.InMemory.DataStores;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Item;
+using NeoServer.Domain.Items;
+using NeoServer.Domain.Items.Factories;
+using NeoServer.Domain.Items.Factories.AttributeFactory;
+using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Creatures.Player.Inventory;
+using NeoServer.Domain.Items.Items.Weapons;
+using NeoServer.Domain.Tests.Server;
+
+namespace NeoServer.Domain.Tests.Items.Factories;
+
+public class ItemFactoryChargesTests
+{
+    private static IItemType CreateDefenseEquipmentType(ushort id, ushort defaultCharges, string slot = "necklace")
+    {
+        var itemType = new ItemType();
+        itemType.SetId(id);
+        itemType.SetClientId(id);
+        itemType.SetName("chargeable item");
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.BodyPosition, slot);
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.Charges, defaultCharges);
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.ShowCharges, (ushort)1);
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.Weight, (ushort)10);
+        itemType.SetGroupIfNone();
+        return itemType;
+    }
+
+    private static IItemType CreateMeleeWeaponType(ushort id, ushort defaultCharges)
+    {
+        var itemType = new ItemType();
+        itemType.SetId(id);
+        itemType.SetClientId(id);
+        itemType.SetName("chargeable weapon");
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.WeaponType, "sword");
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.BodyPosition, "weapon");
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.Charges, defaultCharges);
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.ShowCharges, (ushort)1);
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.Weight, (ushort)40);
+        itemType.SetGroupIfNone();
+        return itemType;
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void ItemFactory_creates_defense_equipment_with_override_charges()
+    {
+        // Arrange
+        var itemType = CreateDefenseEquipmentType(100, defaultCharges: 200);
+        var itemTypeStore = new ItemTypeStore();
+        itemTypeStore.AddOrUpdate(itemType.ServerId, itemType);
+
+        var chargeableFactory = new ChargeableFactory();
+        var sut = new ItemFactory(
+            null,
+            new DefenseEquipmentFactory(itemTypeStore, chargeableFactory),
+            new WeaponFactory(chargeableFactory, itemTypeStore),
+            null, null, null, null, null, itemTypeStore, null);
+
+        var itemTypeAttributes = new Dictionary<ItemTypeAttribute, IConvertible>
+        {
+            { ItemTypeAttribute.Charges, (ushort)150 }
+        };
+
+        // Act
+        var createdItem = sut.Create(100, Location.Inventory(Slot.Necklace), itemTypeAttributes, null, null, null);
+
+        // Assert
+        createdItem.Should().NotBeNull();
+        createdItem.Should().BeAssignableTo<IChargeable>();
+        ((IChargeable)createdItem).Charges.Should().Be(150);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void ItemFactory_creates_defense_equipment_with_default_charges_when_no_override()
+    {
+        // Arrange
+        var itemType = CreateDefenseEquipmentType(100, defaultCharges: 200);
+        var itemTypeStore = new ItemTypeStore();
+        itemTypeStore.AddOrUpdate(itemType.ServerId, itemType);
+
+        var chargeableFactory = new ChargeableFactory();
+        var sut = new ItemFactory(
+            null,
+            new DefenseEquipmentFactory(itemTypeStore, chargeableFactory),
+            new WeaponFactory(chargeableFactory, itemTypeStore),
+            null, null, null, null, null, itemTypeStore, null);
+
+        // Act - no charges override in itemTypeAttributes
+        var createdItem = sut.Create(100, Location.Inventory(Slot.Necklace), null, null, null, null);
+
+        // Assert
+        createdItem.Should().NotBeNull();
+        createdItem.Should().BeAssignableTo<IChargeable>();
+        ((IChargeable)createdItem).Charges.Should().Be(200);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void ItemFactory_creates_weapon_with_override_charges()
+    {
+        // Arrange
+        var itemType = CreateMeleeWeaponType(100, defaultCharges: 100);
+        var itemTypeStore = new ItemTypeStore();
+        itemTypeStore.AddOrUpdate(itemType.ServerId, itemType);
+
+        var chargeableFactory = new ChargeableFactory();
+        var sut = new ItemFactory(
+            null,
+            null,
+            new WeaponFactory(chargeableFactory, itemTypeStore),
+            null, null, null, null, null, itemTypeStore, null);
+
+        var itemTypeAttributes = new Dictionary<ItemTypeAttribute, IConvertible>
+        {
+            { ItemTypeAttribute.Charges, (ushort)75 }
+        };
+
+        // Act
+        var createdItem = sut.Create(100, Location.Inventory(Slot.Left), itemTypeAttributes, null, null, null);
+
+        // Assert
+        createdItem.Should().NotBeNull();
+        createdItem.Should().BeOfType<MeleeWeapon>();
+        createdItem.Should().BeAssignableTo<IChargeable>();
+        ((IChargeable)createdItem).Charges.Should().Be(75);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void ItemFactory_creates_weapon_with_default_charges_when_no_override()
+    {
+        // Arrange
+        var itemType = CreateMeleeWeaponType(100, defaultCharges: 100);
+        var itemTypeStore = new ItemTypeStore();
+        itemTypeStore.AddOrUpdate(itemType.ServerId, itemType);
+
+        var chargeableFactory = new ChargeableFactory();
+        var sut = new ItemFactory(
+            null,
+            null,
+            new WeaponFactory(chargeableFactory, itemTypeStore),
+            null, null, null, null, null, itemTypeStore, null);
+
+        // Act - no charges override in itemTypeAttributes
+        var createdItem = sut.Create(100, Location.Inventory(Slot.Left), null, null, null, null);
+
+        // Assert
+        createdItem.Should().NotBeNull();
+        createdItem.Should().BeOfType<MeleeWeapon>();
+        createdItem.Should().BeAssignableTo<IChargeable>();
+        ((IChargeable)createdItem).Charges.Should().Be(100);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void ItemFactory_creates_defense_equipment_with_zero_override_charges()
+    {
+        // Arrange
+        var itemType = CreateDefenseEquipmentType(100, defaultCharges: 200);
+        var itemTypeStore = new ItemTypeStore();
+        itemTypeStore.AddOrUpdate(itemType.ServerId, itemType);
+
+        var chargeableFactory = new ChargeableFactory();
+        var sut = new ItemFactory(
+            null,
+            new DefenseEquipmentFactory(itemTypeStore, chargeableFactory),
+            new WeaponFactory(chargeableFactory, itemTypeStore),
+            null, null, null, null, null, itemTypeStore, null);
+
+        var itemTypeAttributes = new Dictionary<ItemTypeAttribute, IConvertible>
+        {
+            { ItemTypeAttribute.Charges, (ushort)0 }
+        };
+
+        // Act
+        var createdItem = sut.Create(100, Location.Inventory(Slot.Necklace), itemTypeAttributes, null, null, null);
+
+        // Assert
+        createdItem.Should().NotBeNull();
+        createdItem.Should().BeAssignableTo<IChargeable>();
+        ((IChargeable)createdItem).Charges.Should().Be(0);
+        ((IChargeable)createdItem).NoCharges.Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void ItemFactory_does_not_throw_when_charges_override_present_for_non_matching_item_type()
+    {
+        // Arrange - a regular item that doesn't match any specific factory
+        var itemType = new ItemType();
+        itemType.SetId(100);
+        itemType.SetClientId(100);
+        itemType.SetName("regular item");
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.Weight, (ushort)10);
+        var itemTypeStore = new ItemTypeStore();
+        itemTypeStore.AddOrUpdate(itemType.ServerId, itemType);
+
+        var chargeableFactory = new ChargeableFactory();
+        var sut = new ItemFactory(
+            null,
+            null,
+            new WeaponFactory(chargeableFactory, itemTypeStore),
+            null, null, null, null, null, itemTypeStore, null);
+
+        var itemTypeAttributes = new Dictionary<ItemTypeAttribute, IConvertible>
+        {
+            { ItemTypeAttribute.Charges, (ushort)50 }
+        };
+
+        // Act & Assert - should not throw even though the item type doesn't match any factory
+        var exception = Record.Exception(() =>
+            sut.Create(100, Location.Inventory(Slot.Backpack), itemTypeAttributes, null, null, null));
+        exception.Should().BeNull();
+    }
+}

--- a/tests/NeoServer.Domain.Tests/Items/Items/ItemChargeableTests.cs
+++ b/tests/NeoServer.Domain.Tests/Items/Items/ItemChargeableTests.cs
@@ -1,0 +1,130 @@
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Item;
+using NeoServer.Domain.Items;
+using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Creatures.Player.Inventory;
+using NeoServer.Domain.Items.Items;
+using NeoServer.Domain.Items.Items.Attributes;
+using NeoServer.Domain.Items.Items.Weapons;
+using NeoServer.Domain.Tests.Helpers;
+
+namespace NeoServer.Domain.Tests.Items.Items;
+
+public class ItemChargeableTests
+{
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Item_GetSubType_returns_chargeable_charges_when_item_implements_IChargeable()
+    {
+        // Arrange
+        var defenseItem = ItemTestDataBuilder.CreateDefenseEquipmentItem(1, slot: "necklace", charges: 200);
+        defenseItem.Chargeable.DecreaseCharges();
+        defenseItem.Chargeable.DecreaseCharges();
+
+        // Act
+        var subType = ((IItem)defenseItem).GetSubType();
+
+        // Assert
+        subType.Should().Be(198);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Item_GetSubType_returns_chargeable_charges_when_item_is_weapon_with_charges()
+    {
+        // Arrange
+        var meleeWeapon = (MeleeWeapon)ItemTestDataBuilder.CreateWeaponItem(100, charges: 100);
+        for (var i = 0; i < 10; i++)
+            meleeWeapon.Chargeable.DecreaseCharges();
+
+        // Act
+        var subType = ((IItem)meleeWeapon).GetSubType();
+
+        // Assert
+        subType.Should().Be(90);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Item_GetSubType_returns_metadata_charges_when_item_does_not_implement_IChargeable()
+    {
+        // Arrange
+        var item = ItemTestDataBuilder.CreateRegularItem(1,
+            itemTypeAttributes:
+            [
+                (ItemTypeAttribute.Charges, (ushort)50)
+            ]);
+
+        // Act
+        var subType = ((IItem)item).GetSubType();
+
+        // Assert
+        subType.Should().Be(50);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Item_GetSubType_returns_zero_when_neither_chargeable_nor_metadata_has_charges()
+    {
+        // Arrange
+        var item = ItemTestDataBuilder.CreateRegularItem(1);
+
+        // Act
+        var subType = ((IItem)item).GetSubType();
+
+        // Assert
+        subType.Should().Be(0);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Item_GetSubType_returns_zero_for_chargeable_item_with_null_chargeable()
+    {
+        // Arrange
+        var itemType = new ItemType();
+        itemType.Attributes.SetAttribute(ItemTypeAttribute.Charges, (ushort)75);
+        var item = new BodyDefenseEquipment(itemType, new(100, 100, 7))
+        {
+            Chargeable = null
+        };
+
+        // Act
+        var subType = ((IItem)item).GetSubType();
+
+        // Assert
+        // When Chargeable is null, the type implements IChargeable so the pattern matches,
+        // but Charges delegates to Chargeable?.Charges ?? 0, returning 0.
+        subType.Should().Be(0);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Chargeable_DecreaseCharges_decrements_charges_correctly()
+    {
+        // Arrange
+        var chargeable = new Chargeable(200, true);
+
+        // Act
+        chargeable.DecreaseCharges();
+        chargeable.DecreaseCharges();
+        chargeable.DecreaseCharges();
+
+        // Assert
+        chargeable.Charges.Should().Be(197);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Chargeable_DecreaseCharges_does_not_go_below_zero()
+    {
+        // Arrange
+        var chargeable = new Chargeable(0, true);
+
+        // Act
+        chargeable.DecreaseCharges();
+
+        // Assert
+        chargeable.Charges.Should().Be(0);
+        chargeable.NoCharges.Should().BeTrue();
+    }
+}


### PR DESCRIPTION
### Description

Items with charges (equipment, weapons, amulets) no longer lose their runtime charge count when saved to the database and reloaded after logout or container storage. Fixes #1000.

### Key Changes
- Added `Charges` column to `PlayerInventoryItemEntity` for inventory items
- Save runtime charges in `InventoryManager.SavePlayerInventory` for both insert and update paths
- Load charges from database in `PlayerLoader.ConvertToInventory` and `ItemEntityParser.BuildContainer` and pass through the factory chain
- Extended factory chain (`ItemFactory` -> `DefenseEquipmentFactory`/`WeaponFactory` -> `ChargeableFactory`) to accept optional `chargesOverride`
- `IItem.GetSubType()` now returns runtime `IChargeable.Charges` before falling back to metadata defaults

### Types of Changes
- [X] Bug fix (non-breaking change which fixes an issue)

### Test Case
```
dotnet test tests/NeoServer.Domain.Tests  # 1557 passed (20 new tests)
dotnet test tests/NeoServer.Server.Tests   # 85 passed
dotnet test tests/NeoServer.Networking.Tests # 36 passed
dotnet test tests/NeoServer.Loaders.Tests   # 22 passed
```