### PR TITLE
feat(house): let players buy houses with !buyhouse

### DIFF
--- a/data/libs/functions/player.lua
+++ b/data/libs/functions/player.lua
@@ -1,4 +1,4 @@
-﻿function Player.sendCancelMessage(self, message)
+function Player.sendCancelMessage(self, message)
     if type(message) == "number" then
         message = Game.getReturnMessage(message)
     end
@@ -7,4 +7,30 @@ end
 
 function Player.hasFlag(self, flag)
     return self:getGroup():hasFlag(flag)
+end
+
+function Player.removeTotalMoney(self, amount)
+    local moneyCount = self:getMoney()
+    local bankCount = self:getBankBalance()
+    if amount <= moneyCount then
+        self:removeMoney(amount)
+        return true
+    elseif amount <= (moneyCount + bankCount) then
+        if moneyCount ~= 0 then
+            self:removeMoney(moneyCount)
+            local remains = amount - moneyCount
+            self:setBankBalance(bankCount - remains)
+            self:sendTextMessage(MESSAGE_INFO_DESCR,
+                                 ("Paid %d from inventory and %d gold from bank account. Your account balance is now %d gold."):format(
+                                     moneyCount, amount - moneyCount, self:getBankBalance()))
+            return true
+        end
+
+        self:setBankBalance(bankCount - amount)
+        self:sendTextMessage(MESSAGE_INFO_DESCR,
+                             ("Paid %d gold from bank account. Your account balance is now %d gold."):format(
+                                 amount, self:getBankBalance()))
+        return true
+    end
+    return false
 end

--- a/data/scripts/talkactions/house/buyhouse.lua
+++ b/data/scripts/talkactions/house/buyhouse.lua
@@ -1,0 +1,59 @@
+---@type TalkAction
+local talkAction = TalkAction("!buyhouse")
+
+local config = {level = 1}
+
+---@param player Player
+---@param words string
+---@param param string
+function talkAction.onSay(player, words, param)
+    local housePrice = configManager.getNumber(configKeys.HOUSE_PRICE)
+    if housePrice == -1 then
+        return false
+    end
+
+    if player:getLevel() < config.level then
+        player:sendCancelMessage("You need level " .. config.level ..
+                                     " or higher to buy a house.")
+        return true
+    end
+
+    if not player:canOwnHouse() then
+        player:sendCancelMessage("You need a premium account.")
+        return true
+    end
+
+    -- OpenCoreMMO getNextPosition returns a new position (it does not mutate in place).
+    local position = player:getPosition():getNextPosition(player:getDirection())
+
+    local tile = Tile(position)
+    local house = tile and tile:getHouse()
+    if not house then
+        player:sendCancelMessage(
+            "You have to be looking at the door of the house you would like to buy.")
+        return true
+    end
+
+    if house:getOwnerGuid() > 0 then
+        player:sendCancelMessage("This house already has an owner.")
+        return true
+    end
+
+    if player:getHouse() then
+        player:sendCancelMessage("You are already the owner of a house.")
+        return true
+    end
+
+    local price = house:getTileCount() * housePrice
+    if not player:removeTotalMoney(price) then
+        player:sendCancelMessage("You do not have enough money.")
+        return true
+    end
+
+    house:setOwnerGuid(player:getGuid())
+    player:sendTextMessage(MESSAGE_INFO_DESCR,
+                           "You have successfully bought this house, be sure to have the money for the rent in the bank.")
+    return true
+end
+
+talkAction:register()

--- a/docs/house-system/house-phase3-steps.md
+++ b/docs/house-system/house-phase3-steps.md
@@ -134,8 +134,30 @@ Reference behavior: TFS `edit_door.lua` (words `aleta grav`) plus wiki targeting
 
 ---
 
