### PR TITLE
feat(house): let owners edit door access lists with aleta grav

### DIFF
--- a/data/scripts/spells/house/edit_door.lua
+++ b/data/scripts/spells/house/edit_door.lua
@@ -1,0 +1,51 @@
+local spell = Spell("instant")
+
+function spell.onCastSpell(creature, variant)
+    local player = Player(creature)
+    if not player then
+        return false
+    end
+
+    local function tryDoor(pos)
+        if not pos then
+            return nil, nil
+        end
+        local tile = Tile(pos)
+        local house = tile and tile:getHouse()
+        if not house then
+            return nil, nil
+        end
+        return house, house:getDoorIdByPosition(pos)
+    end
+
+    -- Facing tile first, then the caster's tile (standing in the doorway).
+    -- House is resolved from the door tile so facing from outside still works.
+    local house, doorId = tryDoor(variant:getPosition())
+    if doorId == nil then
+        house, doorId = tryDoor(player:getPosition())
+    end
+
+    if doorId == nil or not house:canEditAccessList(doorId, player) then
+        player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+        player:getPosition():sendMagicEffect(CONST_ME_POFF)
+        return false
+    end
+
+    player:setEditHouse(house, doorId)
+    player:sendHouseWindow(house, doorId)
+    return true
+end
+
+spell:name("House Door List")
+spell:words("aleta grav")
+spell:group("support")
+spell:id(253)
+spell:cooldown(1000)
+spell:groupCooldown(1000)
+spell:level(1)
+spell:mana(0)
+spell:isAggressive(false)
+spell:needCasterTargetOrDirection(true)
+spell:needLearn(false)
+spell:isPremium(false)
+spell:register()

--- a/docs/house-system/House-System-Plan.md
+++ b/docs/house-system/House-System-Plan.md
@@ -74,7 +74,7 @@ New folder: `src/Core/NeoServer.Domain/Houses/`.
   `LinkDoor(uint doorId, IDoorItem)`; `LinkBed(IBedItem)`. Throws if a tile is linked to two houses.
 - **Access:** `GetAccessLevel(IPlayer)` (Owner if `Group.Access` or `CanEditHouses`, else guid /
   subowner / guest / not invited), `IsInvited`, `CanEnter(ICreature)`,
-  `CanEditAccessList(listId, IPlayer)` (owner edits subowner list; owner+subowner edit guest list/doors),
+  `CanEditAccessList(listId, IPlayer)` (owner edits any list; subowner edits guest list only, not door lists),
   `GetAccessList(listId)` / `SetAccessList(listId, HouseAccessList)`.
 - **`SetNewOwner(guid, name, accountId, updatePaidUntil, now, rentPeriodSeconds)`** (ports `House::setOwner`):
   pure domain state change. On owner *change* → clear all access + door lists; set owner fields
@@ -142,7 +142,7 @@ Add `Helpers/House/HouseTestDataBuilder.cs`; reuse `PlayerTestDataBuilder` and
   `AllowAll`, `Clear` resets state, `IsInList` combinations.
 - **HouseAccessLevelTests:** owner/subowner/guest/none resolution; `CanEditHouses` → Owner;
   both-lists → SubOwner wins; `IsInvited` true/false; `CanEnter` invited/uninvited; non-player → true;
-  `CanEditAccessList` owner-vs-subowner-list, subowner-vs-guest-list, guest-edits-anything-false.
+  `CanEditAccessList` owner-vs-subowner-list, subowner-vs-guest-list, owner-vs-door-list, subowner-cannot-edit-door-list, guest-edits-anything-false.
 - **HouseEvictionTests:** owner/subowner kicks guest → allowed; guest kicks other guest / self →
   allowed; guest kicks subowner or owner → fail; cannot kick `CanEditHouses`; `CanEditHouses` can
   kick owner; target not in house → fail; `KickOccupants` only moves now-uninvited.

--- a/docs/house-system/domain-tests.md
+++ b/docs/house-system/domain-tests.md
@@ -39,6 +39,8 @@
 - CanEditAccessList_SubownerEditsSubownerList_ReturnsFalse → false.
 - CanEditAccessList_SubownerEditsGuestList_ReturnsTrue → true.
 - CanEditAccessList_GuestEditsAnyList_ReturnsFalse → false for guest/subowner/door lists.
