### PR TITLE
feat(house): let players sell houses with !sellhouse

### DIFF
--- a/data/scripts/talkactions/house/sellhouse.lua
+++ b/data/scripts/talkactions/house/sellhouse.lua
@@ -1,0 +1,29 @@
+---@type TalkAction
+local talkAction = TalkAction("!sellhouse")
+
+---@param player Player
+---@param words string
+---@param param string
+function talkAction.onSay(player, words, param)
+    local tradePartner = Player(param)
+    if not tradePartner or tradePartner == player then
+        player:sendCancelMessage("Trade player not found.")
+        return true
+    end
+
+    local tile = player:getTile()
+    local house = tile and tile:getHouse() or nil
+    if not house then
+        player:sendCancelMessage("You must stand in your house to initiate the trade.")
+        return true
+    end
+
+    local returnValue = house:startTrade(player, tradePartner)
+    if returnValue ~= RETURNVALUE_NOERROR then
+        player:sendCancelMessage(returnValue)
+    end
+    return true
+end
+
+talkAction:separator(" ")
+talkAction:register()

--- a/docs/house-system/house-phase3-steps.md
+++ b/docs/house-system/house-phase3-steps.md
@@ -156,8 +156,37 @@ Reference behavior: TFS `buyhouse.lua` (words `!buyhouse`). Player must face the
 
 ---
 
+## Slice 5 — `!sellhouse` (House Sale via Trade) — DONE
+
+Full plan: [`house-sellhouse-steps.md`](house-sellhouse-steps.md).
+
+Reference behavior: TFS `sellhouse.lua` + `house:startTrade` (phantom `ITEM_DOCUMENT_RO` in the safe-trade window). Completing the trade calls `SetOwner(buyer)` with `paidUntil` preserved.
+
+### What shipped
+
+1. **Domain** — `House` pending-transfer pointer (`TryAttachTransfer` / `ResetTransfer` / `ExecuteTransfer`). `SetNewOwner` always zeroes `PayRentWarnings` on a real owner change and only refreshes `PaidUntil` when `updatePaidUntil` is true.
+2. **`HouseTransferItem`** — item 1968, not on the map; look text `It is a house transfer document for '{name}'`.
+3. **`HouseTradeService.StartTrade`** — TFS check order (range 2/2/0, owner, partner already owns a house, pending transfer). No premium/sight/auction checks.
+4. **SafeTrade** — skip sight/next-to for the document; on accept move only the buyer’s offer and `SetOwner(buyer, updatePaidUntil: false)`; on cancel drop the pending pointer.
+5. **Lua** — `house:startTrade(player, partner)` and `data/scripts/talkactions/house/sellhouse.lua` (`!sellhouse`, always `return true`).
+
+### In-game smoke checklist
+
+- [ ] Owner inside house, partner online within 2 sqm same floor: `!sellhouse Name` opens trade showing a document
+- [ ] Partner offers gold, both accept → partner owns the house; gold is in the seller’s inventory; document is gone; lists empty; `PaidUntil` unchanged
+- [ ] `!sellhouse` with no name / unknown / self → “Trade player not found.”
+- [ ] Not standing in a house → “You must stand in your house to initiate the trade.”
+- [ ] Subowner inside the house → “You don't own this house.”
+- [ ] Partner already owns a house → “Trade player already owns a house.”
+- [ ] Partner 3 sqm away or different floor → “Trade player is too far away.”
+- [ ] Second `!sellhouse` while the first window is open → “You can not trade this house.”
+- [ ] Cancel or walk > 2 sqm from partner → trade closes, owner unchanged
+- [ ] Command text is not shown in public chat
+
+---
+
 ## Later slices (not started)
 
-- [ ] Talkactions: `leavehouse` / `sellhouse`
+- [ ] Talkaction: `leavehouse`
 - [ ] Full `HouseFunctions` surface (tiles, doors, beds, rent, trade, save)
 - [ ] Rent warning letters