+## Slice 4 — `!buyhouse` (House Purchase) — DONE
+
+Reference behavior: TFS `buyhouse.lua` (words `!buyhouse`). Player must face the house door. Price is `tileCount * pricePerSqm`. `-1` price disables the command (speech falls through as chat).
+
+### What shipped
+
+1. **Config** — `HouseConfiguration.PricePerSqm` (default 1000, `-1` disables) and `RentPeriod` (default `monthly`). Lua `configKeys.HOUSE_PRICE` aliases `HOUSE_PRICE_PER_SQM` and reads `PricePerSqm`.
+2. **Lua House** — `getOwnerGuid`, `getTileCount`, `setOwnerGuid(guid)` → `HouseService.SetOwner` (PaidUntil from rent period; unowned → owned skips eviction).
+3. **Lua Player** — `getGuid` (database id), `getHouse`, `isPremium`, `canOwnHouse` (`CanPlayerOwnHouse`), `getMoney` / `removeMoney`, `getBankBalance` / `setBankBalance`.
+4. **Money** — `Player.removeTotalMoney` in `data/libs/functions/player.lua` (inventory first, then bank).
+5. **Talkaction** — `data/scripts/talkactions/house/buyhouse.lua`. OpenCoreMMO talkaction `true` swallows chat (opposite of TFS booleans). Premium uses `canOwnHouse` so `RequirePremiumAccount` remains the switch.
+
+### In-game smoke checklist
+
+- [ ] Face an unowned house door, premium, enough money → owner set, money taken, success text
+- [ ] `pricePerSqm: -1` → `!buyhouse` appears as normal speech
+- [ ] Not facing a house door / already owned / already own a house / too poor / no premium / low level → matching cancel, no ownership change
+- [ ] Inventory coins first, then bank (bank message when bank is used)
+- [ ] Second `!buyhouse` on another house → already own a house
+
+---
+
 ## Later slices (not started)
 
-- [ ] Talkactions: `buyhouse` / `leavehouse` / `sellhouse`
+- [ ] Talkactions: `leavehouse` / `sellhouse`
 - [ ] Full `HouseFunctions` surface (tiles, doors, beds, rent, trade, save)
 - [ ] Rent warning letters

--- a/src/Core/NeoServer.Domain/Common/Contracts/DataStores/IHouseStore.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/DataStores/IHouseStore.cs
@@ -7,4 +7,5 @@ public interface IHouseStore : IDataStore<uint, House>
 {
     House GetByTile(ITile tile);
     House GetByHouseId(uint houseId);
+    House GetByOwnerGuid(uint ownerGuid);
 }

--- a/src/Core/NeoServer.Domain/Common/GameConfiguration.cs
+++ b/src/Core/NeoServer.Domain/Common/GameConfiguration.cs
@@ -1,4 +1,4 @@
-﻿using NeoServer.Domain.Combat;
+using NeoServer.Domain.Combat;
 
 namespace NeoServer.Domain.Common;
 
@@ -57,5 +57,32 @@ public record HouseConfiguration(
     bool RequirePremiumForSubOwners = true,
     int MaxAccessListLength = 1999,
     int MaxAccessListLines = 100,
-    int MaxSubOwnerCount = 10
-);
+    int MaxSubOwnerCount = 10,
+    int PricePerSqm = 1000,
+    string RentPeriod = "monthly"
+)
+{
+    /// <summary>
+    ///     Seconds in one rent period. daily/weekly/monthly/yearly match the usual
+    ///     house rent cycle; any other value (including "never") is 0 and skips PaidUntil updates.
+    /// </summary>
+    public uint RentPeriodSeconds
+    {
+        get
+        {
+            if (string.IsNullOrEmpty(RentPeriod))
+            {
+                return 0;
+            }
+
+            return RentPeriod.ToLowerInvariant() switch
+            {
+                "daily" => 24 * 60 * 60,
+                "weekly" => 24 * 60 * 60 * 7,
+                "monthly" => 24 * 60 * 60 * 30,
+                "yearly" => 24 * 60 * 60 * 365,
+                _ => 0
+            };
+        }
+    }
+}