+- House_allows_owner_to_edit_door_list → true.
+- House_denies_subowner_editing_door_list → false.
 
 ## HouseEvictionTests
 - CanKick_OwnerKicksGuest_ReturnsTrue → true (caster access >= target, target on house tile).
@@ -81,6 +83,8 @@
 
 ## HouseDoorBedTests
 - GetDoorCount_AfterLinking_ReturnsCount → DoorCount matches linked doors.
+- House_returns_door_id_when_position_matches_linked_door → linked door id.
+- House_returns_null_when_no_door_at_position → null (not 0; door id 0 is a valid list id).
 - LinkBed_AddsBedToHouse_GetBedCountReflects → BedCount matches linked beds.
 - SetAccessList_DoorListId_UpdatesThatDoorOnly → only that door's list changes, other doors unaffected.
 - EntryPosition_DefaultsToFirstTileLocation → EntryPosition == first linked tile's Location.
@@ -148,15 +152,6 @@
 
 The following cases are planned but not implemented in Phase 1. They are listed here to document
 their target phase explicitly — none were silently dropped.
-
-### GetDoorIdByPosition (Phase 3 dependency — m4)
-- `GetDoorIdByPosition_KnownDoor_ReturnsDoorId` — deferred to Phase 3.
-  Requires a reverse `Dictionary<Location, uint>` map populated at `LinkDoor` time.
-  A door item's `Location` is only reliably available after the Phase-2 world-attach step
-  (doors receive their location when linked from the map). Implementing in Phase 1 would require
-  storing a `Location` per door at link time without a reliable source for it.
-  See `House-System-Plan.md` Phase 3, `HouseFunctions.getDoorIdByPosition`.
-- `GetDoorIdByPosition_NoDoorAtPosition_ReturnsZero` — same blocker; deferred to Phase 3.
 
 ### Factory access-list and door seeding (Phase 2 — HouseAccessListLoader)
 - `Create_FromEntity_SeedsGuestList_*`, `Create_FromEntity_SeedsSubownerList_*`,

--- a/docs/house-system/domain.md
+++ b/docs/house-system/domain.md
@@ -403,6 +403,7 @@ Having a house offers many great advantages, here are a few of them:
 3. Owner adds or removes characters from that door's access list.
 
 **Business Rules:**
+- Only the main Owner can cast this spell — Sub-Owners cannot edit door access lists.
 - When a door is open, all characters on the house invite list may pass through, even without explicit door rights.
 - When a door is closed, only characters on that door's access list can open or close it.
 

--- a/docs/house-system/house-phase1-steps.md
+++ b/docs/house-system/house-phase1-steps.md
@@ -111,7 +111,7 @@ last from primitives so tests can target each piece in isolation.
   - `HouseAccessLevel GetAccessLevel(IPlayer)` → Owner if `Group.Access` or `CanEditHouses`; else Owner if guid match (and owner≠0); else SubOwner if in subowner list and premium (when required); else Guest if in guest list; else NotInvited.
   - `bool IsInvited(IPlayer)` ⇒ `GetAccessLevel != NotInvited`.
   - `bool CanEnter(ICreature)` ⇒ non-players true; players ⇒ `IsInvited`.