--- a/docs/house-system/house-sellhouse-steps.md
+++ b/docs/house-system/house-sellhouse-steps.md
@@ -1,0 +1,358 @@
+# House System — `!sellhouse` Talkaction
+
+Companion to `house-phase3-steps.md`. Ports TFS `data/talkactions/scripts/sellhouse.lua` +
+`House::startTrade` / `HouseTransferItem` onto OpenCoreMMO.
+
+This is **not** CipSoft’s website house transfer (domain.md UC-08..UC-10: scheduled date,
+bank debit, items stay). TFS `!sellhouse` is an in-game **safe-trade of a phantom transfer
+document**. Completing the trade calls `setOwner(buyer)` immediately.
+
+---
+
+## TFS behavior (source of truth)
+
+### Talkaction (`sellhouse.lua`)
+
+Words: `!sellhouse` with `separator=" "`. Always swallows speech.
+
+1. Resolve `Player(param)`. Missing, offline, or self → `"Trade player not found."`
+2. House from **seller’s current tile** (`player:getTile():getHouse()`). Not inside a house →
+   `"You must stand in your house to initiate the trade."`
+3. `house:startTrade(player, tradePartner)`. If not `RETURNVALUE_NOERROR`, send that cancel.
+
+Standing in the house is only required to **start**. Walking out after the window opens does
+not cancel by itself (distance to partner still can).
+
+### `house:startTrade` (`luahouse.cpp`)
+
+Checked **in this order**, each returns a `RETURNVALUE_*` (Lua cancel uses `Game.getReturnMessage`):
+
+| Check | Return | Message |
+|---|---|---|
+| Partner not in range (Chebyshev ≤ 2, **same floor**) | `TRADEPLAYERFARAWAY` | Trade player is too far away. |
+| `house.owner != seller.guid` | `YOUDONTOWNTHISHOUSE` | You don't own this house. |
+| Partner already owns a house | `TRADEPLAYERALREADYOWNSAHOUSE` | Trade player already owns a house. |
+| Partner is highest bidder on an auctioned house | `TRADEPLAYERHIGHESTBIDDER` | Trade player is currently the highest bidder of an auctioned house. |
+| Transfer already pending (`getTransferItem()` null) | `YOUCANNOTTRADETHISHOUSE` | You can not trade this house. |
+| `internalStartTrade` fails (already trading, …) | still `NOERROR` | Trade layer already sent its own cancel; transfer item is reset. |
+
+TFS does **not** check premium, level, or sight for `!sellhouse`. Do not add
+`canOwnHouse` here (that gate is for `!buyhouse`). Auction bidding is out of scope —
+treat “highest bidder” as always false until auctions exist.
+
+### Transfer document
+
+- Created as `ITEM_DOCUMENT_RO` (1968) with special description
+  `It is a house transfer document for '{houseName}'.`
+- Lives in a dummy locker, **not** on the map or in inventory. Parent is forced to the seller
+  so the trade window accepts it.
+- Only one pending transfer per house. Second `!sellhouse` while the window is open →
+  `YOUCANNOTTRADETHISHOUSE`.
+- Client trade UX is the normal 0x7D/0x7E window. Buyer must counter-offer an item (gold,
+  etc.). That item **is** the payment; the server never prices the house.
+
+### On accept (`HouseTransferItem::onTradeEvent(ON_TRADE_TRANSFER)`)
+
+1. `House::executeTransfer` → `setOwner(buyerGuid)` then drop the transfer pointer.
+2. Document is destroyed (never remains in the buyer’s backpack).
+3. TFS `setOwner` when the house already has an owner:
+   - Pickupables → old owner depot
+   - Occupants kicked to exit
+   - Beds woken
+   - Guest / subowner / door lists cleared
+   - **`paidUntil` kept** (buyer inherits remaining rent)
+   - **`rentWarnings` reset to 0**
+   - New owner assigned
+
+### On cancel (`ON_TRADE_CANCEL`)
+
+`resetTransferItem()`: destroy the phantom document, clear the pending pointer. Ownership
+unchanged.
+
+---
+
+## OpenCoreMMO alignment notes
+
+- Talkaction `return true` swallows chat (opposite of TFS booleans). Same as `!buyhouse`.
+- Reuse `HouseService.SetOwner` for accept side-effects (evict / wake / depot / persist /
+  `HouseOwnerChangedEvent`). Call it with **`updatePaidUntil: false`**.
+- `SetNewOwner` today only zeroes `PayRentWarnings` when `updatePaidUntil` is true. TFS
+  always zeroes warnings on a real owner change. Fix that in this slice (see Step 1).
+- `ITradeService` currently only exposes `Cancel`. `SafeTradeSystem.Request` already exists
+  and is what `TradeRequestCommand` uses.
+- `TradeRequestValidation` rejects items that are not next to the player, not owned by the
+  seller, or without line of sight. The phantom document fails those checks unless the
+  trade path special-cases `IHouseTransferItem`.
+- `TradeItemExchanger` always `Remove` + `AddItem` both sides. Putting the document on the
+  seller’s **ground** location would make `ItemRemoveService` try to pull it off the tile
+  the seller is standing on. Never place the document on the map.
+
+---
+
+## Design
+
+Keep Lua as thin as TFS. All rules live in C#.
+
+```
+!sellhouse Name
+  → sellhouse.lua
+  → house:startTrade(seller, partner)
+  → HouseTradeService.StartTrade
+       validates (range / owner / partner house / pending)
+       creates HouseTransferItem (id 1968, not on map)
+       house.PendingTransfer = item
+       SafeTradeSystem.Request(seller, partner, item)
+       on Request failure → ResetTransfer, still NoError
+  → trade window
+
+both accept
+  → TradeItemExchanger
+       skip physical move of IHouseTransferItem
+       move partner’s offered item as usual
+       item.Complete(buyer) → HouseService.SetOwner(..., updatePaidUntil: false)
+
+cancel / logout / walk too far
+  → SafeTradeSystem.Cancel
+       item.Cancel() → house.PendingTransfer = null
+```
+
+`HouseTradeService` (new) owns trade orchestration so `HouseService` does not take a
+trade/item-factory dependency. `House` only holds the pending-transfer pointer
+(same role as TFS `transferItem`).
+
+---
+
+## Implementation steps
+
+### 1. Domain — pending transfer + warning reset
+
+**`House`**
+
+- `IHouseTransferItem PendingTransfer { get; private set; }`
+- `bool TryAttachTransfer(IHouseTransferItem item)` — false if one is already attached
+  (TFS `getTransferItem()` returning null).
+- `void ResetTransfer()` — clear pointer only (item teardown is the service’s job).
+- `bool ExecuteTransfer(IHouseTransferItem item, uint newOwnerGuid)` — true only when
+  `item` is the attached pending item; then clear the pointer. Ownership change stays in
+  `HouseService.SetOwner`.
+
+**`SetNewOwner`**
+
+When the owner actually changes (`guid != OwnerGuid`), always `PayRentWarnings = 0`.
+Still only refresh `PaidUntil` when `updatePaidUntil && guid != 0`.
+
+### 2. Domain — `IHouseTransferItem` + `HouseTransferItem`
+
+New types under `src/Core/NeoServer.Domain/Houses/`:
+
+```csharp
+public interface IHouseTransferItem : IItem
+{
+    House House { get; }
+    void Complete(IPlayer newOwner);
+    void Cancel();
+}
+```
+
+`HouseTransferItem` subclasses `Paper` (item 1968 is paper). Constructed by
+`HouseTradeService` with `IItemTypeStore` (do **not** route through `ItemFactory` — that
+would yield a plain `Paper` with no house link).
+
+- `SetOwner(seller)` so `TradeRequestValidation.PlayerCannotTradeItem` passes.
+- Location type **Container or Slot**, never Ground (so `ItemRemoveService` / `IsNextTo`
+  do not treat it as a floor item). Container/Slot makes `Location.IsNextTo` return true.
+- `Attributes.Description` =
+  `It is a house transfer document for '{house.Name}'.`
+- Override `GetLookText` to append that sentence. `InspectionTextBuilder` only reads
+  `Metadata.Description`, so an override is required for look-in-trade / OTCv8 tooltips.
+- `Complete` / `Cancel` are delegates set by `HouseTradeService` at creation (item must
+  not depend on `HouseService` or `ITradeService`).
+
+### 3. Domain — `HouseTradeService`
+
+`Houses/Services/IHouseTradeService.cs` + `HouseTradeService.cs`.
+
+Inject: `IHouseService`, `IHouseStore`, `SafeTradeSystem` (or extend `ITradeService` with
+`Request` — prefer extending the interface so Lua/DI stay on contracts), `IItemTypeStore`,
+`HouseConfiguration`.
+
+`StartTrade(House house, IPlayer seller, IPlayer partner) → HouseTradeResult`
+
+1. Null / same player → Lua already handled; still guard in C#.
+2. `seller.Location.Z != partner.Location.Z` **or** Chebyshev distance > 2 → `TradePlayerFarAway`.
+   (`GetMaxSqmDistance` ignores Z; TFS `isInRange(..., 2, 2, 0)` does not.)
+3. `house.OwnerGuid != seller.Id` → `YouDontOwnThisHouse`.
+4. `houseStore.GetByOwnerGuid(partner.Id) is not null` → `TradePlayerAlreadyOwnsAHouse`.
+5. Auction stub: skip (always pass).
+6. Create `HouseTransferItem` (type 1968). `TryAttachTransfer` false → `YouCannotTradeThisHouse`.
+7. `tradeService.Request(seller, partner, item)`.
+   - Failure → `ResetTransfer()`, return `NoError` (TFS: trade already cancelled the player).
+   - Success → `NoError`.
+
+`CompleteTransfer(House house, IHouseTransferItem item, IPlayer buyer)`
+
+- `house.ExecuteTransfer(item, buyer.Id)` must succeed (stale item → no-op).
+- `houseService.SetOwner(house, buyer.Id, buyer.Name, (int)buyer.AccountId,
+  updatePaidUntil: false, DateTime.UtcNow, rentPeriodSeconds)`.
+
+`CancelTransfer(House house)` → `house.ResetTransfer()`.
+
+`HouseTradeResult` lives in Domain (do not leak Lua `ReturnValueType`):
+
+`NoError`, `TradePlayerFarAway`, `YouDontOwnThisHouse`, `TradePlayerAlreadyOwnsAHouse`,
+`TradePlayerHighestBidder`, `YouCannotTradeThisHouse`.
+
+Register in `ServiceInjection.cs`.
+
+### 4. SafeTrade hooks
+
+**`ITradeService`** — add `SafeTradeError Request(IPlayer player, IPlayer secondPlayer, IItem item)`
+so `HouseTradeService` does not depend on the concrete `SafeTradeSystem` if that stays
+practical. `TradeRequestCommand` can switch to the interface too (optional cleanup).
+
+**`TradeRequestValidation`** — when `items[0] is IHouseTransferItem`:
+
+- Skip `HasNoSightClearToPlayer` (TFS `startTrade` has no sight check).
+- Skip `PlayerIsNotNextToItem` (document is not on the map). Keep the **player–player**
+  range check as a backstop; `StartTrade` already enforced TFS 2/2/0.
+
+**`TradeItemExchanger.Exchange`**
+
+- Identify which of the two root items is `IHouseTransferItem` (normally the seller’s).
+- Physically exchange only the **other** item (buyer’s gold/item → seller).
+- Do **not** `Remove`/`AddItem` the transfer document.
+- Skip capacity/room checks **for adding the document to the buyer** (it is never added).
+  Still validate the seller can receive the buyer’s offer.
+- On success call `transferItem.Complete(buyer)` where buyer is the player who did **not**
+  offer the document.
+- If both sides somehow offered a transfer item, fail the trade (should be impossible).
+
+**`SafeTradeSystem.Close` / `Cancel`**
+
+Before untracking items, if any traded item is `IHouseTransferItem`, call `Cancel()`.
+Must run on every close path (reject, logout, walk > 2 sqm from partner, item deleted).
+
+Do not subscribe the phantom document to `OnDeleted`/`OnRemoved` in a way that
+recursively cancels during `Complete` (Complete already detaches first).
+
+### 5. Lua
+
+**`HouseFunctions.LuaHouseStartTrade`**
+
+```
+house:startTrade(player, tradePartner) → RETURNVALUE_*
+```
+
+Map `HouseTradeResult` → `ReturnValueType` integers already registered
+(`TRADEPLAYERFARAWAY` … `YOUCANNOTTRADETHISHOUSE`). `ReturnMessageExtensions` already has
+the TFS strings.
+
+Push `nil` when house/player/partner userdata is missing (TFS).
+
+**`data/scripts/talkactions/house/sellhouse.lua`**
+
+Port TFS script; OpenCoreMMO talkaction conventions:
+
+- `TalkAction("!sellhouse")` + `separator(" ")`
+- `Player(param)` for online lookup (existing `LuaPlayerCreate`)
+- `player:getTile()` / `tile:getHouse()` (already bound)
+- `sendCancelMessage` string or `RETURNVALUE_*` (existing `player.lua` helper)
+- **Always `return true`** so the command is not spoken
+
+### 6. Docs tracker
+
+In `house-phase3-steps.md`, mark Slice 5 `!sellhouse` as the next talkaction slice and
+leave `!leavehouse` in later slices.
+
+---
+
+## Tests
+
+Follow `.agents/skills/unit-testing/SKILL.md`: xUnit, FluentAssertions, real domain objects,
+mock only `I*Repository`. Helpers: `HouseTestDataBuilder`, `PlayerTestDataBuilder`,
+`MapTestDataBuilder`, `ItemTestDataBuilder`.
+
+### `SetNewOwner` / `HouseService`
+
+- Owner A → owner B with `updatePaidUntil: false` → `PaidUntil` unchanged, `PayRentWarnings == 0`,
+  access lists cleared, `SetOwner` still evicts / wakes / depots (existing tests cover seams).
+
+### `House` pending transfer
+
+- `TryAttachTransfer` succeeds once; second attach fails until `ResetTransfer` / `ExecuteTransfer`.
+- `ExecuteTransfer` with a different item returns false and does not clear a live pending item.
+
+### `HouseTradeService` (Category `Validation` / `HappyPath`)
+
+Use two players on a small map (same pattern as `SafeTrade` tests).
+
+| Case | Expected |
+|---|---|
+| Partner > 2 sqm or different floor | `TradePlayerFarAway`, no trade window, no pending item |
+| Seller is not owner (guest / subowner / stranger) | `YouDontOwnThisHouse` |
+| Partner already owns any house | `TradePlayerAlreadyOwnsAHouse` |
+| Happy path start | `NoError`, `PendingTransfer` set, both players in `TradeRequestTracker` |
+| Start while pending | `YouCannotTradeThisHouse` |
+| Seller already in another trade | `NoError`, pending cleared, existing SafeTrade cancel message |
+
+### SafeTrade + house document (`TradeCompletionTests` / new `HouseTradeTests`)
+
+| Case | Expected |
+|---|---|
+| Both accept (seller document + buyer item) | Buyer is owner; seller’s item is the buyer’s offer; document not in either inventory; `PendingTransfer` null |
+| Cancel / walk away | Owner unchanged; `PendingTransfer` null |
+| Look text | Contains `house transfer document for '{Name}'` |
+
+Do not mock `HouseService` or `SafeTradeSystem`. Mock `IHouseRepository` only.
+
+---
+
+## In-game smoke checklist
+
+- [ ] Owner inside house, partner online within 2 sqm same floor: `!sellhouse Name` opens trade
+      showing a document on both clients; partner also sees “{Owner} wants to trade with you.”
+- [ ] Partner offers gold, both accept → partner owns the house; gold is in the seller’s inventory;
+      document is gone; guest/subowner/door lists empty; remaining rent (`PaidUntil`) unchanged
+- [ ] Pickupables from the house appear in the **old** owner depot (config flag on)
+- [ ] Occupants who are not the new owner are at the house exit
+- [ ] `!sellhouse` with no name / unknown / self → “Trade player not found.”
+- [ ] Cast from street / neighbor house → “You must stand in your house to initiate the trade.”
+- [ ] Subowner inside the house → “You don't own this house.”
+- [ ] Partner already owns a house → “Trade player already owns a house.”
+- [ ] Partner 3 sqm away or different floor → “Trade player is too far away.”
+- [ ] Second `!sellhouse` while the first window is open → “You can not trade this house.”
+- [ ] Cancel or walk > 2 sqm from partner → trade closes, owner unchanged, a later `!sellhouse` works
+- [ ] Command text is not shown in public chat
+
+---
+
+## Out of scope
+
+- `!leavehouse`
+- Auctions / `TRADEPLAYERHIGHESTBIDDER` (always allow)
+- Premium check on the buyer
+- CipSoft scheduled website transfer (UC-08..UC-10)
+- Pricing the house server-side (payment is whatever the buyer puts in the trade)
+- Full `HouseFunctions` surface (tiles, beds, rent getters, `save`)
+
+---
+
+## Suggested file list
+
+| File | Change |
+|---|---|
+| `src/Core/NeoServer.Domain/Houses/House.cs` | Pending transfer + warning reset on owner change |
+| `src/Core/NeoServer.Domain/Houses/IHouseTransferItem.cs` | New |
+| `src/Core/NeoServer.Domain/Houses/HouseTransferItem.cs` | New |
+| `src/Core/NeoServer.Domain/Houses/HouseTradeResult.cs` | New |
+| `src/Core/NeoServer.Domain/Houses/Services/IHouseTradeService.cs` | New |
+| `src/Core/NeoServer.Domain/Houses/Services/HouseTradeService.cs` | New |
+| `src/Core/NeoServer.Domain/Common/Contracts/Services/ITradeService.cs` | Add `Request` |
+| `src/Core/NeoServer.Domain/SafeTrade/Validations/TradeRequestValidation.cs` | Skip sight / next-to for transfer item |
+| `src/Core/NeoServer.Domain/SafeTrade/Operations/TradeItemExchanger.cs` | Token exchange + `Complete` |
+| `src/Core/NeoServer.Domain/SafeTrade/SafeTradeSystem.cs` | `Cancel` → `IHouseTransferItem.Cancel` |
+| `src/Standalone/IoC/Modules/ServiceInjection.cs` | Register `IHouseTradeService` |
+| `src/Extensions/NeoServer.Scripts.LuaJIT/Functions/HouseFunctions.cs` | `startTrade` |
+| `data/scripts/talkactions/house/sellhouse.lua` | New |
+| `tests/NeoServer.Domain.Tests/Houses/` | New trade tests + `SetNewOwner` warning case |
+| `docs/house-system/house-phase3-steps.md` | Slice 5 tracker |

