### PR TITLE
feat(house): let owners manage sub-owners via aleta som

### DIFF
--- a/data/scripts/spells/house/invite_subowners.lua
+++ b/data/scripts/spells/house/invite_subowners.lua
@@ -1,0 +1,33 @@
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, variant)
+    local player = Player(creature)
+    if not player then
+        return false
+    end
+
+    local tile = player:getTile()
+    local house = tile and tile:getHouse() or nil
+    if not house or not house:canEditAccessList(SUBOWNER_LIST, player) then
+        player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+        player:getPosition():sendMagicEffect(CONST_ME_POFF)
+        return false
+    end
+
+    player:setEditHouse(house, SUBOWNER_LIST)
+    player:sendHouseWindow(house, SUBOWNER_LIST)
+    return true
+end
+
+spell:name("House Subowner List")
+spell:words("aleta som")
+spell:group("support")
+spell:id(251)
+spell:cooldown(1000)
+spell:groupCooldown(1000)
+spell:level(1)
+spell:mana(0)
+spell:isAggressive(false)
+spell:needLearn(false)
+spell:isPremium(false)
+spell:register()

--- a/docs/house-system/house-phase3-steps.md
+++ b/docs/house-system/house-phase3-steps.md
@@ -41,9 +41,29 @@ Reference behavior: guest-list spell + house window packets `0x97` / `0x8A`.
 
 ---
 
+## Slice 2 — `aleta som` (House Subowner List) — DONE
+
+### What shipped
+
+- `data/scripts/spells/house/invite_subowners.lua` — words `aleta som`, spell id **251**, `SUBOWNER_LIST` access list
+- Owner-only behavior enforced by existing domain rule `House.CanEditAccessList` (owner can edit subowner list; subowner cannot)
+- Save path already kicks uninvited occupants after subowner list updates via `IHouseEviction` (`HouseEvictionService.KickUninvited`)
+- **Max 10 sub-owners** — `HouseConfiguration.MaxSubOwnerCount` (default 10) enforced in `PlayerEditHouseAccessListCommand`; exclusions/comments don't occupy a slot
+- **Premium-gated sub-owner abilities** — `House.RequirePremiumForSubOwners` (wired from `HouseConfiguration.RequirePremiumForSubOwners`, default true): free-account characters keep their slot on the list but lose all sub-owner rights (guest-list editing, kicking, door access, entry) until premium is restored. Independent from `RequirePremiumAccount` (ownership).
+
+### In-game smoke checklist
+
+- [ ] Owner on house tile casts `aleta som` → subowner list window opens
+- [ ] Subowner casts `aleta som` → cancel + POFF
+- [ ] Guest / stranger / outside house cast → cancel + POFF
+- [ ] Owner removes a subowner name and saves → that player (if inside) teleported to exit; list persists
+- [ ] Owner saves an 11th subowner → rejected with "may contain at most 10 characters"
+- [ ] Free-account character on the subowner list loses entry + subowner abilities; regains them when premium is restored
+
+---
+
 ## Later slices (not started)
 
-- [ ] `aleta som` — House Subowner List (`invite_subowners.lua`)
 - [ ] `aleta grav` — House Door List (`edit_door.lua` + `getDoorIdByPosition`)
 - [ ] `alana sio` — House Kick (`kick_guest.lua`)
 - [ ] Talkactions: `buyhouse` / `leavehouse` / `sellhouse`

--- a/src/ApplicationServer/NeoServer.Server.Commands/Player/House/PlayerEditHouseAccessListCommand.cs
+++ b/src/ApplicationServer/NeoServer.Server.Commands/Player/House/PlayerEditHouseAccessListCommand.cs
@@ -55,6 +55,14 @@ public class PlayerEditHouseAccessListCommand(
             return;
         }
 
+        if (listId == HouseListId.SubOwnerList &&
+            CountSubOwners(text) > houseConfiguration.MaxSubOwnerCount)
+        {
+            OperationFailService.Send(player,
+                $"The sub-owner list may contain at most {houseConfiguration.MaxSubOwnerCount} characters.");
+            return;
+        }
+
         // Reload the access list using the loader so parsing is consistent
         accessListLoader
             .Load(house, [(listId, text)])