-  - `bool CanEditAccessList(uint listId, IPlayer)` ⇒ subowner list requires Owner; guest list / door lists require `>= SubOwner`.
+  - `bool CanEditAccessList(uint listId, IPlayer)` ⇒ owner edits any list; subowner edits guest list only (not door lists).
   - `string GetAccessList(uint listId)` / `void SetAccessList(uint listId, HouseAccessList list)` (store structured list; door listId updates only that door's list).
 - **Where:** `Houses/House.cs`
 - **Depends on:** Steps 3, 6.
@@ -245,6 +245,8 @@ Each row: **Test → Expected output**. Groups map to the Step-12 test classes.
 - CanEditAccessList_SubownerEditsSubownerList_ReturnsFalse → false.
 - CanEditAccessList_SubownerEditsGuestList_ReturnsTrue → true.
 - CanEditAccessList_GuestEditsAnyList_ReturnsFalse → false.
+- House_allows_owner_to_edit_door_list → true.
+- House_denies_subowner_editing_door_list → false.
 
 ## HouseEvictionTests (pure aggregate checks)
 - CanKick_OwnerKicksGuest_ReturnsTrue → returns true.
@@ -279,8 +281,8 @@ Each row: **Test → Expected output**. Groups map to the Step-12 test classes.
 - LinkTile_SameTileToTwoHouses_Throws → throws.
 
 ## HouseDoorBedTests
-- GetDoorIdByPosition_KnownDoor_ReturnsDoorId → expected door id.
-- GetDoorIdByPosition_NoDoorAtPosition_ReturnsZeroOrNil → 0/none.
+- House_returns_door_id_when_position_matches_linked_door → expected door id.
+- House_returns_null_when_no_door_at_position → null.
 - SetAccessList_DoorListId_UpdatesThatDoorOnly → only that door's list changes.
 - GetDoorCount_AfterLinking_ReturnsCount → count matches.
 - LinkBed_AddsBedToHouse_GetBedCountReflects → count matches.

--- a/docs/house-system/house-phase3-steps.md
+++ b/docs/house-system/house-phase3-steps.md
@@ -100,9 +100,42 @@ Reference behavior: TFS `kick_guest.lua` (words `alana sio`).
 
 ---
 
+## Slice 3 — `aleta grav` (House Door List) — DONE
+
+Reference behavior: TFS `edit_door.lua` (words `aleta grav`) plus wiki targeting (standing in the doorway or facing the door from either side).
+
+### What shipped
+
+1. **Domain**
+   - `House.GetDoorIdByPosition(Location)` — reverse `Dictionary<Location, uint>` filled in `LinkDoor` (survives door open/close transform)
+   - Returns `null` when no door is at that position (door id `0` is a valid list id)
+   - `CanEditAccessList` matches TFS: owner may edit any list; subowner may edit the guest list only (not door lists)
+
+2. **Lua binding** — `house:getDoorIdByPosition(position)` in `HouseFunctions` (number or `nil`)
+
+3. **Spell**
+   - `data/scripts/spells/house/edit_door.lua` — words `aleta grav`, spell id **253**, `needCasterTargetOrDirection(true)`
+   - Tries the facing tile first, then the caster's tile; house is resolved from the **door** tile so facing from outside works
+   - Save path is the existing house window (`0x97` / `0x8A`); door-list edits do not kick occupants
+
+4. **Domain tests**
+   - `HouseDoorBedTests`: known door / no door at position
+   - `HouseAccessLevelTests`: owner may edit a door list; subowner may not
+
+### In-game smoke checklist
+
+- [ ] Owner faces a house door and casts `aleta grav` → that door's access list window opens
+- [ ] Owner standing on an open doorway casts `aleta grav` → that door's window opens
+- [ ] Owner faces the door from outside the house → window opens
+- [ ] Subowner / guest / stranger cast → cancel + POFF
+- [ ] Cast not facing a house door and not standing on one → cancel + POFF
+- [ ] Owner saves a name on the door list → persists; occupants are not kicked
+- [ ] Guest not on that door list cannot open/close the door; invited guests can still walk through while it is open
+
+---
+
 ## Later slices (not started)
 
-- [ ] `aleta grav` — House Door List (`edit_door.lua` + `getDoorIdByPosition`)
 - [ ] Talkactions: `buyhouse` / `leavehouse` / `sellhouse`
 - [ ] Full `HouseFunctions` surface (tiles, doors, beds, rent, trade, save)
 - [ ] Rent warning letters

--- a/src/Core/NeoServer.Domain/Houses/House.cs
+++ b/src/Core/NeoServer.Domain/Houses/House.cs
@@ -12,6 +12,7 @@ public class House
 {
     private readonly List<IDynamicTile> _tiles = new();
     private readonly Dictionary<uint, IItem> _doors = new();
+    private readonly Dictionary<Location, uint> _doorIdsByPosition = new();
     private readonly List<IItem> _beds = new();
     private readonly Dictionary<uint, HouseAccessList> _accessLists = new();
 
@@ -84,7 +85,29 @@ public class House
 
     public void LinkDoor(uint doorId, IItem door)
     {
+        if (_doors.TryGetValue(doorId, out var existing) &&
+            _doorIdsByPosition.TryGetValue(existing.Location, out var mappedId) &&
+            mappedId == doorId)
+        {
+            _doorIdsByPosition.Remove(existing.Location);
+        }
+
         _doors[doorId] = door;
+        _doorIdsByPosition[door.Location] = doorId;
+    }
+
+    /// <summary>
+    ///     Door id at <paramref name="position"/>, or null when no door is linked there.
+    ///     Null (not 0) means miss — door id 0 is a valid list id.
+    /// </summary>
+    public uint? GetDoorIdByPosition(Location position)
+    {
+        if (_doorIdsByPosition.TryGetValue(position, out var doorId))
+        {
+            return doorId;
+        }
+
+        return null;
     }
 
     public void LinkBed(IItem bed)
@@ -220,11 +243,15 @@ public class House
     {
         var level = GetAccessLevel(player);
 
-        if (listId == HouseListId.SubOwnerList)
-            return level == HouseAccessLevel.Owner;
+        if (level == HouseAccessLevel.Owner)
+        {
+            return true;
+        }
 
-        if (listId == HouseListId.GuestList || HouseListId.IsDoorList(listId))
-            return level >= HouseAccessLevel.SubOwner;
+        if (level == HouseAccessLevel.SubOwner)
+        {
+            return listId == HouseListId.GuestList;
+        }
 
         return false;
     }

--- a/src/Core/NeoServer.Domain/Spells/Entities/Spell.cs
+++ b/src/Core/NeoServer.Domain/Spells/Entities/Spell.cs
@@ -96,12 +96,15 @@ public abstract class BaseSpell : ISpell
 
         if (target is IDynamicTile targetTile)
         {
-            if (targetTile.HasFlag(TileFlags.BlockProjecTile) || targetTile.HasFlag(TileFlags.FloorChange) ||
-                targetTile.HasTeleport(out _))
-                return Result.Fail(InvalidOperation.NotEnoughRoom);
+            if (IsAggressive)
+            {
+                if (targetTile.HasFlag(TileFlags.BlockProjecTile) || targetTile.HasFlag(TileFlags.FloorChange) ||
+                    targetTile.HasTeleport(out _))
+                    return Result.Fail(InvalidOperation.NotEnoughRoom);
 
-            if (IsAggressive && targetTile.HasFlag(TileFlags.ProtectionZone))
-                return Result.Fail(InvalidOperation.NotPermittedInProtectionZone);
+                if (targetTile.HasFlag(TileFlags.ProtectionZone))
+                    return Result.Fail(InvalidOperation.NotPermittedInProtectionZone);
+            }
 
             if (BlockingSolid && targetTile.HasFlag(TileFlags.Unpassable))
                 return Result.Fail(InvalidOperation.NotEnoughRoom);

--- a/src/Extensions/NeoServer.Scripts.LuaJIT/Functions/HouseFunctions.cs
+++ b/src/Extensions/NeoServer.Scripts.LuaJIT/Functions/HouseFunctions.cs
@@ -8,8 +8,8 @@ using NeoServer.Scripts.LuaJIT.Functions.Interfaces;
 namespace NeoServer.Scripts.LuaJIT.Functions;
 
 /// <summary>
-///     Minimal House Lua bindings for Phase 3 spell slices (aleta sio, alana sio).
-///     Full HouseFunctions surface (doors, trade, rent, etc.) comes in later slices.
+///     Minimal House Lua bindings for Phase 3 spell slices (aleta sio, aleta som, alana sio, aleta grav).
+///     Full HouseFunctions surface (tiles, beds, rent, trade, save) comes in later slices.
 /// </summary>
 public class HouseFunctions : LuaScriptInterface, IHouseFunctions
 {
@@ -31,6 +31,7 @@ public class HouseFunctions : LuaScriptInterface, IHouseFunctions
         RegisterMethod(luaState, "House", "getId", LuaHouseGetId);
         RegisterMethod(luaState, "House", "canEditAccessList", LuaHouseCanEditAccessList);
         RegisterMethod(luaState, "House", "getAccessList", LuaHouseGetAccessList);
+        RegisterMethod(luaState, "House", "getDoorIdByPosition", LuaHouseGetDoorIdByPosition);
         RegisterMethod(luaState, "House", "kickPlayer", LuaHouseKickPlayer);
 
         RegisterGlobalVariable(luaState, "GUEST_LIST", HouseListId.GuestList);
@@ -98,6 +99,28 @@ public class HouseFunctions : LuaScriptInterface, IHouseFunctions
 
         var list = house.GetAccessList(listId);
         Lua.PushString(luaState, list?.RawText ?? string.Empty);
+        return 1;
+    }
+
+    private static int LuaHouseGetDoorIdByPosition(LuaState luaState)
+    {
+        // house:getDoorIdByPosition(position)
+        var house = GetUserdata<House>(luaState, 1);
+        if (house is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        var position = GetPosition(luaState, 2);
+        var doorId = house.GetDoorIdByPosition(position);
+        if (doorId is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        Lua.PushNumber(luaState, doorId.Value);
         return 1;
     }
 

--- a/tests/NeoServer.Domain.Tests/Houses/HouseAccessLevelTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseAccessLevelTests.cs
@@ -210,4 +210,27 @@ public class HouseAccessLevelTests
         house.CanEditAccessList(HouseListId.SubOwnerList, player).Should().BeFalse();
         house.CanEditAccessList(1, player).Should().BeFalse();
     }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void House_allows_owner_to_edit_door_list()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(id: 1);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+
+        house.CanEditAccessList(1, player).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void House_denies_subowner_editing_door_list()
+    {
+        var player = HouseTestDataBuilder.CreatePlayer(name: "Sub");
+        var house = HouseTestDataBuilder.Build(accessLists: new Dictionary<uint, HouseAccessList>
+        {
+            { HouseListId.SubOwnerList, HouseTestDataBuilder.CreateAccessList("Sub") }
+        });
+
+        house.CanEditAccessList(1, player).Should().BeFalse();
+    }
 }

--- a/tests/NeoServer.Domain.Tests/Houses/HouseDoorBedTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseDoorBedTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using NeoServer.Domain.Common.Contracts.Items;
 using NeoServer.Domain.Common.Contracts.World.Tiles;
+using NeoServer.Domain.Common.Location.Structs;
 using NeoServer.Domain.Tests.Helpers.House;
 using NeoServer.Domain.Houses.AccessList;
 
@@ -16,6 +17,30 @@ public class HouseDoorBedTests
         house.LinkDoor(2, new Mock<IItem>().Object);
 
         house.DoorCount.Should().Be(2);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void House_returns_door_id_when_position_matches_linked_door()
+    {
+        var doorLocation = new Location(101, 100, 7);
+        var door = HouseTestDataBuilder.CreateItemMock(location: doorLocation);
+        var house = HouseTestDataBuilder.Build();
+
+        house.LinkDoor(3, door.Object);
+
+        house.GetDoorIdByPosition(doorLocation).Should().Be(3u);
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void House_returns_null_when_no_door_at_position()
+    {
+        var door = HouseTestDataBuilder.CreateItemMock(location: new Location(101, 100, 7));
+        var house = HouseTestDataBuilder.Build();
+        house.LinkDoor(3, door.Object);
+
+        house.GetDoorIdByPosition(new Location(102, 100, 7)).Should().BeNull();
     }
 
     [Fact]

--- a/tests/NeoServer.Domain.Tests/Spell/SpellTests.cs
+++ b/tests/NeoServer.Domain.Tests/Spell/SpellTests.cs
@@ -5,12 +5,15 @@ using NeoServer.Domain.Common.Contracts.Items;
 using NeoServer.Domain.Common.Contracts.Services;
 using NeoServer.Domain.Common.Contracts.World.Tiles;
 using NeoServer.Domain.Common.Creatures;
+using NeoServer.Domain.Common.Item;
+using NeoServer.Domain.Common.Location;
 using NeoServer.Domain.Common.Results;
 using NeoServer.Domain.Creatures.Conditions.Enums;
 using NeoServer.Domain.Services;
 using NeoServer.Domain.Spells;
 using NeoServer.Domain.Spells.Entities;
 using NeoServer.Domain.Spells.Events;
+using NeoServer.Domain.Tests.Helpers;
 using NeoServer.Domain.Tests.Helpers.Map;
 using NeoServer.Domain.Tests.Helpers.Player;
 using NeoServer.Domain.World.Services;
@@ -416,6 +419,94 @@ public class SpellTests
             e.Caster == player && e.Spell == spell)), Times.Once);
     }
 
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Spell_casts_when_facing_blocked_tile_and_not_blocking_solid()
+    {
+        var map = MapTestDataBuilder.Build(100, 102, 100, 102, 7, 7);
+        var pathFinder = new PathFinder(map);
+        var mapTool = new MapTool(map, pathFinder);
+        var spellService = new SpellService(
+            new SpellCastValidation(mapTool),
+            _eventAggregatorMock.Object,
+            new CreatureSpeechService(map),
+            map);
+
+        var player = PlayerTestDataBuilder.Build();
+        map.PlaceCreature(player);
+        player.TurnTo(Direction.East);
+
+        var door = ItemTestDataBuilder.CreateUnpassableItem(1210);
+        door.Metadata.Flags.Add(ItemFlag.BlockProjectTile);
+        ((IDynamicTile)map[101, 100, 7]).AddItem(door);
+
+        var spell = new TestSpell { NeedCasterTargetOrDirection = true, BlockingSolid = false, IsAggressive = false };
+
+        var result = spellService.Cast(player, null, spell, false);
+
+        result.Should().BeTrue();
+        _eventAggregatorMock.Verify(x => x.InvokeEvent(It.IsAny<SpellFailedToCastEvent>()), Times.Never);
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Spell_fails_with_not_enough_room_when_aggressive_and_facing_blocked_tile()
+    {
+        var map = MapTestDataBuilder.Build(100, 102, 100, 102, 7, 7);
+        var pathFinder = new PathFinder(map);
+        var mapTool = new MapTool(map, pathFinder);
+        var spellService = new SpellService(
+            new SpellCastValidation(mapTool),
+            _eventAggregatorMock.Object,
+            new CreatureSpeechService(map),
+            map);
+
+        var player = PlayerTestDataBuilder.Build();
+        map.PlaceCreature(player);
+        player.TurnTo(Direction.East);
+
+        var door = ItemTestDataBuilder.CreateUnpassableItem(1210);
+        door.Metadata.Flags.Add(ItemFlag.BlockProjectTile);
+        ((IDynamicTile)map[101, 100, 7]).AddItem(door);
+
+        var spell = new TestSpell { NeedCasterTargetOrDirection = true, IsAggressive = true };
+
+        var result = spellService.Cast(player, null, spell, false);
+
+        result.Should().BeFalse();
+        _eventAggregatorMock.Verify(x => x.InvokeEvent(It.Is<SpellFailedToCastEvent>(e =>
+            e.Caster == player && e.Spell == spell && e.Error == InvalidOperation.NotEnoughRoom)), Times.Once);
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Spell_fails_with_not_enough_room_when_blocking_solid_and_facing_unpassable_tile()
+    {
+        var map = MapTestDataBuilder.Build(100, 102, 100, 102, 7, 7);
+        var pathFinder = new PathFinder(map);
+        var mapTool = new MapTool(map, pathFinder);
+        var spellService = new SpellService(
+            new SpellCastValidation(mapTool),
+            _eventAggregatorMock.Object,
+            new CreatureSpeechService(map),
+            map);
+
+        var player = PlayerTestDataBuilder.Build();
+        map.PlaceCreature(player);
+        player.TurnTo(Direction.East);
+
+        var door = ItemTestDataBuilder.CreateUnpassableItem(1210);
+        door.Metadata.Flags.Add(ItemFlag.BlockProjectTile);
+        ((IDynamicTile)map[101, 100, 7]).AddItem(door);
+
+        var spell = new TestSpell { NeedCasterTargetOrDirection = true, BlockingSolid = true };
+
+        var result = spellService.Cast(player, null, spell, false);
+
+        result.Should().BeFalse();
+        _eventAggregatorMock.Verify(x => x.InvokeEvent(It.Is<SpellFailedToCastEvent>(e =>
+            e.Caster == player && e.Spell == spell && e.Error == InvalidOperation.NotEnoughRoom)), Times.Once);
+    }
 
     private class TestSpell : BaseSpell
     {


### PR DESCRIPTION
### Description
House owners can edit a specific door's access list with `aleta grav` while standing in the doorway or facing the door from either side. Subowners, guests, and strangers cannot.

### Key Changes
- `aleta grav` opens the house window for the targeted door's access list (owner only)
- Door lookup uses the facing tile first, then the caster's tile, so standing in a doorway and facing from outside both work
- Saving a door list persists without kicking occupants
- Non-aggressive spells can target a closed door; aggressive directional spells still fail with not enough room

### Types of Changes
- [x] New feature (non-breaking change which adds functionality)

### Test Case
- `dotnet test tests/NeoServer.Domain.Tests --filter FullyQualifiedName~HouseDoorBedTests|FullyQualifiedName~HouseAccessLevelTests|FullyQualifiedName~SpellTests`
- `dotnet test tests/NeoServer.Server.Tests --filter FullyQualifiedName~PlayerEditHouseAccessListCommandTest`