--- a/src/ApplicationServer/NeoServer.Server.Events/Player/Trade/TradeRequestedEventHandler.cs
+++ b/src/ApplicationServer/NeoServer.Server.Events/Player/Trade/TradeRequestedEventHandler.cs
@@ -1,5 +1,4 @@
 ﻿using NeoServer.Domain.Common.Helpers;
-using NeoServer.Domain.SafeTrade;
 using NeoServer.Domain.SafeTrade.Request;
 using NeoServer.Networking.Packets.Outgoing;
 using NeoServer.Networking.Packets.Outgoing.Trade;
@@ -29,50 +28,61 @@ public class TradeRequestedEventHandler : IEventHandler
         _gameServer.CreatureManager.GetPlayerConnection(tradeRequest.PlayerRequested.CreatureId,
             out var playerRequestedConnection);
 
-        playerRequestingConnection.OutgoingPackets.Enqueue(new TradeRequestPacket(tradeRequest.PlayerRequesting.Name,
-            tradeRequest.Items)
-        {
-            ShowItemDescription = playerRequestingConnection.OtcV8Version > 0 &&
-                                  _clientConfiguration.OtcV8.GameItemTooltip
-        });
-
+        EnqueueOwnTrade(tradeRequest, playerRequestingConnection);
+        EnqueueCounterTrade(tradeRequest, playerRequestedConnection);
         SendTradeMessage(tradeRequest, playerRequestedConnection);
 
-        SendAcknowledgeTradeToBothPlayers(tradeRequest, playerRequestingConnection, playerRequestedConnection);
+        playerRequestingConnection?.Send();
+        playerRequestedConnection?.Send();
+    }
 
-        playerRequestingConnection.Send();
-        playerRequestedConnection.Send();
+    private void EnqueueOwnTrade(TradeRequest tradeRequest, IConnection connection)
+    {
+        if (connection?.OutgoingPackets is null)
+        {
+            return;
+        }
+
+        connection.OutgoingPackets.Enqueue(new TradeRequestPacket(tradeRequest.PlayerRequesting.Name,
+            tradeRequest.Items)
+        {
+            ShowItemDescription = ShowItemDescription(connection)
+        });
+    }
+
+    private void EnqueueCounterTrade(TradeRequest tradeRequest, IConnection connection)
+    {
+        if (connection?.OutgoingPackets is null)
+        {
+            return;
+        }
+
+        connection.OutgoingPackets.Enqueue(new TradeRequestPacket(tradeRequest.PlayerRequesting.Name,
+            tradeRequest.Items, acknowledged: true)
+        {
+            ShowItemDescription = ShowItemDescription(connection)
+        });
     }
 
     private static void SendTradeMessage(TradeRequest tradeRequest, IConnection playerRequestedConnection)
     {
-        if (tradeRequest.PlayerAcknowledgedTrade) return;
+        if (tradeRequest.PlayerAcknowledgedTrade)
+        {
+            return;
+        }
 
-        var message = $"{tradeRequest.PlayerRequested.Name} wants to trade with you.";
+        if (playerRequestedConnection?.OutgoingPackets is null)
+        {
+            return;
+        }
+
+        var message = $"{tradeRequest.PlayerRequesting.Name} wants to trade with you.";
         playerRequestedConnection.OutgoingPackets.Enqueue(new TextMessagePacket(message,
             TextMessageOutgoingType.Small));
     }
 