@@ -64,5 +72,23 @@ public class PlayerEditHouseAccessListCommand(
         houseRepository.SaveAccessList(houseId, listId, text);
 
         houseEviction.KickUninvited(house, listId);
+    }
+
+    /// <summary>
+    ///     Counts how many sub-owners the given list text would grant access to.
+    ///     Only entries that invite players (exact names, wildcards, guilds, or
+    ///     allow-all) occupy a sub-owner slot; exclusions and comments do not.
+    /// </summary>
+    private static int CountSubOwners(string text)
+    {
+        var count = 0;
+        foreach (var entry in HouseAccessListParser.Parse(text).Entries)
+        {
+            if (entry.Kind != ListEntryKind.ExcludePlayer)
+            {
+                count++;
+            }
+        }
+        return count;
     }
 }

--- a/src/Core/NeoServer.Domain/Common/GameConfiguration.cs
+++ b/src/Core/NeoServer.Domain/Common/GameConfiguration.cs
@@ -54,6 +54,8 @@ public record ReportConfiguration(uint ReportMaxTime = 60);
 public record HouseConfiguration(
     bool TransferItemsToDepotOnOwnershipChange = true,
     bool RequirePremiumAccount = true,
+    bool RequirePremiumForSubOwners = true,
     int MaxAccessListLength = 1999,
-    int MaxAccessListLines = 100
+    int MaxAccessListLines = 100,
+    int MaxSubOwnerCount = 10
 );

--- a/src/Core/NeoServer.Domain/Houses/House.cs
+++ b/src/Core/NeoServer.Domain/Houses/House.cs
@@ -30,6 +30,13 @@ public class House
     public int OwnerAccountId { get; set; }
     public Location? EntryPosition { get; set; }
 
+    /// <summary>
+    ///     When true, only players with an active Premium Account may exercise
+    ///     sub-owner rights. Free-account characters keep their slot on the
+    ///     sub-owner list but are inactive until premium is restored.
+    /// </summary>
+    public bool RequirePremiumForSubOwners { get; set; } = true;
+
     public IReadOnlyCollection<IDynamicTile> Tiles => _tiles.AsReadOnly();
     public IReadOnlyDictionary<uint, IItem> Doors => _doors.AsReadOnly();
     public IReadOnlyCollection<IItem> Beds => _beds.AsReadOnly();
@@ -92,7 +99,9 @@ public class House
         if (OwnerGuid != 0 && player.Id == OwnerGuid)
             return HouseAccessLevel.Owner;
 
-        if (_accessLists.TryGetValue(HouseListId.SubOwnerList, out var subOwnerList) && subOwnerList.IsInList(player))
+        if (_accessLists.TryGetValue(HouseListId.SubOwnerList, out var subOwnerList) &&
+            subOwnerList.IsInList(player) &&
+            IsActiveSubOwner(player))
             return HouseAccessLevel.SubOwner;
 
         if (_accessLists.TryGetValue(HouseListId.GuestList, out var guestList) && guestList.IsInList(player))
@@ -100,6 +109,14 @@ public class House
 
         return HouseAccessLevel.NotInvited;
     }