--- a/src/Core/NeoServer.Domain/Houses/Services/HouseService.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/HouseService.cs
@@ -88,9 +88,14 @@ public class HouseService(
         return true;
     }
 
-    /// <summary>Returns false when premium is required and the player lacks premium time.</summary>
+    /// <summary>Returns false when the player is null, or when premium is required and the player lacks premium time.</summary>
     public bool CanPlayerOwnHouse(IPlayer player)
     {
+        if (player is null)
+        {
+            return false;
+        }
+
         if (!houseConfiguration.RequirePremiumAccount)
             return true;
 

--- a/src/Core/NeoServer.Domain/Houses/Services/IHouseService.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/IHouseService.cs
@@ -18,6 +18,6 @@ public interface IHouseService
     /// <summary>Kick a player out of the house. Only subowners or higher can kick lower-level players.</summary>
     bool KickPlayer(House house, IPlayer caster, IPlayer target);
 
-    /// <summary>Returns false when premium is required and the player lacks premium time.</summary>
+    /// <summary>Returns false when the player is null, or when premium is required and the player lacks premium time.</summary>
     bool CanPlayerOwnHouse(IPlayer player);
 }

--- a/src/Database/NeoServer.Data.InMemory.DataStores/HouseStore.cs
+++ b/src/Database/NeoServer.Data.InMemory.DataStores/HouseStore.cs
@@ -20,4 +20,20 @@ public class HouseStore : DataStore<HouseStore, uint, House>, IHouseStore
     {
         return Get(houseId);
     }
+
+    public House GetByOwnerGuid(uint ownerGuid)
+    {
+        if (ownerGuid == 0)
+        {
+            return null;
+        }
+
+        foreach (var house in All)
+        {
+            if (house.OwnerGuid == ownerGuid)
+                return house;
+        }
+
+        return null;
+    }
 }