-    private void SendAcknowledgeTradeToBothPlayers(TradeRequest tradeRequest,
-        IConnection playerRequestingConnection,
-        IConnection playerRequestedConnection)
+    private bool ShowItemDescription(IConnection connection)
     {
-        if (!tradeRequest.PlayerAcknowledgedTrade) return;
-
-        var items = SafeTradeSystem.GetTradedItems(tradeRequest.PlayerRequested);
-
-        playerRequestingConnection.OutgoingPackets.Enqueue(new TradeRequestPacket(tradeRequest.PlayerRequested.Name,
-            items, true)
-        {
-            ShowItemDescription = playerRequestingConnection.OtcV8Version > 0 &&
-                                  _clientConfiguration.OtcV8.GameItemTooltip
-        });
-
-        playerRequestedConnection.OutgoingPackets.Enqueue(new TradeRequestPacket(tradeRequest.PlayerRequesting.Name,
-            tradeRequest.Items, true)
-        {
-            ShowItemDescription =
-                playerRequestedConnection.OtcV8Version > 0 && _clientConfiguration.OtcV8.GameItemTooltip
-        });
+        return connection.OtcV8Version > 0 && _clientConfiguration.OtcV8 is { GameItemTooltip: true };
     }
 }

--- a/src/Core/NeoServer.Domain/Common/Contracts/Services/ITradeService.cs
+++ b/src/Core/NeoServer.Domain/Common/Contracts/Services/ITradeService.cs
@@ -1,8 +1,11 @@
-﻿using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.SafeTrade.Validations;
 
 namespace NeoServer.Domain.Common.Contracts.Services;
 
 public interface ITradeService
 {
     void Cancel(IPlayer playerCanceling);
+    SafeTradeError Request(IPlayer player, IPlayer secondPlayer, IItem item);
 }

--- a/src/Core/NeoServer.Domain/Houses/House.cs
+++ b/src/Core/NeoServer.Domain/Houses/House.cs
@@ -290,11 +290,51 @@ public class House
         OwnerName = guid != 0 ? name : string.Empty;
         OwnerAccountId = guid != 0 ? accountId : 0;
 
+        PayRentWarnings = 0;
+
         if (updatePaidUntil && guid != 0)
         {
             PaidUntil = now.AddSeconds(rentPeriodSeconds);
-            PayRentWarnings = 0;
         }
+    }
+
+    public HouseTransferItem PendingTransfer { get; private set; }
+
+    public bool TryAttachTransfer(HouseTransferItem item)
+    {
+        if (item is null)
+        {
+            return false;
+        }
+
+        if (PendingTransfer is not null)
+        {
+            return false;
+        }
+
+        PendingTransfer = item;
+        return true;
+    }
+
+    public void ResetTransfer()
+    {
+        PendingTransfer = null;
+    }
+
+    public bool ExecuteTransfer(HouseTransferItem item)
+    {
+        if (item is null || PendingTransfer is null)
+        {
+            return false;
+        }
+
+        if (!ReferenceEquals(PendingTransfer, item))
+        {
+            return false;
+        }
+
+        PendingTransfer = null;
+        return true;
     }
 
     public bool CanKick(IPlayer caster, IPlayer target)

--- a/src/Core/NeoServer.Domain/Houses/HouseTradeResult.cs
+++ b/src/Core/NeoServer.Domain/Houses/HouseTradeResult.cs
@@ -1,0 +1,11 @@
+namespace NeoServer.Domain.Houses;
+
+public enum HouseTradeResult : byte
+{
+    NoError,
+    TradePlayerFarAway,
+    YouDontOwnThisHouse,
+    TradePlayerAlreadyOwnsAHouse,
+    TradePlayerHighestBidder,
+    YouCannotTradeThisHouse
+}

--- a/src/Core/NeoServer.Domain/Houses/HouseTransferItem.cs
+++ b/src/Core/NeoServer.Domain/Houses/HouseTransferItem.cs
@@ -1,0 +1,80 @@
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.Items;
+using NeoServer.Domain.Common.Item;
+using NeoServer.Domain.Common.Location.Structs;
+using NeoServer.Domain.Items;
+using NeoServer.Domain.Items.Items;
+
+namespace NeoServer.Domain.Houses;
+
+public class HouseTransferItem : Paper
+{
+    public const ushort DocumentItemId = 1968;
+
+    private readonly Action<IPlayer> _onComplete;
+
+    public HouseTransferItem(IItemType metadata, House house, Action<IPlayer> onComplete)
+        : base(metadata, Location.Container(0, 0))
+    {
+        House = house;
+        _onComplete = onComplete;
+    }
+
+    public House House { get; }
+
+    public static IItemType CreateMetadata(IItemType source = null)
+    {
+        var type = new ItemType();
+        type.SetId(DocumentItemId);
+        type.SetClientId(source?.ClientId ?? DocumentItemId);
+        type.SetName(string.IsNullOrWhiteSpace(source?.Name) ? "document" : source.Name);
+        type.SetArticle(string.IsNullOrWhiteSpace(source?.Article) ? "a" : source.Article);
+
+        var weight = source is { Weight: > 0 } ? source.Weight : 1.5f;
+        type.Attributes.SetAttribute(ItemTypeAttribute.Weight, weight);
+        type.SetFlag(ItemFlag.Pickupable);
+        type.SetFlag(ItemFlag.Movable);
+        return type;
+    }
+
+    public static HouseTransferItem Create(IItemType metadata, House house, IPlayer seller, Action<IPlayer> onComplete)
+    {
+        var item = new HouseTransferItem(metadata, house, onComplete);
+        item.SetOwner(seller);
+        item.Attributes.SetAttribute(ItemAttribute.Description,
+            $"It is a house transfer document for '{house.Name}'.");
+        return item;
+    }
+
+    public override string GetLookText(bool isClose = false, bool showInternalDetails = false)
+    {
+        var lookText = base.GetLookText(isClose, showInternalDetails);
+        var description = Attributes.GetAttribute(ItemAttribute.Description);
+        if (string.IsNullOrWhiteSpace(description))
+        {
+            return lookText;
+        }
+
+        return $"{lookText}\n{description}";
+    }
+
+    public void Complete(IPlayer newOwner)
+    {
+        if (newOwner is null)
+        {
+            return;
+        }
+
+        if (!House.ExecuteTransfer(this))
+        {
+            return;
+        }
+
+        _onComplete?.Invoke(newOwner);
+    }
+
+    public void Cancel()
+    {
+        House.ResetTransfer();
+    }
+}

--- a/src/Core/NeoServer.Domain/Houses/Services/HouseTradeService.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/HouseTradeService.cs
@@ -1,0 +1,71 @@
+using NeoServer.Domain.Common;
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.DataStores;
+using NeoServer.Domain.Common.Contracts.Services;
+using NeoServer.Domain.SafeTrade.Validations;
+
+namespace NeoServer.Domain.Houses.Services;
+
+public class HouseTradeService(
+    IHouseService houseService,
+    IHouseStore houseStore,
+    ITradeService tradeService,
+    IItemTypeStore itemTypeStore,
+    HouseConfiguration houseConfiguration) : IHouseTradeService
+{
+    public HouseTradeResult StartTrade(House house, IPlayer seller, IPlayer partner)
+    {
+        if (house is null || seller is null || partner is null || seller == partner)
+        {
+            return HouseTradeResult.YouCannotTradeThisHouse;
+        }
+
+        if (seller.Location.Z != partner.Location.Z ||
+            seller.Location.GetMaxSqmDistance(partner.Location) > 2)
+        {
+            return HouseTradeResult.TradePlayerFarAway;
+        }
+
+        if (house.OwnerGuid != seller.Id)
+        {
+            return HouseTradeResult.YouDontOwnThisHouse;
+        }
+
+        if (houseStore.GetByOwnerGuid(partner.Id) is not null)
+        {
+            return HouseTradeResult.TradePlayerAlreadyOwnsAHouse;
+        }
+
+        if (house.PendingTransfer is not null)
+        {
+            return HouseTradeResult.YouCannotTradeThisHouse;
+        }
+
+        itemTypeStore.TryGetValue(HouseTransferItem.DocumentItemId, out var sourceType);
+        var metadata = HouseTransferItem.CreateMetadata(sourceType);
+        var transferItem = HouseTransferItem.Create(metadata, house, seller, buyer =>
+        {
+            houseService.SetOwner(
+                house,
+                buyer.Id,
+                buyer.Name,
+                (int)buyer.AccountId,
+                updatePaidUntil: false,
+                DateTime.UtcNow,
+                houseConfiguration.RentPeriodSeconds);
+        });
+
+        if (!house.TryAttachTransfer(transferItem))
+        {
+            return HouseTradeResult.YouCannotTradeThisHouse;
+        }
+
+        var tradeResult = tradeService.Request(seller, partner, transferItem);
+        if (tradeResult is not SafeTradeError.None)
+        {
+            house.ResetTransfer();
+        }
+
+        return HouseTradeResult.NoError;
+    }
+}

