### PR TITLE
feat: show gate of expertise level requirement on look for all doors

### DIFF
--- a/data/extensions/Items/Doors/LevelDoor.cs
+++ b/data/extensions/Items/Doors/LevelDoor.cs
@@ -63,13 +63,7 @@ public class LevelDoor : Door
     public override string GetLookText(
         bool isClose = false, bool showInternalDetails = false)
     {
-        Attributes.TryGetAttribute(ItemAttribute.ActionId, out int actionId);
-
-        var minLevel = Math.Max(0, actionId - 1000);
-
-        return minLevel == 0
-            ? "You see a gate of expertise for any level."
-            : $"You see a gate of expertise for level {minLevel}.\nOnly the worthy may pass.";
+        return base.GetLookText(isClose, showInternalDetails);
     }
 
     public new static bool IsApplicable(IItemType type)

--- a/src/Core/NeoServer.Domain/Items/Inspection/GateOfExpertiseInspectionTextBuilder.cs
+++ b/src/Core/NeoServer.Domain/Items/Inspection/GateOfExpertiseInspectionTextBuilder.cs
@@ -1,0 +1,100 @@
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Item;
+
+namespace NeoServer.Domain.Items.Inspection;
+
+public static class GateOfExpertiseInspectionTextBuilder
+{
+    public const int LevelDoorActionIdBase = 1000;
+
+    private const string GateOfExpertiseName = "gate of expertise";
+    private const string WorthyLine = "Only the worthy may pass.";
+
+    public static bool TryGetMinLevel(IItem item, out int minLevel)
+    {
+        minLevel = 0;
+
+        if (item.ActionId == 0)
+        {
+            return false;
+        }
+
+        if (!TryGetBaseActionId(item, out var baseActionId))
+        {
+            return false;
+        }
+
+        if (item.ActionId < baseActionId)
+        {
+            return false;
+        }
+
+        minLevel = item.ActionId - baseActionId;
+        return true;
+    }
+
+    public static string BuildLevelSuffix(IItem item)
+    {
+        if (!TryGetMinLevel(item, out var minLevel))
+        {
+            return string.Empty;
+        }
+
+        if (minLevel == 0)
+        {
+            return " for any level";
+        }
+
+        return $" for level {minLevel}";
+    }
+
+    public static string BuildWorthyLine(IItem item, bool isClose)
+    {
+        if (!isClose)
+        {
+            return string.Empty;
+        }
+
+        if (!string.IsNullOrWhiteSpace(item.Metadata.Description))
+        {
+            return string.Empty;
+        }
+
+        if (!TryGetMinLevel(item, out var minLevel))
+        {
+            return string.Empty;
+        }
+
+        if (minLevel == 0)
+        {
+            return string.Empty;
+        }
+
+        return WorthyLine;
+    }
+
+    private static bool TryGetBaseActionId(IItem item, out int baseActionId)
+    {
+        baseActionId = 0;
+
+        if (item.Metadata.Attributes.TryGetAttribute(ItemTypeAttribute.LevelDoor, out int levelDoorBase))
+        {
+            baseActionId = levelDoorBase;
+            return true;
+        }
+
+        if (!IsGateOfExpertiseDoor(item))
+        {
+            return false;
+        }
+
+        baseActionId = LevelDoorActionIdBase;
+        return true;
+    }
+
+    private static bool IsGateOfExpertiseDoor(IItem item)
+    {
+        return item.Metadata.Attributes.GetAttribute(ItemTypeAttribute.Type) == "door"
+               && string.Equals(item.Name, GateOfExpertiseName, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/src/Core/NeoServer.Domain/Items/Inspection/InspectionTextBuilder.cs
+++ b/src/Core/NeoServer.Domain/Items/Inspection/InspectionTextBuilder.cs
@@ -21,7 +21,7 @@ public class InspectionTextBuilder
         AddRequirement(item, inspectionText);
 
         AddWeight(item, isClose, inspectionText);
-        AddDescription(item, inspectionText);
+        AddDescription(item, isClose, inspectionText);
 
         var finalText = inspectionText.ToString().TrimNewLine().AddEndOfSentencePeriod();
 
@@ -46,10 +46,20 @@ public class InspectionTextBuilder
         inspectionText.AppendNewLine(result);
     }
 
-    private static void AddDescription(IItem item, StringBuilder inspectionText)
+    private static void AddDescription(IItem item, bool isClose, StringBuilder inspectionText)
     {
-        if (!string.IsNullOrWhiteSpace(item.Metadata.Description))
-            inspectionText.AppendNewLine(item.Metadata.Description);
+        var worthyLine = GateOfExpertiseInspectionTextBuilder.BuildWorthyLine(item, isClose);
+        if (!string.IsNullOrWhiteSpace(worthyLine))
+        {
+            inspectionText.AppendNewLine(worthyLine);
+        }
+
+        if (string.IsNullOrWhiteSpace(item.Metadata.Description))
+        {
+            return;
+        }
+
+        inspectionText.AppendNewLine(item.Metadata.Description);
     }
 
     private static void AddWeight(IItem item, bool isClose, StringBuilder inspectionText)
@@ -69,6 +79,7 @@ public class InspectionTextBuilder
         inspectionText.Append(item is ICumulative cumulative
             ? $"{cumulative.Amount} {item.Name}{(cumulative.Amount > 1 ? "s" : "")}"
             : $"{item.Metadata.Article} {item.Name}");
+        inspectionText.Append(GateOfExpertiseInspectionTextBuilder.BuildLevelSuffix(item));
     }
 
     private static void AddEquipmentAttributes(IItem item, StringBuilder inspectionText)

--- a/tests/NeoServer.Domain.Tests/Items/Inspection/GateOfExpertiseInspectionTextBuilderTests.cs
+++ b/tests/NeoServer.Domain.Tests/Items/Inspection/GateOfExpertiseInspectionTextBuilderTests.cs
@@ -1,0 +1,120 @@
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Item;
+using NeoServer.Domain.Items.Inspection;
+using NeoServer.Domain.Tests.Helpers;
+
+namespace NeoServer.Domain.Tests.Items.Inspection;
+
+public class GateOfExpertiseInspectionTextBuilderTests
+{
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Build_closed_gate_with_level_requirement_shows_level_and_worthy_line_when_close()
+    {
+        var item = CreateGateItem(actionId: 1020);
+
+        var actual = InspectionTextBuilder.Build(item, isClose: true);
+
+        actual.Should().Be("You see a gate of expertise for level 20.\nOnly the worthy may pass.");
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Build_closed_gate_with_any_level_action_id_shows_any_level_text()
+    {
+        var item = CreateGateItem(actionId: 1000);
+
+        var actual = InspectionTextBuilder.Build(item, isClose: true);
+
+        actual.Should().Be("You see a gate of expertise for any level.");
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Build_open_gate_without_leveldoor_metadata_still_shows_level_from_preserved_action_id()
+    {
+        var item = CreateGateItem(actionId: 1020, includeLevelDoorMetadata: false);
+
+        var actual = InspectionTextBuilder.Build(item, isClose: true);
+
+        actual.Should().Be("You see a gate of expertise for level 20.\nOnly the worthy may pass.");
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Build_gate_without_action_id_shows_plain_name()
+    {
+        var item = CreateGateItem();
+
+        var actual = InspectionTextBuilder.Build(item, isClose: true);
+
+        actual.Should().Be("You see a gate of expertise.");
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Build_gate_with_action_id_below_base_shows_plain_name()
+    {
+        var item = CreateGateItem(actionId: 500);
+
+        var actual = InspectionTextBuilder.Build(item, isClose: true);
+
+        actual.Should().Be("You see a gate of expertise.");
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Build_quest_door_with_high_action_id_remains_unchanged()
+    {
+        var item = CreateDoorItem(name: "quest door", actionId: 5000);
+
+        var actual = InspectionTextBuilder.Build(item, isClose: true);
+
+        actual.Should().Be("You see a quest door.");
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Build_gate_from_far_look_shows_level_without_worthy_line()
+    {
+        var item = CreateGateItem(actionId: 1020);
+
+        var actual = InspectionTextBuilder.Build(item, isClose: false);
+
+        actual.Should().Be("You see a gate of expertise for level 20.");
+    }
+
+    private static IItem CreateGateItem(ushort actionId = 0, bool includeLevelDoorMetadata = true)
+    {
+        return CreateDoorItem("gate of expertise", actionId, includeLevelDoorMetadata);
+    }
+
+    private static IItem CreateDoorItem(string name, ushort actionId = 0, bool includeLevelDoorMetadata = false)
+    {
+        var itemTypeAttributes = new List<(ItemTypeAttribute, IConvertible)>
+        {
+            (ItemTypeAttribute.Type, "door")
+        };
+
+        if (includeLevelDoorMetadata)
+        {
+            itemTypeAttributes.Add((ItemTypeAttribute.LevelDoor, GateOfExpertiseInspectionTextBuilder.LevelDoorActionIdBase));
+        }
+
+        (ItemAttribute, IConvertible)[] itemAttributes = actionId > 0
+            ?
+            [
+                (ItemAttribute.ActionId, actionId),
+                (ItemAttribute.Count, 1)
+            ]
+            :
+            [
+                (ItemAttribute.Count, 1)
+            ];
+
+        var item = ItemTestDataBuilder.CreateRegularItem(1227, itemTypeAttributes.ToArray(), itemAttributes);
+        item.Metadata.SetName(name);
+        item.Metadata.SetArticle("a");
+        return item;
+    }
+}


### PR DESCRIPTION
### Description
Gates of expertise now show TFS-style look text (level requirement and worthy line) for every closed and open variant with a valid map ActionId, without requiring the LevelDoor C# script.

### Key Changes
- Add domain-level gate look detection via `leveldoor` metadata or name fallback (for open variants after Lua transform)
- Wire level suffix and worthy line into `InspectionTextBuilder`
- Delegate `LevelDoor.GetLookText` to the shared builder path
- Add unit tests covering closed/open gates, any-level aid, missing aid, quest doors, and far look

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
`dotnet test tests/NeoServer.Domain.Tests --filter FullyQualifiedName~GateOfExpertiseInspectionTextBuilderTests`