+
+    /// <summary>
+    ///     Whether the player may exercise sub-owner rights. Free-account characters
+    ///     keep their slot on the sub-owner list but lose all sub-owner abilities
+    ///     until premium is restored.
+    /// </summary>
+    private bool IsActiveSubOwner(IPlayer player) =>
+        !RequirePremiumForSubOwners || player.HasPremiumTime;
 
     public bool CanUseDoor(IPlayer player, uint doorId)
     {

--- a/src/Loaders/NeoServer.Loaders/Houses/HouseLoader.cs
+++ b/src/Loaders/NeoServer.Loaders/Houses/HouseLoader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using NeoServer.Domain.Common;
 using NeoServer.Domain.Common.Contracts.DataStores;
 using NeoServer.Domain.Common.Contracts.Items;
 using NeoServer.Domain.Common.Contracts.World.Tiles;
@@ -25,6 +26,7 @@ public class HouseLoader(
     HouseAccessListLoader accessListLoader,
     HouseXmlParser houseXmlParser,
     ServerConfiguration serverConfiguration,
+    HouseConfiguration houseConfiguration,
     ILogger logger,
     WorldLoader worldLoader) : ICustomLoader
 {
@@ -61,6 +63,7 @@ public class HouseLoader(
             {
                 var house = houseFactory.Create(data.Id, data.Name, data.TownId, data.Rent,
                     0, string.Empty, 0, null, 0);
+                house.RequirePremiumForSubOwners = houseConfiguration.RequirePremiumForSubOwners;
 
                 if (data.EntryX != 0 || data.EntryY != 0 || data.EntryZ != 0)
                 {

--- a/src/Standalone/appsettings.json
+++ b/src/Standalone/appsettings.json
@@ -75,7 +75,11 @@
     },
     "house": {
       "transferItemsToDepotOnOwnershipChange": true,
-      "requirePremiumAccount": true
+      "requirePremiumAccount": true,
+      "requirePremiumForSubOwners": true,
+      "maxAccessListLength": 1999,
+      "maxAccessListLines": 100,
+      "maxSubOwnerCount": 10
     }
   },
   "client": {

--- a/tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs
+++ b/tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs
@@ -106,7 +106,7 @@ public static class HouseTestDataBuilder
         return itemMock;
     }
 
-    public static IPlayer CreatePlayer(uint id = 1, ushort level = 10, uint guildId = 0, GuildRankInfo guildRank = null, string name = "Player", string guildName = null, Group group = null)
+    public static IPlayer CreatePlayer(uint id = 1, ushort level = 10, uint guildId = 0, GuildRankInfo guildRank = null, string name = "Player", string guildName = null, Group group = null, bool hasPremiumTime = true)
     {
         var playerMock = new Mock<IPlayer>();
         playerMock.Setup(x => x.Id).Returns(id);
@@ -117,6 +117,7 @@ public static class HouseTestDataBuilder
         playerMock.Setup(x => x.GuildRank).Returns(guildRank);
         playerMock.Setup(x => x.AccountId).Returns(id);
         playerMock.Setup(x => x.Group).Returns(group);
+        playerMock.Setup(x => x.HasPremiumTime).Returns(hasPremiumTime);
 
         if (guildName is not null)
         {

--- a/tests/NeoServer.Domain.Tests/Houses/HouseAccessLevelTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseAccessLevelTests.cs
@@ -29,6 +29,44 @@ public class HouseAccessLevelTests
     }
 
     [Fact]
+    public void GetAccessLevel_NonPremiumSubOwner_ReturnsNotInvited()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Sub", hasPremiumTime: false);
+        var house = HouseTestDataBuilder.Build(accessLists: new Dictionary<uint, HouseAccessList>
+        {
+            { HouseListId.SubOwnerList, HouseTestDataBuilder.CreateAccessList("Sub") }
+        });
+
+        house.GetAccessLevel(player).Should().Be(HouseAccessLevel.NotInvited);
+    }
+
+    [Fact]
+    public void GetAccessLevel_NonPremiumSubOwnerInGuestList_ReturnsGuest()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Sub", hasPremiumTime: false);
+        var house = HouseTestDataBuilder.Build(accessLists: new Dictionary<uint, HouseAccessList>
+        {
+            { HouseListId.SubOwnerList, HouseTestDataBuilder.CreateAccessList("Sub") },
+            { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Sub") }
+        });
+
+        house.GetAccessLevel(player).Should().Be(HouseAccessLevel.Guest);
+    }
+
+    [Fact]
+    public void GetAccessLevel_NonPremiumSubOwner_WhenPremiumNotRequired_ReturnsSubOwner()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Sub", hasPremiumTime: false);
+        var house = HouseTestDataBuilder.Build(accessLists: new Dictionary<uint, HouseAccessList>
+        {
+            { HouseListId.SubOwnerList, HouseTestDataBuilder.CreateAccessList("Sub") }
+        });
+        house.RequirePremiumForSubOwners = false;
+
+        house.GetAccessLevel(player).Should().Be(HouseAccessLevel.SubOwner);
+    }
+
+    [Fact]
     public void GetAccessLevel_PlayerInGuestListOnly_ReturnsGuest()
     {
         var player = HouseTestDataBuilder.CreatePlayer(name: "Guest");

--- a/tests/NeoServer.Domain.Tests/Houses/HouseAccessLevelTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseAccessLevelTests.cs
@@ -29,6 +29,7 @@ public class HouseAccessLevelTests
     }
 
     [Fact]
+    [Trait("Category", "Validation")]
     public void GetAccessLevel_NonPremiumSubOwner_ReturnsNotInvited()
     {
         var player = HouseTestDataBuilder.CreatePlayer(name: "Sub", hasPremiumTime: false);
@@ -41,6 +42,7 @@ public class HouseAccessLevelTests
     }
 
     [Fact]
+    [Trait("Category", "EdgeCase")]
     public void GetAccessLevel_NonPremiumSubOwnerInGuestList_ReturnsGuest()
     {
         var player = HouseTestDataBuilder.CreatePlayer(name: "Sub", hasPremiumTime: false);
@@ -54,6 +56,7 @@ public class HouseAccessLevelTests
     }
 
     [Fact]
+    [Trait("Category", "HappyPath")]
     public void GetAccessLevel_NonPremiumSubOwner_WhenPremiumNotRequired_ReturnsSubOwner()
     {
         var player = HouseTestDataBuilder.CreatePlayer(name: "Sub", hasPremiumTime: false);

--- a/tests/NeoServer.Domain.Tests/Houses/HouseEvictionTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseEvictionTests.cs
@@ -60,6 +60,7 @@ public class HouseEvictionTests
     }
 
     [Fact]
+    [Trait("Category", "Validation")]
     public void CanKick_NonPremiumSubownerKicksGuest_ReturnsFalse()
     {
         var tileMock = HouseTestDataBuilder.CreateTileMock();
@@ -80,6 +81,7 @@ public class HouseEvictionTests
     }
 
     [Fact]
+    [Trait("Category", "HappyPath")]
     public void CanKick_NonPremiumSubownerKicksGuest_WhenPremiumNotRequired_ReturnsTrue()
     {
         var tileMock = HouseTestDataBuilder.CreateTileMock();

--- a/tests/NeoServer.Domain.Tests/Houses/HouseEvictionTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseEvictionTests.cs
@@ -60,6 +60,47 @@ public class HouseEvictionTests
     }
 
     [Fact]
+    public void CanKick_NonPremiumSubownerKicksGuest_ReturnsFalse()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var guest = HouseTestDataBuilder.CreatePlayer(id: 3, level: 5);
+        var guestMock = Mock.Get(guest);
+        guestMock.Setup(x => x.Tile).Returns(tileMock.Object);
+
+        var house = HouseTestDataBuilder.Build(
+            tiles: new List<Mock<IDynamicTile>> { tileMock },
+            accessLists: new Dictionary<uint, HouseAccessList>
+            {
+                { HouseListId.SubOwnerList, HouseTestDataBuilder.CreateAccessList("Sub") }
+            });
+
+        var subowner = HouseTestDataBuilder.CreatePlayer(id: 2, level: 50, name: "Sub", hasPremiumTime: false);
+
+        house.CanKick(subowner, guest).Should().BeFalse();
+    }
+
+    [Fact]
+    public void CanKick_NonPremiumSubownerKicksGuest_WhenPremiumNotRequired_ReturnsTrue()
+    {
+        var tileMock = HouseTestDataBuilder.CreateTileMock();
+        var guest = HouseTestDataBuilder.CreatePlayer(id: 3, level: 5);
+        var guestMock = Mock.Get(guest);
+        guestMock.Setup(x => x.Tile).Returns(tileMock.Object);
+
+        var house = HouseTestDataBuilder.Build(
+            tiles: new List<Mock<IDynamicTile>> { tileMock },
+            accessLists: new Dictionary<uint, HouseAccessList>
+            {
+                { HouseListId.SubOwnerList, HouseTestDataBuilder.CreateAccessList("Sub") }
+            });
+        house.RequirePremiumForSubOwners = false;
+
+        var subowner = HouseTestDataBuilder.CreatePlayer(id: 2, level: 50, name: "Sub", hasPremiumTime: false);
+
+        house.CanKick(subowner, guest).Should().BeTrue();
+    }
+
+    [Fact]
     public void CanKick_GuestKicksAnyone_ReturnsFalse()
     {
         var tileMock = HouseTestDataBuilder.CreateTileMock();

--- a/tests/NeoServer.Server.Tests/Commands/PlayerEditHouseAccessListCommandTest.cs
+++ b/tests/NeoServer.Server.Tests/Commands/PlayerEditHouseAccessListCommandTest.cs
@@ -71,6 +71,48 @@ public class PlayerEditHouseAccessListCommandTest
 
     [Fact]
     [Trait("Category", "HappyPath")]
+    public void Execute_SubOwnerListRemovesOnlineSubOwner_KicksRemovedPlayer()
+    {
+        // Arrange
+        var map = MapTestDataBuilder.Build(1, 101, 1, 101, 7, 7);
+        var subOwner = PlayerTestDataBuilder.Build(id: 2, name: "SubOwner", map: map, premiumTime: 30);
+        var subOwnerTile = (IDynamicTile)map[50, 49, 7];
+
+        var subOwnerList = HouseTestDataBuilder.CreateAccessList("SubOwner");
+        subOwnerList.RawText = "SubOwner";
+
+        var house = HouseTestDataBuilder.Build(
+            id: 10,
+            ownerGuid: 1,
+            entryPosition: new Location(50, 50, 7),
+            realTiles: [subOwnerTile],
+            accessLists: new Dictionary<uint, Domain.Houses.AccessList.HouseAccessList>
+            {
+                { HouseListId.SubOwnerList, subOwnerList }
+            });
+
+        subOwner.SetNewLocation(new Location(50, 49, 7));
+        map.PlaceCreature(subOwner);
+
+        var houseStore = new HouseStore();
+        houseStore.AddOrUpdate(10, house);
+
+        var houseRepository = new Mock<IHouseRepository>();
+        var eviction = new HouseEvictionService(CreateMovementService(map));
+        var command = CreateCommand(houseStore, houseRepository.Object, eviction);
+
+        var owner = PlayerTestDataBuilder.Build(id: 1, name: "Owner", map: map);
+
+        // Act
+        command.Execute(owner, houseId: 10, HouseListId.SubOwnerList, text: string.Empty);
+
+        // Assert
+        houseRepository.Verify(x => x.SaveAccessList(10, HouseListId.SubOwnerList, string.Empty), Times.Once);
+        subOwner.Location.Should().Be(new Location(50, 50, 7));
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
     public void Execute_DoorListEdit_DoesNotKick()
     {
         // Arrange
@@ -108,6 +150,97 @@ public class PlayerEditHouseAccessListCommandTest
         // Assert
         houseRepository.Verify(x => x.SaveAccessList(10, 1, string.Empty), Times.Once);
         guest.Location.Should().Be(new Location(50, 49, 7));
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Execute_SubOwnerListWithElevenEntries_DoesNotSave()
+    {
+        // Arrange
+        var map = MapTestDataBuilder.Build(1, 101, 1, 101, 7, 7);
+        var house = HouseTestDataBuilder.Build(id: 10, ownerGuid: 1);
+
+        var houseStore = new HouseStore();
+        houseStore.AddOrUpdate(10, house);
+
+        var houseRepository = new Mock<IHouseRepository>();
+        var eviction = new HouseEvictionService(CreateMovementService(map));
+        var command = CreateCommand(houseStore, houseRepository.Object, eviction);
+        var owner = PlayerTestDataBuilder.Build(id: 1, name: "Owner", map: map);
+
+        var names = new List<string>(11);
+        for (var i = 1; i <= 11; i++)
+        {
+            names.Add($"Sub{i}");
+        }
+
+        // Act
+        command.Execute(owner, houseId: 10, HouseListId.SubOwnerList, string.Join('\n', names));
+
+        // Assert
+        houseRepository.Verify(
+            x => x.SaveAccessList(It.IsAny<uint>(), It.IsAny<uint>(), It.IsAny<string>()),
+            Times.Never);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Execute_SubOwnerListWithTenEntries_Saves()
+    {
+        // Arrange
+        var map = MapTestDataBuilder.Build(1, 101, 1, 101, 7, 7);
+        var house = HouseTestDataBuilder.Build(id: 10, ownerGuid: 1);
+
+        var houseStore = new HouseStore();
+        houseStore.AddOrUpdate(10, house);
+
+        var houseRepository = new Mock<IHouseRepository>();
+        var eviction = new HouseEvictionService(CreateMovementService(map));
+        var command = CreateCommand(houseStore, houseRepository.Object, eviction);
+        var owner = PlayerTestDataBuilder.Build(id: 1, name: "Owner", map: map);
+
+        var names = new List<string>(10);
+        for (var i = 1; i <= 10; i++)
+        {
+            names.Add($"Sub{i}");
+        }
+        var text = string.Join('\n', names);
+
+        // Act
+        command.Execute(owner, houseId: 10, HouseListId.SubOwnerList, text);
+
+        // Assert
+        houseRepository.Verify(x => x.SaveAccessList(10, HouseListId.SubOwnerList, text), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Execute_SubOwnerListExclusionsDoNotCountTowardLimit_Saves()
+    {
+        // Arrange
+        var map = MapTestDataBuilder.Build(1, 101, 1, 101, 7, 7);
+        var house = HouseTestDataBuilder.Build(id: 10, ownerGuid: 1);
+
+        var houseStore = new HouseStore();
+        houseStore.AddOrUpdate(10, house);
+
+        var houseRepository = new Mock<IHouseRepository>();
+        var eviction = new HouseEvictionService(CreateMovementService(map));
+        var command = CreateCommand(houseStore, houseRepository.Object, eviction);
+        var owner = PlayerTestDataBuilder.Build(id: 1, name: "Owner", map: map);
+
+        var lines = new List<string>(12) { "!Excluded", "# comment" };
+        for (var i = 1; i <= 10; i++)
+        {
+            lines.Add($"Sub{i}");
+        }
+        var text = string.Join('\n', lines);
+
+        // Act
+        command.Execute(owner, houseId: 10, HouseListId.SubOwnerList, text);
+
+        // Assert
+        houseRepository.Verify(x => x.SaveAccessList(10, HouseListId.SubOwnerList, text), Times.Once);
     }
 
     [Fact]


### PR DESCRIPTION
### Description
Owners can now manage the sub-owner list from inside the house with the `aleta som` spell. Sub-owner lists are capped at 10 characters and only Premium Account players can be active sub-owners.

### Key Changes
- `aleta som` spell (id 251) opens the sub-owner list window for the house owner
- Sub-owner list capped at 10 entries (`HouseConfiguration.MaxSubOwnerCount`); exclusions and comments do not count toward the limit
- Sub-owner abilities (guest-list editing, kicking, door access, entry) now require an active Premium Account (`HouseConfiguration.RequirePremiumForSubOwners`); free-account characters keep their slot but are inactive until premium is restored
- New `house` settings in `appsettings.json`; removal of a sub-owner still evicts them from the house immediately

### Types of Changes
- [x] New feature (non-breaking change which adds functionality)

### Test Case
- `dotnet test tests/NeoServer.Domain.Tests --filter "FullyQualifiedName~Houses"`
- `dotnet test tests/NeoServer.Server.Tests --filter "FullyQualifiedName~PlayerEditHouseAccessListCommandTest"`