--- a/src/Core/NeoServer.Domain/Houses/Services/IHouseTradeService.cs
+++ b/src/Core/NeoServer.Domain/Houses/Services/IHouseTradeService.cs
@@ -1,0 +1,8 @@
+using NeoServer.Domain.Common.Contracts.Creatures;
+
+namespace NeoServer.Domain.Houses.Services;
+
+public interface IHouseTradeService
+{
+    HouseTradeResult StartTrade(House house, IPlayer seller, IPlayer partner);
+}

--- a/src/Core/NeoServer.Domain/SafeTrade/Operations/TradeItemExchanger.cs
+++ b/src/Core/NeoServer.Domain/SafeTrade/Operations/TradeItemExchanger.cs
@@ -63,19 +63,48 @@ public class TradeItemExchanger
     {
         if (Guard.AnyNull(itemFromPlayerRequested, playerRequesting, itemFromPlayerRequesting, playerRequested)) return;
 
+        var houseTransferFromRequestingPlayer = itemFromPlayerRequesting as Houses.HouseTransferItem;
+        var houseTransferFromRequestedPlayer = itemFromPlayerRequested as Houses.HouseTransferItem;
+        
+        // A house sale has exactly one transfer document (seller) and one payment (buyer).
+        // Both sides offering a document is invalid and cannot be completed safely.
+        if (houseTransferFromRequestingPlayer is not null && houseTransferFromRequestedPlayer is not null)
+        {
+            return;
+        }
+
+        if (houseTransferFromRequestingPlayer is not null)
+        {
+            ExchangeOfferedItem(playerRequesting, itemFromPlayerRequested, itemFromPlayerRequesting);
+            houseTransferFromRequestingPlayer.Complete(playerRequested);
+            return;
+        }
+
+        if (houseTransferFromRequestedPlayer is not null)
+        {
+            ExchangeOfferedItem(playerRequested, itemFromPlayerRequesting, itemFromPlayerRequested);
+            houseTransferFromRequestedPlayer.Complete(playerRequesting);
+            return;
+        }
+
         var playerRequestingSlotDestination =
             TradeSlotDestinationQuery.Get(playerRequesting, itemFromPlayerRequested, itemFromPlayerRequesting);
 
         var playerRequestedSlotDestination =
             TradeSlotDestinationQuery.Get(playerRequested, itemFromPlayerRequesting, itemFromPlayerRequested);
 
-        // Remove the items from their previous locations
         _itemRemoveService.Remove(itemFromPlayerRequesting);
         _itemRemoveService.Remove(itemFromPlayerRequested);
 
-        // Add the items to each player's inventory
         AddItemToInventory(playerRequesting, itemFromPlayerRequested, playerRequestingSlotDestination);
         AddItemToInventory(playerRequested, itemFromPlayerRequesting, playerRequestedSlotDestination);
+    }
+
+    private void ExchangeOfferedItem(IPlayer receiver, IItem offeredItem, IItem transferDocument)
+    {
+        var slotDestination = TradeSlotDestinationQuery.Get(receiver, offeredItem, transferDocument);
+        _itemRemoveService.Remove(offeredItem);
+        AddItemToInventory(receiver, offeredItem, slotDestination);
     }
 
     private static void AddItemToInventory(IPlayer player, IItem item, Slot slot)

--- a/src/Core/NeoServer.Domain/SafeTrade/SafeTradeSystem.cs
+++ b/src/Core/NeoServer.Domain/SafeTrade/SafeTradeSystem.cs
@@ -123,9 +123,13 @@ public class SafeTradeSystem : ITradeService
 
         var tradeFromPlayerRequested = TradeRequestTracker.GetTradeRequest(tradeRequest.PlayerRequested);
 
-        // Unsubscribe both players from the trade request event.
         var itemFromPlayerRequesting = tradeRequest.Items;
         var itemFromPlayerRequested = tradeFromPlayerRequested?.Items ?? [];
+
+        CancelHouseTransfers(itemFromPlayerRequesting);
+        CancelHouseTransfers(itemFromPlayerRequested);
+
+        // Unsubscribe both players from the trade request event.
 
         TradeRequestEventHandler.Unsubscribe(tradeRequest.PlayerRequesting, itemFromPlayerRequesting);
         TradeRequestEventHandler.Unsubscribe(tradeRequest.PlayerRequested, itemFromPlayerRequested);
@@ -137,6 +141,22 @@ public class SafeTradeSystem : ITradeService
         TradeRequestTracker.Untrack(tradeRequest.PlayerRequested);
 
         OnClosed?.Invoke(tradeRequest);
+    }
+
+    private static void CancelHouseTransfers(IItem[] items)
+    {
+        if (items is null)
+        {
+            return;
+        }
+
+        foreach (var item in items)
+        {
+            if (item is Houses.HouseTransferItem transferItem)
+            {
+                transferItem.Cancel();
+            }
+        }
     }
 
     private static IItem[] GetItems(IItem item)

