### PR TITLE
fix(house): keep guests from opening internal house doors

### DIFF
--- a/src/Core/NeoServer.Domain/Houses/House.cs
+++ b/src/Core/NeoServer.Domain/Houses/House.cs
@@ -122,17 +122,88 @@ public class House
 
     public bool CanUseDoor(IPlayer player, uint doorId)
     {
+        _doors.TryGetValue(doorId, out var door);
+        return CanUseDoor(player, door?.Location ?? default, doorId);
+    }
+
+    /// <summary>
+    ///     Invited players may open/close the house entry door. Internal doors require
+    ///     sub-owner access or an explicit per-door list entry.
+    /// </summary>
+    public bool CanUseDoor(IPlayer player, Location doorLocation, uint? doorId = null)
+    {
         if (GetAccessLevel(player) >= HouseAccessLevel.SubOwner)
             return true;
 
-        var list = GetAccessList(doorId);
+        if (IsInvited(player) && IsEntryDoor(doorLocation, doorId))
+            return true;
 
-        // No per-door list configured yet — any invited character may use the door.
-        // Once a door list exists (even empty), it alone decides access for guests.
-        if (list is null)
-            return IsInvited(player);
+        if (doorId is null)
+            return false;
 
-        return list.IsInList(player);
+        var list = GetAccessList(doorId.Value);
+        return list is not null && list.IsInList(player);
+    }
+
+    /// <summary>
+    ///     The entry door is the house door on or adjacent to <see cref="EntryPosition"/>
+    ///     (the kick/exit tile). When several doors qualify, the closest one wins.
+    /// </summary>
+    public bool IsEntryDoor(Location doorLocation, uint? doorId = null)
+    {
+        if (EntryPosition is null)
+            return false;
+
+        var entry = EntryPosition.Value;
+        if (doorLocation.Z != entry.Z)
+            return false;
+
+        var entryDoorId = FindEntryDoorId();
+        if (entryDoorId is not null)
+        {
+            if (doorId is not null)
+                return doorId == entryDoorId;
+
+            if (_doors.TryGetValue(entryDoorId.Value, out var entryDoor) && entryDoor is not null)
+                return entryDoor.Location == doorLocation;
+        }
+
+        return doorLocation.GetMaxSqmDistance(entry) <= 1;
+    }
+
+    private uint? FindEntryDoorId()
+    {
+        if (EntryPosition is null)
+            return null;
+
+        var entry = EntryPosition.Value;
+        uint? bestId = null;
+        var bestDistance = int.MaxValue;
+
+        foreach (var (id, door) in _doors)
+        {
+            if (door is null)
+                continue;
+
+            var location = door.Location;
+            if (location.Z != entry.Z)
+                continue;
+
+            var distance = location.GetMaxSqmDistance(entry);
+            if (distance > 1)
+                continue;
+
+            if (distance > bestDistance)
+                continue;
+
+            if (distance < bestDistance || bestId is null || id < bestId)
+            {
+                bestDistance = distance;
+                bestId = id;
+            }
+        }
+
+        return bestId;
     }
 
     public bool IsInvited(IPlayer player)

--- a/src/Database/NeoServer.Data.InMemory.DataStores/HouseStore.cs
+++ b/src/Database/NeoServer.Data.InMemory.DataStores/HouseStore.cs
@@ -1,8 +1,6 @@
-using NeoServer.Data.InMemory.DataStores;
 using NeoServer.Domain.Common.Contracts.DataStores;
 using NeoServer.Domain.Common.Contracts.World.Tiles;
 using NeoServer.Domain.Houses;
-using NeoServer.Domain.World.Models.Tiles;
 
 [assembly: System.Runtime.CompilerServices.InternalsVisibleTo("NeoServer.Domain.Tests")]
 