--- a/src/Database/NeoServer.Data/Repositories/Player/PlayerRepository.cs
+++ b/src/Database/NeoServer.Data/Repositories/Player/PlayerRepository.cs
@@ -56,7 +56,6 @@ public class PlayerRepository(DbContextOptions<NeoContext> contextOptions, ILogg
 
         foreach (var player in players)
         {
-            tasks.Clear();
             tasks.Add(SavePlayer(player));
         }
 
@@ -161,6 +160,7 @@ public class PlayerRepository(DbContextOptions<NeoContext> contextOptions, ILogg
         playerEntity.MagicLevel = player.GetRawSkillLevel(SkillType.Magic);
         playerEntity.MagicLevelTries = player.GetSkillTries(SkillType.Magic);
         playerEntity.Experience = player.Experience;
+        playerEntity.BankAmount = player.BankAmount;
         playerEntity.ChaseMode = player.ChaseMode;
         playerEntity.FightMode = player.FightMode;
         playerEntity.Vocation = player.VocationType;

--- a/src/Extensions/NeoServer.Scripts.LuaJIT/Functions/ConfigFunctions.cs
+++ b/src/Extensions/NeoServer.Scripts.LuaJIT/Functions/ConfigFunctions.cs
@@ -1,4 +1,5 @@
-﻿using LuaNET;
+using LuaNET;
+using NeoServer.Domain.Common;
 using NeoServer.Scripts.LuaJIT.Enums.Config;
 using NeoServer.Scripts.LuaJIT.Functions.Interfaces;
 using NeoServer.Scripts.LuaJIT.Interfaces;
@@ -11,15 +12,18 @@ public class ConfigFunctions : LuaScriptInterface, IConfigFunctions
     private static IConfigManager _configManager;
     private static ConfigurationMap _configurationMap;
     private static ServerConfiguration _serverConfiguration;
+    private static HouseConfiguration _houseConfiguration;
 
     public ConfigFunctions(
         IConfigManager configManager,
         ConfigurationMap configurationMap,
-        ServerConfiguration serverConfiguration) : base(nameof(ConfigFunctions))
+        ServerConfiguration serverConfiguration,
+        HouseConfiguration houseConfiguration) : base(nameof(ConfigFunctions))
     {
         _configManager = configManager;
         _configurationMap = configurationMap;
         _serverConfiguration = serverConfiguration;
+        _houseConfiguration = houseConfiguration ?? new HouseConfiguration();
     }
 
     public void Init(LuaState luaState)
@@ -35,6 +39,7 @@ public class ConfigFunctions : LuaScriptInterface, IConfigFunctions
         RegisterEnumIn<StringConfigType>(luaState, "configKeys");
         RegisterEnumIn<IntegerConfigType>(luaState, "configKeys");
         RegisterEnumIn<FloatingConfigType>(luaState, "configKeys");
+        RegisterVariable(luaState, "configKeys", "HOUSE_PRICE", IntegerConfigType.HOUSE_PRICE_PER_SQM);
 
         // foreach (var item in Enum.GetValues<BooleanConfigType>())
         //     RegisterVariable(luaState, "configKeys", item.ToString(), item);
@@ -68,7 +73,14 @@ public class ConfigFunctions : LuaScriptInterface, IConfigFunctions
     public static int LuaConfigManagerGetNumber(LuaState luaState)
     {
         // configManager:getNumber()
-        Lua.PushNumber(luaState, _configManager.GetNumber(GetNumber<IntegerConfigType>(luaState, -1)));
+        var key = GetNumber<IntegerConfigType>(luaState, -1);
+        if (key == IntegerConfigType.HOUSE_PRICE_PER_SQM)
+        {
+            Lua.PushNumber(luaState, _houseConfiguration.PricePerSqm);
+            return 1;
+        }
+
+        Lua.PushNumber(luaState, _configManager.GetNumber(key));
         return 1;
     }
 

--- a/src/Extensions/NeoServer.Scripts.LuaJIT/Functions/HouseFunctions.cs
+++ b/src/Extensions/NeoServer.Scripts.LuaJIT/Functions/HouseFunctions.cs
@@ -1,4 +1,5 @@
 using LuaNET;
+using NeoServer.Domain.Common;
 using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Common.Contracts.DataStores;
 using NeoServer.Domain.Houses;
@@ -8,19 +9,27 @@ using NeoServer.Scripts.LuaJIT.Functions.Interfaces;
 namespace NeoServer.Scripts.LuaJIT.Functions;
 
 /// <summary>
-///     Minimal House Lua bindings for Phase 3 spell slices (aleta sio, aleta som, alana sio, aleta grav).
+///     House Lua bindings for Phase 3 (access-list spells, kick, and !buyhouse).
 ///     Full HouseFunctions surface (tiles, beds, rent, trade, save) comes in later slices.
 /// </summary>
 public class HouseFunctions : LuaScriptInterface, IHouseFunctions
 {
     private static IHouseStore _houseStore;
     private static IHouseService _houseService;
+    private static ICreatureGameInstance _creatureGameInstance;
+    private static HouseConfiguration _houseConfiguration;
 
-    public HouseFunctions(IHouseStore houseStore, IHouseService houseService) :
+    public HouseFunctions(
+        IHouseStore houseStore,
+        IHouseService houseService,
+        ICreatureGameInstance creatureGameInstance,
+        HouseConfiguration houseConfiguration) :
         base(nameof(HouseFunctions))
     {
         _houseStore = houseStore;
         _houseService = houseService;
+        _creatureGameInstance = creatureGameInstance;
+        _houseConfiguration = houseConfiguration ?? new HouseConfiguration();
     }
 
     public void Init(LuaState luaState)
@@ -29,6 +38,9 @@ public class HouseFunctions : LuaScriptInterface, IHouseFunctions
         RegisterMetaMethod(luaState, "House", "__eq", LuaUserdataCompare<House>);
 
         RegisterMethod(luaState, "House", "getId", LuaHouseGetId);
+        RegisterMethod(luaState, "House", "getOwnerGuid", LuaHouseGetOwnerGuid);
+        RegisterMethod(luaState, "House", "setOwnerGuid", LuaHouseSetOwnerGuid);
+        RegisterMethod(luaState, "House", "getTileCount", LuaHouseGetTileCount);
         RegisterMethod(luaState, "House", "canEditAccessList", LuaHouseCanEditAccessList);
         RegisterMethod(luaState, "House", "getAccessList", LuaHouseGetAccessList);
         RegisterMethod(luaState, "House", "getDoorIdByPosition", LuaHouseGetDoorIdByPosition);
@@ -65,6 +77,60 @@ public class HouseFunctions : LuaScriptInterface, IHouseFunctions
         }
 
         Lua.PushNumber(luaState, house.Id);
+        return 1;
+    }
+
+    private static int LuaHouseGetOwnerGuid(LuaState luaState)
+    {
+        // house:getOwnerGuid()
+        var house = GetUserdata<House>(luaState, 1);
+        if (house is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        Lua.PushNumber(luaState, house.OwnerGuid);
+        return 1;
+    }
+
+    private static int LuaHouseSetOwnerGuid(LuaState luaState)
+    {
+        // house:setOwnerGuid(guid[, updateDatabase = true])
+        var house = GetUserdata<House>(luaState, 1);
+        if (house is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        var guid = GetNumber<uint>(luaState, 2);
+        var name = string.Empty;
+        var accountId = 0;
+        if (guid != 0 && _creatureGameInstance.TryGetPlayer(guid, out var player) && player is not null)
+        {
+            name = player.Name;
+            accountId = (int)player.AccountId;
+        }
+
+        var rentPeriodSeconds = _houseConfiguration.RentPeriodSeconds;
+        var updatePaidUntil = rentPeriodSeconds != 0;
+        _houseService.SetOwner(house, guid, name, accountId, updatePaidUntil, DateTime.UtcNow, rentPeriodSeconds);
+        PushBoolean(luaState, true);
+        return 1;
+    }
+
+    private static int LuaHouseGetTileCount(LuaState luaState)
+    {
+        // house:getTileCount()
+        var house = GetUserdata<House>(luaState, 1);
+        if (house is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        Lua.PushNumber(luaState, house.TileCount);
         return 1;
     }
 

--- a/src/Extensions/NeoServer.Scripts.LuaJIT/Functions/PlayerFunctions.cs
+++ b/src/Extensions/NeoServer.Scripts.LuaJIT/Functions/PlayerFunctions.cs
@@ -1,8 +1,9 @@
-﻿using LuaNET;
+using LuaNET;
 using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Common.Contracts.DataStores;
 using NeoServer.Domain.Common.Contracts.Items;
 using NeoServer.Domain.Common.Contracts.Items.Types;
+using NeoServer.Domain.Common.Contracts.Services;
 using NeoServer.Domain.Common.Creatures;
 using NeoServer.Domain.Common.Item;
 using NeoServer.Domain.Common.Location.Structs;
@@ -10,6 +11,7 @@ using NeoServer.Domain.Creatures.Player;
 using NeoServer.Domain.Creatures.Player.Inventory;
 using NeoServer.Domain.Guild;
 using NeoServer.Domain.Houses;
+using NeoServer.Domain.Houses.Services;
 using NeoServer.Networking.Packets.Outgoing;
 using NeoServer.Networking.Packets.Outgoing.Window;
 using NeoServer.Scripts.LuaJIT.Enums;
@@ -26,6 +28,10 @@ public class PlayerFunctions : LuaScriptInterface, IPlayerFunctions
     private static IItemFactory _itemFactory;
     private static IItemTypeStore _itemTypeStore;
     private static IHouseEditWindowStore _houseEditWindowStore;
+    private static IHouseStore _houseStore;
+    private static IHouseService _houseService;
+    private static ICoinTransaction _coinTransaction;
+    private static ICoinTypeStore _coinTypeStore;
     private static ILogger _logger;
 
     public PlayerFunctions(
@@ -33,12 +39,20 @@ public class PlayerFunctions : LuaScriptInterface, IPlayerFunctions
         IItemFactory itemFactory,
         IItemTypeStore itemTypeStore,
         IHouseEditWindowStore houseEditWindowStore,
+        IHouseStore houseStore,
+        IHouseService houseService,
+        ICoinTransaction coinTransaction,
+        ICoinTypeStore coinTypeStore,
         ILogger logger) : base(nameof(PlayerFunctions))
     {
         _gameCreatureManager = gameCreatureManager;
         _itemFactory = itemFactory;
         _itemTypeStore = itemTypeStore;
         _houseEditWindowStore = houseEditWindowStore;
+        _houseStore = houseStore;
+        _houseService = houseService;
+        _coinTransaction = coinTransaction;
+        _coinTypeStore = coinTypeStore;
         _logger = logger;
     }
 
@@ -78,6 +92,14 @@ public class PlayerFunctions : LuaScriptInterface, IPlayerFunctions
         RegisterMethod(luaState, "Player", "showTextDialog", LuaPlayerShowTextDialog);
         RegisterMethod(luaState, "Player", "setEditHouse", LuaPlayerSetEditHouse);
         RegisterMethod(luaState, "Player", "sendHouseWindow", LuaPlayerSendHouseWindow);
+        RegisterMethod(luaState, "Player", "getGuid", LuaPlayerGetGuid);
+        RegisterMethod(luaState, "Player", "getHouse", LuaPlayerGetHouse);
+        RegisterMethod(luaState, "Player", "isPremium", LuaPlayerIsPremium);
+        RegisterMethod(luaState, "Player", "canOwnHouse", LuaPlayerCanOwnHouse);
+        RegisterMethod(luaState, "Player", "getMoney", LuaPlayerGetMoney);
+        RegisterMethod(luaState, "Player", "removeMoney", LuaPlayerRemoveMoney);
+        RegisterMethod(luaState, "Player", "getBankBalance", LuaPlayerGetBankBalance);
+        RegisterMethod(luaState, "Player", "setBankBalance", LuaPlayerSetBankBalance);
 
         RegisterMethod(luaState, "Player", "addItem", LuaPlayerAddItem);
         RegisterMethod(luaState, "Player", "removeItem", LuaPlayerRemoveItem);
@@ -587,6 +609,136 @@ public class PlayerFunctions : LuaScriptInterface, IPlayerFunctions
 
         connection.OutgoingPackets.Enqueue(new HouseWindowPacket(windowTextId, text));
         connection.Send();
+
+        PushBoolean(luaState, true);
+        return 1;
+    }
+
+    private static int LuaPlayerGetGuid(LuaState luaState)
+    {
+        // player:getGuid()
+        var player = GetUserdata<IPlayer>(luaState, 1);
+        if (player is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        Lua.PushNumber(luaState, player.Id);
+        return 1;
+    }
+
+    private static int LuaPlayerGetHouse(LuaState luaState)
+    {
+        // player:getHouse()
+        var player = GetUserdata<IPlayer>(luaState, 1);
+        if (player is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        var house = _houseStore.GetByOwnerGuid(player.Id);
+        if (house is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        PushUserdata(luaState, house);
+        SetMetatable(luaState, -1, "House");
+        return 1;
+    }
+
+    private static int LuaPlayerIsPremium(LuaState luaState)
+    {
+        // player:isPremium()
+        var player = GetUserdata<IPlayer>(luaState, 1);
+        if (player is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        PushBoolean(luaState, player.HasPremiumTime);
+        return 1;
+    }
+
+    private static int LuaPlayerCanOwnHouse(LuaState luaState)
+    {
+        // player:canOwnHouse()
+        var player = GetUserdata<IPlayer>(luaState, 1);
+        PushBoolean(luaState, _houseService.CanPlayerOwnHouse(player));
+        return 1;
+    }
+
+    private static int LuaPlayerGetMoney(LuaState luaState)
+    {
+        // player:getMoney()
+        var player = GetUserdata<IPlayer>(luaState, 1);
+        if (player is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        var money = player.Inventory?.GetTotalMoney(_coinTypeStore) ?? 0;
+        Lua.PushNumber(luaState, money);
+        return 1;
+    }
+
+    private static int LuaPlayerRemoveMoney(LuaState luaState)
+    {
+        // player:removeMoney(money)
+        var player = GetUserdata<IPlayer>(luaState, 1);
+        if (player is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        var amount = GetNumber<ulong>(luaState, 2);
+        PushBoolean(luaState, _coinTransaction.RemoveCoins(player, amount, useBank: false));
+        return 1;
+    }
+
+    private static int LuaPlayerGetBankBalance(LuaState luaState)
+    {
+        // player:getBankBalance()
+        var player = GetUserdata<IPlayer>(luaState, 1);
+        if (player is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        Lua.PushNumber(luaState, player.BankAmount);
+        return 1;
+    }
+
+    private static int LuaPlayerSetBankBalance(LuaState luaState)
+    {
+        // player:setBankBalance(amount)
+        var player = GetUserdata<IPlayer>(luaState, 1);
+        if (player?.Bank is null)
+        {
+            PushBoolean(luaState, false);
+            return 1;
+        }
+
+        var amount = GetNumber<ulong>(luaState, 2);
+        var current = player.BankAmount;
+        if (amount > current)
+        {
+            player.Bank.Credit(amount - current);
+            PushBoolean(luaState, true);
+            return 1;
+        }
+
+        if (amount < current)
+        {
+            player.Bank.Debit(current - amount);
+        }
 
         PushBoolean(luaState, true);
         return 1;

--- a/src/Standalone/IoC/Modules/ConfigurationInjection.cs
+++ b/src/Standalone/IoC/Modules/ConfigurationInjection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -49,7 +49,7 @@ public static class ConfigurationInjection
         builder.AddSingleton(gameConfiguration.PvP);
         builder.AddSingleton(gameConfiguration.Combat);
         builder.AddSingleton(gameConfiguration.Yell);
-        builder.AddSingleton(gameConfiguration.House);
+        builder.AddSingleton(gameConfiguration.House ?? new HouseConfiguration());
 
         builder.AddSingleton<IConfiguration>(configuration);
 

--- a/src/Standalone/appsettings.json
+++ b/src/Standalone/appsettings.json
@@ -79,7 +79,9 @@
       "requirePremiumForSubOwners": true,
       "maxAccessListLength": 1999,
       "maxAccessListLines": 100,
-      "maxSubOwnerCount": 10
+      "maxSubOwnerCount": 10,
+      "pricePerSqm": 1000,
+      "rentPeriod": "monthly"
     }
   },
   "client": {

--- a/tests/NeoServer.Domain.Tests/Houses/HouseServiceTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseServiceTests.cs
@@ -248,6 +248,76 @@ public class HouseServiceTests
         repoMock.Verify(x => x.Save(It.IsAny<House>()), Times.Never);
     }
 
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CanPlayerOwnHouse_WhenRequirePremiumIsFalse_ReturnsTrueForNonPremiumPlayer()
+    {
+        var service = CreateService(houseConfiguration: new HouseConfiguration(RequirePremiumAccount: false));
+        var player = HouseTestDataBuilder.CreatePlayer(hasPremiumTime: false);
+
+        service.CanPlayerOwnHouse(player).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CanPlayerOwnHouse_WhenRequirePremiumIsFalse_ReturnsTrueForPremiumPlayer()
+    {
+        var service = CreateService(houseConfiguration: new HouseConfiguration(RequirePremiumAccount: false));
+        var player = HouseTestDataBuilder.CreatePlayer(hasPremiumTime: true);
+
+        service.CanPlayerOwnHouse(player).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void CanPlayerOwnHouse_WhenRequirePremiumIsTrue_ReturnsFalseForNonPremiumPlayer()
+    {
+        var service = CreateService(houseConfiguration: new HouseConfiguration(RequirePremiumAccount: true));
+        var player = HouseTestDataBuilder.CreatePlayer(hasPremiumTime: false);
+
+        service.CanPlayerOwnHouse(player).Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CanPlayerOwnHouse_WhenRequirePremiumIsTrue_ReturnsTrueForPremiumPlayer()
+    {
+        var service = CreateService(houseConfiguration: new HouseConfiguration(RequirePremiumAccount: true));
+        var player = HouseTestDataBuilder.CreatePlayer(hasPremiumTime: true);
+
+        service.CanPlayerOwnHouse(player).Should().BeTrue();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void CanPlayerOwnHouse_WhenRequirePremiumIsTrue_ReturnsFalseForNullPlayer()
+    {
+        var service = CreateService(houseConfiguration: new HouseConfiguration(RequirePremiumAccount: true));
+
+        service.CanPlayerOwnHouse(null).Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void CanPlayerOwnHouse_WhenRequirePremiumIsFalse_ReturnsFalseForNullPlayer()
+    {
+        var service = CreateService(houseConfiguration: new HouseConfiguration(RequirePremiumAccount: false));
+
+        service.CanPlayerOwnHouse(null).Should().BeFalse();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void CanPlayerOwnHouse_DefaultConfig_RequiresPremium()
+    {
+        var service = CreateService();
+        var freePlayer = HouseTestDataBuilder.CreatePlayer(hasPremiumTime: false);
+        var premiumPlayer = HouseTestDataBuilder.CreatePlayer(hasPremiumTime: true);
+
+        service.CanPlayerOwnHouse(freePlayer).Should().BeFalse();
+        service.CanPlayerOwnHouse(premiumPlayer).Should().BeTrue();
+    }
+
     private static HouseService CreateService(
         Mock<IHouseRepository> repo = null,
         Mock<IHouseEviction> eviction = null,

--- a/tests/NeoServer.Domain.Tests/Houses/HouseStoreTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseStoreTests.cs
@@ -46,4 +46,37 @@ public class HouseStoreTests
 
         store.GetByTile(tileMock.Object).Should().BeNull();
     }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void GetByOwnerGuid_returns_house_when_owner_matches()
+    {
+        var house = HouseTestDataBuilder.Build(id: 5, ownerGuid: 42);
+        var store = new HouseStore();
+        store.AddOrUpdate(5, house);
+
+        store.GetByOwnerGuid(42).Should().BeSameAs(house);
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void GetByOwnerGuid_returns_null_when_owner_is_unknown()
+    {
+        var house = HouseTestDataBuilder.Build(id: 5, ownerGuid: 42);
+        var store = new HouseStore();
+        store.AddOrUpdate(5, house);
+
+        store.GetByOwnerGuid(99).Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void GetByOwnerGuid_returns_null_when_owner_guid_is_zero()
+    {
+        var house = HouseTestDataBuilder.Build(id: 5, ownerGuid: 0);
+        var store = new HouseStore();
+        store.AddOrUpdate(5, house);
+
+        store.GetByOwnerGuid(0).Should().BeNull();
+    }
 }


### PR DESCRIPTION
### Description
Players can buy a house by facing its door and saying `!buyhouse`. Bank gold spent on the purchase is written during the regular player save, not on every debit.

### Key Changes
- Add `!buyhouse` talkaction with level, premium, ownership, and funds checks; payment uses inventory gold first, then bank
- Expose house/player Lua bindings needed to buy (owner guid, tile count, money/bank, `canOwnHouse`)
- Add configurable house price per sqm and rent period (`HOUSE_PRICE` / `pricePerSqm`)
- Persist bank balance on player save and save every logged-in player in the batch (previously only the last player was saved)

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
`dotnet test tests/NeoServer.Domain.Tests --filter FullyQualifiedName~House` (140 passed)
In-game: face a house door, `!buyhouse`, confirm ownership and that bank/inventory gold is deducted after save/logout.