--- a/src/Core/NeoServer.Domain/SafeTrade/Validations/TradeExchangeValidation.cs
+++ b/src/Core/NeoServer.Domain/SafeTrade/Validations/TradeExchangeValidation.cs
@@ -22,15 +22,18 @@ internal static class TradeExchangeValidation
         IPlayer playerRequesting,
         IItem itemFromPlayerRequested)
     {
-        // Check if playerRequested has enough inventory space to add itemFromPlayerRequesting
-        var firstPlayerCanAddItem = CanAddItem(playerRequested, itemFromPlayerRequesting, itemFromPlayerRequested);
-        if (firstPlayerCanAddItem is not SafeTradeError.None)
+        if (itemFromPlayerRequesting is not Houses.HouseTransferItem)
         {
-            OperationFailService.Send(playerRequesting.CreatureId, DEFAULT_ERROR_MESSAGE);
-            return firstPlayerCanAddItem;
+            var firstPlayerCanAddItem = CanAddItem(playerRequested, itemFromPlayerRequesting, itemFromPlayerRequested);
+            if (firstPlayerCanAddItem is not SafeTradeError.None)
+            {
+                OperationFailService.Send(playerRequesting.CreatureId, DEFAULT_ERROR_MESSAGE);
+                return firstPlayerCanAddItem;
+            }
         }
 
-        // Check if playerRequesting has enough inventory space to add itemFromPlayerRequested
+        if (itemFromPlayerRequested is Houses.HouseTransferItem) return SafeTradeError.None;
+
         var secondPlayerCanAddItem = CanAddItem(playerRequesting, itemFromPlayerRequested, itemFromPlayerRequesting);
         if (secondPlayerCanAddItem is SafeTradeError.None) return secondPlayerCanAddItem;
 

--- a/src/Core/NeoServer.Domain/SafeTrade/Validations/TradeRequestValidation.cs
+++ b/src/Core/NeoServer.Domain/SafeTrade/Validations/TradeRequestValidation.cs
@@ -36,12 +36,15 @@ internal class TradeRequestValidation
 
         if (ItemIsAlreadyBeingTraded(firstPlayer, items)) return SafeTradeError.ItemAlreadyBeingTraded;
 
-        if (PlayerIsNotNextToItem(firstPlayer, items)) return SafeTradeError.PlayerNotCloseToItem;
+        var isHouseTransfer = items[0] is Houses.HouseTransferItem;
+
+        if (!isHouseTransfer && PlayerIsNotNextToItem(firstPlayer, items)) return SafeTradeError.PlayerNotCloseToItem;
 
         // Ensure that both players are close enough to each other
         if (PlayerIsNotCloseEnough(firstPlayer, secondPlayer)) return SafeTradeError.PlayersNotCloseToEachOther;
 
-        if (!HasSightClearToSecondPlayer(firstPlayer, secondPlayer)) return SafeTradeError.HasNoSightClearToPlayer;
+        if (!isHouseTransfer && !HasSightClearToSecondPlayer(firstPlayer, secondPlayer))
+            return SafeTradeError.HasNoSightClearToPlayer;
 
         // Ensure that the second player is not already in a trade with someone else
         if (SecondPlayerIsAlreadyTrading(firstPlayer, secondPlayer)) return SafeTradeError.SecondPlayerAlreadyTrading;

--- a/src/Extensions/NeoServer.Scripts.LuaJIT/Functions/HouseFunctions.cs
+++ b/src/Extensions/NeoServer.Scripts.LuaJIT/Functions/HouseFunctions.cs
@@ -4,30 +4,34 @@ using NeoServer.Domain.Common.Contracts.Creatures;
 using NeoServer.Domain.Common.Contracts.DataStores;
 using NeoServer.Domain.Houses;
 using NeoServer.Domain.Houses.Services;
+using NeoServer.Scripts.LuaJIT.Enums;
 using NeoServer.Scripts.LuaJIT.Functions.Interfaces;
 
 namespace NeoServer.Scripts.LuaJIT.Functions;
 
 /// <summary>
-///     House Lua bindings for Phase 3 (access-list spells, kick, and !buyhouse).
-///     Full HouseFunctions surface (tiles, beds, rent, trade, save) comes in later slices.
+///     House Lua bindings for Phase 3 (access-list spells, kick, !buyhouse, and !sellhouse).
+///     Full HouseFunctions surface (tiles, beds, rent, save) comes in later slices.
 /// </summary>
 public class HouseFunctions : LuaScriptInterface, IHouseFunctions
 {
     private static IHouseStore _houseStore;
     private static IHouseService _houseService;
+    private static IHouseTradeService _houseTradeService;
     private static ICreatureGameInstance _creatureGameInstance;
     private static HouseConfiguration _houseConfiguration;
 
     public HouseFunctions(
         IHouseStore houseStore,
         IHouseService houseService,
+        IHouseTradeService houseTradeService,
         ICreatureGameInstance creatureGameInstance,
         HouseConfiguration houseConfiguration) :
         base(nameof(HouseFunctions))
     {
         _houseStore = houseStore;
         _houseService = houseService;
+        _houseTradeService = houseTradeService;
         _creatureGameInstance = creatureGameInstance;
         _houseConfiguration = houseConfiguration ?? new HouseConfiguration();
     }
@@ -45,6 +49,7 @@ public class HouseFunctions : LuaScriptInterface, IHouseFunctions
         RegisterMethod(luaState, "House", "getAccessList", LuaHouseGetAccessList);
         RegisterMethod(luaState, "House", "getDoorIdByPosition", LuaHouseGetDoorIdByPosition);
         RegisterMethod(luaState, "House", "kickPlayer", LuaHouseKickPlayer);
+        RegisterMethod(luaState, "House", "startTrade", LuaHouseStartTrade);
 
         RegisterGlobalVariable(luaState, "GUEST_LIST", HouseListId.GuestList);
         RegisterGlobalVariable(luaState, "SUBOWNER_LIST", HouseListId.SubOwnerList);
@@ -206,5 +211,37 @@ public class HouseFunctions : LuaScriptInterface, IHouseFunctions
         // HouseService validates CanKick (relative access, CanEditHouses, tile).
         PushBoolean(luaState, _houseService.KickPlayer(house, caster, target));
         return 1;
+    }
+
+    private static int LuaHouseStartTrade(LuaState luaState)
+    {
+        // house:startTrade(player, tradePartner)
+        var house = GetUserdata<House>(luaState, 1);
+        var player = GetUserdata<IPlayer>(luaState, 2);
+        var tradePartner = GetUserdata<IPlayer>(luaState, 3);
+
+        if (house is null || player is null || tradePartner is null)
+        {
+            Lua.PushNil(luaState);
+            return 1;
+        }
+
+        var result = _houseTradeService.StartTrade(house, player, tradePartner);
+        Lua.PushNumber(luaState, (int)ToReturnValue(result));
+        return 1;
+    }
+
+    private static ReturnValueType ToReturnValue(HouseTradeResult result)
+    {
+        return result switch
+        {
+            HouseTradeResult.NoError => ReturnValueType.RETURNVALUE_NOERROR,
+            HouseTradeResult.TradePlayerFarAway => ReturnValueType.RETURNVALUE_TRADEPLAYERFARAWAY,
+            HouseTradeResult.YouDontOwnThisHouse => ReturnValueType.RETURNVALUE_YOUDONTOWNTHISHOUSE,
+            HouseTradeResult.TradePlayerAlreadyOwnsAHouse => ReturnValueType.RETURNVALUE_TRADEPLAYERALREADYOWNSAHOUSE,
+            HouseTradeResult.TradePlayerHighestBidder => ReturnValueType.RETURNVALUE_TRADEPLAYERHIGHESTBIDDER,
+            HouseTradeResult.YouCannotTradeThisHouse => ReturnValueType.RETURNVALUE_YOUCANNOTTRADETHISHOUSE,
+            _ => ReturnValueType.RETURNVALUE_NOTPOSSIBLE
+        };
     }
 }

--- a/src/Standalone/IoC/Modules/ServiceInjection.cs
+++ b/src/Standalone/IoC/Modules/ServiceInjection.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
 using NeoServer.Domain.Combat.Attacks;
 using NeoServer.Domain.Combat.Monster;
@@ -68,7 +68,7 @@ public static class ServiceInjection
         builder.AddSingleton<IMonsterTargetSearch, MonsterTargetSearch>();
         builder.AddSingleton<IMonsterTargetingService, MonsterTargetingService>();
         builder.AddSingleton<MonsterStateService>();
-        builder.AddSingleton<ITradeService, SafeTradeSystem>();
+        builder.AddSingleton<ITradeService>(sp => sp.GetRequiredService<SafeTradeSystem>());
         builder.AddSingleton<PlayerChannelService>();
         builder.AddSingleton<TargetDetectorService>();
         builder.AddSingleton<ICreatureMovementService, CreatureMovementService>();
@@ -120,6 +120,7 @@ public static class ServiceInjection
 
         //house services
         builder.AddSingleton<IHouseService, HouseService>();
+        builder.AddSingleton<IHouseTradeService, HouseTradeService>();
         builder.AddSingleton<IHouseEviction, HouseEvictionService>();
         builder.AddSingleton<IHouseBedWaker, HouseBedWakerService>();
         builder.AddSingleton<IHouseDepotTransfer, HouseDepotTransferService>();

--- a/tests/NeoServer.Domain.Tests/Houses/HouseOwnershipTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseOwnershipTests.cs
@@ -138,4 +138,27 @@ public class HouseOwnershipTests
 
         house.PaidUntil.Should().Be(now.AddSeconds(86400));
     }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void SetNewOwner_ChangingOwner_WithoutUpdatePaidUntil_ResetsPayRentWarnings()
+    {
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1, payRentWarnings: 5);
+
+        house.SetNewOwner(10, "NewOwner", 100, false, DateTime.UtcNow, 86400);
+
+        house.PayRentWarnings.Should().Be(0);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void SetNewOwner_ChangingOwner_WithoutUpdatePaidUntil_KeepsPaidUntil()
+    {
+        var paidUntil = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1, paidUntil: paidUntil);
+
+        house.SetNewOwner(10, "NewOwner", 100, false, DateTime.UtcNow, 86400);
+
+        house.PaidUntil.Should().Be(paidUntil);
+    }
 }