@@ -12,8 +10,10 @@ public class HouseStore : DataStore<HouseStore, uint, House>, IHouseStore
 {
     public House GetByTile(ITile tile)
     {
-        var houseId = (tile as DynamicTile)?.HouseId;
-        return houseId.HasValue ? Get(houseId.Value) : null;
+        if (tile is not IDynamicTile dynamicTile || dynamicTile.HouseId is not > 0)
+            return null;
+
+        return Get(dynamicTile.HouseId.Value);
     }
 
     public House GetByHouseId(uint houseId)

--- a/src/Extensions/NeoServer.Scripts.LuaJIT/ScriptServices/LuaActionScriptService.cs
+++ b/src/Extensions/NeoServer.Scripts.LuaJIT/ScriptServices/LuaActionScriptService.cs
@@ -116,25 +116,23 @@ public class LuaActionScriptService : IActionScriptService
 
     /// <summary>
     ///     House door access gate. Non-house doors are always allowed.
-    ///     House doors without a DoorId allow any invited character when no per-door list exists.
+    ///     Invited players may use the entry door; internal doors require
+    ///     sub-owner access or an explicit per-door list entry.
     /// </summary>
     private bool CanUseHouseDoor(IPlayer player, IItem item)
     {
         if (!item.IsDoor) return true;
 
         var tile = item.Parent as ITile ?? item.Owner as ITile ?? _map.GetTile(item.Location);
-        if (tile is null) return true;
+        if (tile is not IDynamicTile dynamicTile || dynamicTile.HouseId is not > 0)
+            return true;
 
-        var house = _houseStore.GetByTile(tile);
-        if (house is null) return true;
+        var house = _houseStore.GetByHouseId(dynamicTile.HouseId.Value) ?? _houseStore.GetByTile(tile);
+        if (house is null)
+            return false;
 
-        if (!TryGetDoorId(item, out var doorId))
-        {
-            // Door without a DoorId: allow any invited character (matches unset per-door list).
-            return house.IsInvited(player);
-        }
-
-        return house.CanUseDoor(player, doorId);
+        uint? doorId = TryGetDoorId(item, out var parsedDoorId) ? parsedDoorId : null;
+        return house.CanUseDoor(player, item.Location, doorId);
     }
 
     private static bool TryGetDoorId(IItem item, out uint doorId)

--- a/tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs
+++ b/tests/NeoServer.Domain.Tests/Helpers/House/HouseTestDataBuilder.cs
@@ -98,11 +98,13 @@ public static class HouseTestDataBuilder
         return tileMock;
     }
 
-    public static Mock<IItem> CreateItemMock(bool isPickupable = true, ushort serverId = 100)
+    public static Mock<IItem> CreateItemMock(bool isPickupable = true, ushort serverId = 100, Location? location = null)
     {
         var itemMock = new Mock<IItem>();
         itemMock.Setup(x => x.IsPickupable).Returns(isPickupable);
         itemMock.Setup(x => x.ServerId).Returns(serverId);
+        if (location is not null)
+            itemMock.Setup(x => x.Location).Returns(location.Value);
         return itemMock;
     }
 

--- a/tests/NeoServer.Domain.Tests/Houses/HouseDoorAccessTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseDoorAccessTests.cs
@@ -1,3 +1,4 @@
+using NeoServer.Domain.Common.Location.Structs;
 using NeoServer.Domain.Creatures.Player;
 using NeoServer.Domain.Houses;
 using NeoServer.Domain.Houses.AccessList;
@@ -31,8 +32,8 @@ public class HouseDoorAccessTests
     }
 
     [Fact]
-    [Trait("Category", "HappyPath")]
-    public void House_allows_door_use_when_player_is_guest_and_door_list_not_configured()
+    [Trait("Category", "Validation")]
+    public void House_denies_door_use_when_player_is_guest_only()
     {
         var player = HouseTestDataBuilder.CreatePlayer(name: "Guest");
         var house = HouseTestDataBuilder.Build(accessLists: new Dictionary<uint, HouseAccessList>
@@ -40,7 +41,7 @@ public class HouseDoorAccessTests
             { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Guest") }
         });
 
-        house.CanUseDoor(player, doorId: 1).Should().BeTrue();
+        house.CanUseDoor(player, doorId: 1).Should().BeFalse();
     }
 
     [Fact]
@@ -71,7 +72,7 @@ public class HouseDoorAccessTests
 
     [Fact]
     [Trait("Category", "Validation")]
-    public void House_denies_door_use_when_door_list_is_null_and_player_not_invited()
+    public void House_denies_door_use_when_door_list_is_null()
     {
         var player = HouseTestDataBuilder.CreatePlayer(name: "Stranger");
         var house = HouseTestDataBuilder.Build();
@@ -142,5 +143,75 @@ public class HouseDoorAccessTests
         });
 
         house.CanUseDoor(player, doorId: 0).Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void House_allows_door_use_when_guest_uses_entry_door()
+    {
+        var entry = new Location(100, 100, 7);
+        var door = HouseTestDataBuilder.CreateItemMock(location: new Location(100, 99, 7));
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Guest");
+        var house = HouseTestDataBuilder.Build(
+            entryPosition: entry,
+            doors: [(1, door)],
+            accessLists: new Dictionary<uint, HouseAccessList>
+            {
+                { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Guest") }
+            });
+
+        house.CanUseDoor(player, doorId: 1).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void House_allows_door_use_when_guest_uses_entry_door_by_location()
+    {
+        var entry = new Location(100, 100, 7);
+        var doorLocation = new Location(100, 99, 7);
+        var door = HouseTestDataBuilder.CreateItemMock(location: doorLocation);
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Guest");
+        var house = HouseTestDataBuilder.Build(
+            entryPosition: entry,
+            doors: [(1, door)],
+            accessLists: new Dictionary<uint, HouseAccessList>
+            {
+                { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Guest") }
+            });
+
+        house.CanUseDoor(player, doorLocation).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void House_denies_door_use_when_guest_uses_internal_door()
+    {
+        var entry = new Location(100, 100, 7);
+        var entryDoor = HouseTestDataBuilder.CreateItemMock(location: new Location(100, 99, 7));
+        var internalDoor = HouseTestDataBuilder.CreateItemMock(location: new Location(100, 95, 7));
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Guest");
+        var house = HouseTestDataBuilder.Build(
+            entryPosition: entry,
+            doors: [(1, entryDoor), (2, internalDoor)],
+            accessLists: new Dictionary<uint, HouseAccessList>
+            {
+                { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Guest") }
+            });
+
+        house.CanUseDoor(player, doorId: 2).Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void House_denies_door_use_when_stranger_uses_entry_door()
+    {
+        var entry = new Location(100, 100, 7);
+        var door = HouseTestDataBuilder.CreateItemMock(location: new Location(100, 99, 7));
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Stranger");
+        var house = HouseTestDataBuilder.Build(
+            entryPosition: entry,
+            doors: [(1, door)]);
+
+        house.CanUseDoor(player, doorId: 1).Should().BeFalse();
     }
 }

--- a/tests/NeoServer.Domain.Tests/Houses/HouseStoreTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseStoreTests.cs
@@ -1,0 +1,49 @@
+using Moq;
+using NeoServer.Data.InMemory.DataStores;
+using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Tests.Helpers.House;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseStoreTests
+{
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void GetByTile_returns_house_when_tile_has_house_id()
+    {
+        var house = HouseTestDataBuilder.Build(id: 5);
+        var store = new HouseStore();
+        store.AddOrUpdate(5, house);
+
+        var tileMock = new Mock<IDynamicTile>();
+        tileMock.Setup(t => t.HouseId).Returns(5u);
+
+        store.GetByTile(tileMock.Object).Should().BeSameAs(house);
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void GetByTile_returns_null_when_tile_has_no_house_id()
+    {
+        var house = HouseTestDataBuilder.Build(id: 5);
+        var store = new HouseStore();
+        store.AddOrUpdate(5, house);
+
+        var tileMock = new Mock<IDynamicTile>();
+        tileMock.Setup(t => t.HouseId).Returns((uint?)null);
+
+        store.GetByTile(tileMock.Object).Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void GetByTile_returns_null_when_house_id_is_zero()
+    {
+        var store = new HouseStore();
+
+        var tileMock = new Mock<IDynamicTile>();
+        tileMock.Setup(t => t.HouseId).Returns(0u);
+
+        store.GetByTile(tileMock.Object).Should().BeNull();
+    }
+}


### PR DESCRIPTION
### Description
Uninvited players could open every house door, and invited guests were locked out of the entry after that was tightened. Guests may now open only the house entry door; internal doors stay locked unless the player is owner, sub-owner, or on that door list.

### Key Changes
- Strangers can no longer open house doors
- Invited players can open/close the entry door (the door on or next to the house exit tile)
- Internal doors require owner, sub-owner, or an explicit per-door list
- House lookup from a tile uses the tile house id, so the door gate no longer fails open

### Types of Changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
- `dotnet test tests/NeoServer.Domain.Tests --filter FullyQualifiedName~HouseDoorAccessTests`
- In-game: guest can open/close the front door and is blocked on internal doors; a stranger is blocked on all house doors; owner can use every door