--- a/tests/NeoServer.Domain.Tests/Houses/HouseTradeServiceTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseTradeServiceTests.cs
@@ -1,0 +1,232 @@
+using Moq;
+using NeoServer.Data.InMemory.DataStores;
+using NeoServer.Domain.Common;
+using NeoServer.Domain.Common.Contracts.Creatures;
+using NeoServer.Domain.Common.Contracts.World;
+using NeoServer.Domain.Creatures.Player.Inventory;
+using NeoServer.Domain.Houses;
+using NeoServer.Domain.Houses.AccessList;
+using NeoServer.Domain.Houses.Services;
+using NeoServer.Domain.Items.Services;
+using NeoServer.Domain.Repositories;
+using NeoServer.Domain.SafeTrade;
+using NeoServer.Domain.SafeTrade.Operations;
+using NeoServer.Domain.Tests.Helpers;
+using NeoServer.Domain.Tests.Helpers.House;
+using NeoServer.Domain.Tests.Helpers.Map;
+using NeoServer.Domain.Tests.Helpers.Player;
+using NeoServer.Domain.World.Models.Tiles;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseTradeServiceTests
+{
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void StartTrade_when_partner_is_too_far_returns_trade_player_far_away()
+    {
+        var context = CreateContext();
+        ((DynamicTile)context.Map[100, 104, 7]).AddCreature(context.Partner);
+
+        var result = context.TradeService.StartTrade(context.House, context.Seller, context.Partner);
+
+        result.Should().Be(HouseTradeResult.TradePlayerFarAway);
+        context.House.PendingTransfer.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void StartTrade_when_partner_is_on_another_floor_returns_trade_player_far_away()
+    {
+        var context = CreateContext(toZ: 8);
+        ((DynamicTile)context.Map[101, 100, 8]).AddCreature(context.Partner);
+
+        var result = context.TradeService.StartTrade(context.House, context.Seller, context.Partner);
+
+        result.Should().Be(HouseTradeResult.TradePlayerFarAway);
+        context.House.PendingTransfer.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void StartTrade_when_seller_is_not_owner_returns_you_dont_own_this_house()
+    {
+        var context = CreateContext();
+        PlaceAdjacent(context);
+        context.House.OwnerGuid = 99;
+
+        var result = context.TradeService.StartTrade(context.House, context.Seller, context.Partner);
+
+        result.Should().Be(HouseTradeResult.YouDontOwnThisHouse);
+        context.House.PendingTransfer.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void StartTrade_when_partner_already_owns_a_house_returns_already_owns_a_house()
+    {
+        var context = CreateContext();
+        PlaceAdjacent(context);
+        var otherHouse = HouseTestDataBuilder.Build(id: 2, ownerGuid: context.Partner.Id);
+        context.HouseStore.AddOrUpdate(otherHouse.Id, otherHouse);
+
+        var result = context.TradeService.StartTrade(context.House, context.Seller, context.Partner);
+
+        result.Should().Be(HouseTradeResult.TradePlayerAlreadyOwnsAHouse);
+        context.House.PendingTransfer.Should().BeNull();
+    }
+
+    [Fact]
+    [ThreadBlocking]
+    [Trait("Category", "HappyPath")]
+    public void StartTrade_when_players_are_in_range_opens_trade_and_attaches_transfer()
+    {
+        var context = CreateContext();
+        PlaceAdjacent(context);
+
+        var result = context.TradeService.StartTrade(context.House, context.Seller, context.Partner);
+
+        result.Should().Be(HouseTradeResult.NoError);
+        context.House.PendingTransfer.Should().NotBeNull();
+
+        context.SafeTrade.Cancel(context.Seller);
+        context.House.PendingTransfer.Should().BeNull();
+    }
+
+    [Fact]
+    [ThreadBlocking]
+    [Trait("Category", "Validation")]
+    public void StartTrade_when_a_transfer_is_already_pending_returns_you_cannot_trade_this_house()
+    {
+        var context = CreateContext();
+        PlaceAdjacent(context);
+        context.TradeService.StartTrade(context.House, context.Seller, context.Partner);
+
+        var result = context.TradeService.StartTrade(context.House, context.Seller, context.Partner);
+
+        result.Should().Be(HouseTradeResult.YouCannotTradeThisHouse);
+        context.SafeTrade.Cancel(context.Seller);
+    }
+
+    [Fact]
+    [ThreadBlocking]
+    [Trait("Category", "Validation")]
+    public void StartTrade_when_seller_is_already_trading_returns_no_error_and_clears_pending()
+    {
+        var context = CreateContext();
+        PlaceAdjacent(context);
+
+        var weapon = ItemTestDataBuilder.CreateWeaponItem(1);
+        context.Seller.Inventory.AddItem(weapon, Slot.Left);
+        context.SafeTrade.Request(context.Seller, context.Partner, weapon);
+
+        var result = context.TradeService.StartTrade(context.House, context.Seller, context.Partner);
+
+        result.Should().Be(HouseTradeResult.NoError);
+        context.House.PendingTransfer.Should().BeNull();
+        context.SafeTrade.Cancel(context.Seller);
+    }
+
+    [Fact]
+    [ThreadBlocking]
+    [Trait("Category", "HappyPath")]
+    public void Completing_trade_transfers_ownership_and_does_not_leave_the_document()
+    {
+        var paidUntil = new DateTime(2025, 6, 1, 0, 0, 0, DateTimeKind.Utc);
+        var context = CreateContext(paidUntil: paidUntil, payRentWarnings: 4);
+        PlaceAdjacent(context);
+
+        var payment = ItemTestDataBuilder.CreateWeaponItem(20, weight: 10);
+        context.Partner.Inventory.AddItem(payment, Slot.Left);
+
+        context.TradeService.StartTrade(context.House, context.Seller, context.Partner);
+        context.SafeTrade.Request(context.Partner, context.Seller, payment);
+        context.SafeTrade.AcceptTrade(context.Seller);
+        var result = context.SafeTrade.AcceptTrade(context.Partner);
+
+        result.Should().Be(NeoServer.Domain.SafeTrade.Validations.SafeTradeError.None);
+        context.House.OwnerGuid.Should().Be(context.Partner.Id);
+        context.House.OwnerName.Should().Be(context.Partner.Name);
+        context.House.PaidUntil.Should().Be(paidUntil);
+        context.House.PayRentWarnings.Should().Be(0);
+        context.House.PendingTransfer.Should().BeNull();
+        context.House.GetAccessList(HouseListId.GuestList).Should().BeNull();
+        context.Seller.Inventory[Slot.Left].Should().Be(payment);
+        context.Partner.Inventory[Slot.Left].Should().BeNull();
+    }
+
+    [Fact]
+    [ThreadBlocking]
+    [Trait("Category", "HappyPath")]
+    public void Cancelling_trade_leaves_ownership_unchanged()
+    {
+        var context = CreateContext();
+        PlaceAdjacent(context);
+
+        context.TradeService.StartTrade(context.House, context.Seller, context.Partner);
+        context.SafeTrade.Cancel(context.Seller);
+
+        context.House.OwnerGuid.Should().Be(context.Seller.Id);
+        context.House.PendingTransfer.Should().BeNull();
+    }
+
+    private static void PlaceAdjacent(TradeContext context)
+    {
+        ((DynamicTile)context.Map[100, 100, 7]).AddCreature(context.Seller);
+        ((DynamicTile)context.Map[101, 100, 7]).AddCreature(context.Partner);
+    }
+
+    private static TradeContext CreateContext(
+        byte toZ = 7,
+        DateTime? paidUntil = null,
+        byte payRentWarnings = 0)
+    {
+        var map = MapTestDataBuilder.Build(100, 110, 100, 110, 7, toZ);
+        var seller = PlayerTestDataBuilder.Build(id: 1, name: "Seller", map: map, capacity: 1000);
+        var partner = PlayerTestDataBuilder.Build(id: 2, name: "Partner", map: map, capacity: 1000);
+
+        var house = HouseTestDataBuilder.Build(
+            id: 1,
+            ownerGuid: seller.Id,
+            ownerName: seller.Name,
+            paidUntil: paidUntil,
+            payRentWarnings: payRentWarnings,
+            accessLists: new Dictionary<uint, HouseAccessList>
+            {
+                { HouseListId.GuestList, HouseTestDataBuilder.CreateAccessList("Guest") }
+            });
+
+        var houseStore = new HouseStore();
+        houseStore.AddOrUpdate(house.Id, house);
+
+        var itemTypeStore = new ItemTypeStore();
+        itemTypeStore.AddOrUpdate(HouseTransferItem.DocumentItemId, HouseTransferItem.CreateMetadata());
+
+        var safeTrade = new SafeTradeSystem(new TradeItemExchanger(new ItemRemoveService(map)), map);
+        var houseService = new HouseService(
+            new Mock<IHouseRepository>().Object,
+            new Mock<IHouseEviction>().Object,
+            new Mock<IHouseBedWaker>().Object,
+            new Mock<IHouseDepotTransfer>().Object,
+            new Mock<ICreatureGameInstance>().Object,
+            new HouseConfiguration());
+
+        var tradeService = new HouseTradeService(
+            houseService,
+            houseStore,
+            safeTrade,
+            itemTypeStore,
+            new HouseConfiguration());
+
+        return new TradeContext(map, seller, partner, house, houseStore, safeTrade, tradeService);
+    }
+
+    private sealed record TradeContext(
+        IMap Map,
+        IPlayer Seller,
+        IPlayer Partner,
+        House House,
+        HouseStore HouseStore,
+        SafeTradeSystem SafeTrade,
+        HouseTradeService TradeService);
+}

--- a/tests/NeoServer.Domain.Tests/Houses/HouseTransferTests.cs
+++ b/tests/NeoServer.Domain.Tests/Houses/HouseTransferTests.cs
@@ -1,0 +1,86 @@
+using NeoServer.Domain.Houses;
+using NeoServer.Domain.Tests.Helpers.House;
+using NeoServer.Domain.Tests.Helpers.Player;
+
+namespace NeoServer.Domain.Tests.Houses;
+
+public class HouseTransferTests
+{
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void TryAttachTransfer_succeeds_when_house_has_no_pending_transfer()
+    {
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+        var item = CreateTransferItem(house);
+
+        house.TryAttachTransfer(item).Should().BeTrue();
+        house.PendingTransfer.Should().BeSameAs(item);
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void TryAttachTransfer_fails_when_a_transfer_is_already_pending()
+    {
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+        var first = CreateTransferItem(house);
+        var second = CreateTransferItem(house);
+
+        house.TryAttachTransfer(first).Should().BeTrue();
+        house.TryAttachTransfer(second).Should().BeFalse();
+        house.PendingTransfer.Should().BeSameAs(first);
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void ExecuteTransfer_with_a_different_item_does_not_clear_pending_transfer()
+    {
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+        var pending = CreateTransferItem(house);
+        var other = CreateTransferItem(house);
+        house.TryAttachTransfer(pending);
+
+        house.ExecuteTransfer(other).Should().BeFalse();
+        house.PendingTransfer.Should().BeSameAs(pending);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void ExecuteTransfer_with_pending_item_clears_the_transfer()
+    {
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+        var pending = CreateTransferItem(house);
+        house.TryAttachTransfer(pending);
+
+        house.ExecuteTransfer(pending).Should().BeTrue();
+        house.PendingTransfer.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void ResetTransfer_allows_a_new_attach()
+    {
+        var house = HouseTestDataBuilder.Build(ownerGuid: 1);
+        house.TryAttachTransfer(CreateTransferItem(house));
+        house.ResetTransfer();
+
+        var next = CreateTransferItem(house);
+        house.TryAttachTransfer(next).Should().BeTrue();
+        house.PendingTransfer.Should().BeSameAs(next);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Transfer_document_look_text_includes_house_name()
+    {
+        var house = HouseTestDataBuilder.Build(name: "Sunset Lane 4", ownerGuid: 1);
+        var item = CreateTransferItem(house);
+
+        item.GetLookText(isClose: true).Should().Contain("house transfer document for 'Sunset Lane 4'");
+    }
+
+    private static HouseTransferItem CreateTransferItem(House house)
+    {
+        var seller = PlayerTestDataBuilder.Build(id: house.OwnerGuid == 0 ? 1 : house.OwnerGuid);
+        return HouseTransferItem.Create(HouseTransferItem.CreateMetadata(), house, seller, _ => { });
+    }
+}

--- a/tests/NeoServer.Server.Tests/Events/TradeRequestedEventHandlerTests.cs
+++ b/tests/NeoServer.Server.Tests/Events/TradeRequestedEventHandlerTests.cs
@@ -1,0 +1,134 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using FluentAssertions;
+using Moq;
+using NeoServer.Domain.SafeTrade.Request;
+using NeoServer.Domain.Tests.Helpers;
+using NeoServer.Domain.Tests.Helpers.Player;
+using NeoServer.Networking.Packets.Messages;
+using NeoServer.Networking.Packets.Outgoing;
+using NeoServer.Networking.Packets.Outgoing.Trade;
+using NeoServer.Server.Common.Contracts;
+using NeoServer.Server.Common.Contracts.Network;
+using NeoServer.Server.Configurations;
+using NeoServer.Server.Events.Player.Trade;
+using Xunit;
+
+namespace NeoServer.Server.Tests.Events;
+
+public class TradeRequestedEventHandlerTests
+{
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Buyer_receives_trade_window_when_seller_requests_trade()
+    {
+        var (handler, sellerConnection, buyerConnection, tradeRequest) = CreateHandler();
+
+        handler.Execute(tradeRequest);
+
+        var buyerTradePacket = buyerConnection.Object.OutgoingPackets.OfType<TradeRequestPacket>().Should()
+            .ContainSingle().Subject;
+        ReadOpcode(buyerTradePacket).Should().Be((byte)GameOutgoingPacketType.AcknowlegdeTradeRequest);
+
+        var sellerTradePacket = sellerConnection.Object.OutgoingPackets.OfType<TradeRequestPacket>().Should()
+            .ContainSingle().Subject;
+        ReadOpcode(sellerTradePacket).Should().Be((byte)GameOutgoingPacketType.TradeRequest);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Buyer_receives_message_with_seller_name_when_trade_is_requested()
+    {
+        var (handler, _, buyerConnection, tradeRequest) = CreateHandler();
+
+        handler.Execute(tradeRequest);
+
+        var textPacket = buyerConnection.Object.OutgoingPackets.OfType<TextMessagePacket>().Should().ContainSingle()
+            .Subject;
+        ReadText(textPacket).Should().Contain("Seller wants to trade with you.");
+    }
+
+    [Fact]
+    [Trait("Category", "ErrorCondition")]
+    public void TradeRequestedEventHandler_does_not_throw_when_buyer_connection_is_missing()
+    {
+        var seller = PlayerTestDataBuilder.Build(1, "Seller");
+        var buyer = PlayerTestDataBuilder.Build(2, "Buyer");
+        var item = ItemTestDataBuilder.CreateWeaponItem(1);
+        var tradeRequest = new TradeRequest(seller, buyer, [item]);
+
+        var sellerConnection = CreateConnection();
+        var creatureManager = new Mock<IGameCreatureManager>();
+        IConnection sellerConnectionObject = sellerConnection.Object;
+        IConnection missingConnection = null;
+        creatureManager.Setup(manager => manager.GetPlayerConnection(seller.CreatureId, out sellerConnectionObject))
+            .Returns(true);
+        creatureManager.Setup(manager => manager.GetPlayerConnection(buyer.CreatureId, out missingConnection))
+            .Returns(false);
+
+        var gameServer = new Mock<IGameServer>();
+        gameServer.SetupGet(server => server.CreatureManager).Returns(creatureManager.Object);
+
+        var handler = new TradeRequestedEventHandler(gameServer.Object, CreateClientConfiguration());
+
+        var act = () => handler.Execute(tradeRequest);
+
+        act.Should().NotThrow();
+        sellerConnection.Object.OutgoingPackets.OfType<TradeRequestPacket>().Should().ContainSingle();
+        sellerConnection.Verify(connection => connection.Send(), Times.Once);
+    }
+
+    private static (TradeRequestedEventHandler Handler, Mock<IConnection> SellerConnection,
+        Mock<IConnection> BuyerConnection, TradeRequest TradeRequest) CreateHandler()
+    {
+        var seller = PlayerTestDataBuilder.Build(1, "Seller");
+        var buyer = PlayerTestDataBuilder.Build(2, "Buyer");
+        var item = ItemTestDataBuilder.CreateWeaponItem(1);
+        var tradeRequest = new TradeRequest(seller, buyer, [item]);
+
+        var sellerConnection = CreateConnection();
+        var buyerConnection = CreateConnection();
+
+        var creatureManager = new Mock<IGameCreatureManager>();
+        IConnection sellerConnectionObject = sellerConnection.Object;
+        IConnection buyerConnectionObject = buyerConnection.Object;
+        creatureManager.Setup(manager => manager.GetPlayerConnection(seller.CreatureId, out sellerConnectionObject))
+            .Returns(true);
+        creatureManager.Setup(manager => manager.GetPlayerConnection(buyer.CreatureId, out buyerConnectionObject))
+            .Returns(true);
+
+        var gameServer = new Mock<IGameServer>();
+        gameServer.SetupGet(server => server.CreatureManager).Returns(creatureManager.Object);
+
+        var handler = new TradeRequestedEventHandler(gameServer.Object, CreateClientConfiguration());
+        return (handler, sellerConnection, buyerConnection, tradeRequest);
+    }
+
+    private static Mock<IConnection> CreateConnection()
+    {
+        var connection = new Mock<IConnection>();
+        connection.SetupGet(c => c.OutgoingPackets).Returns(new Queue<IOutgoingPacket>());
+        connection.SetupGet(c => c.OtcV8Version).Returns((ushort)0);
+        return connection;
+    }
+
+    private static ClientConfiguration CreateClientConfiguration()
+    {
+        return new ClientConfiguration(new ClientConfiguration.OtcV8Configuration(false, false, false, false));
+    }
+
+    private static byte ReadOpcode(IOutgoingPacket packet)
+    {
+        var message = new NetworkMessage();
+        packet.WriteToMessage(message);
+        return message.Buffer[0];
+    }
+
+    private static string ReadText(IOutgoingPacket packet)
+    {
+        var message = new NetworkMessage();
+        packet.WriteToMessage(message);
+        return Encoding.Latin1.GetString(message.Buffer, 0, message.Length);
+    }
+}


### PR DESCRIPTION
### Description
Players can now sell their house to another player in-game using `!sellhouse`. The seller must stand inside their house and initiate a safe trade with a phantom transfer document; completing the trade transfers ownership immediately.

### Key Changes
- Add `!sellhouse` talkaction and `house:startTrade` Lua binding
- Introduce `HouseTradeService` and `HouseTransferItem` for phantom document safe-trade flow
- Extend safe trade to support non-inventory items owned by the seller
- Transfer ownership on trade accept via `HouseService.SetOwner` (keeps `paidUntil`, resets rent warnings)
- Add domain and event handler tests for trade validation and ownership transfer

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
`dotnet test tests/NeoServer.Domain.Tests --filter FullyQualifiedName~House`
`dotnet test tests/NeoServer.Server.Tests --filter FullyQualifiedName~TradeRequested`