### PR TITLE
refactor: remove third-party cryptography from account login

### DIFF
--- a/src/ApplicationServer/NeoServer.Server.Security/NeoServer.Server.Security.csproj
+++ b/src/ApplicationServer/NeoServer.Server.Security/NeoServer.Server.Security.csproj
@@ -7,7 +7,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle.NetCore" Version="2.2.1"/>
         <PackageReference Include="Serilog" Version="4.3.1" />
     </ItemGroup>
 

--- a/src/ApplicationServer/NeoServer.Server.Security/RSA.cs
+++ b/src/ApplicationServer/NeoServer.Server.Security/RSA.cs
@@ -69,48 +69,32 @@ public static class Rsa
 
     private static byte[] ConvertDecryptOutput(BigInteger value)
     {
-        var output = value.ToByteArray(isUnsigned: true, isBigEndian: true);
-
-        if (output.Length == 0)
-        {
-            return new byte[PlaintextLength];
-        }
-
-        if (output.Length > PlaintextLength && output[0] == 0)
-        {
-            var trimmed = new byte[output.Length - 1];
-            Buffer.BlockCopy(output, 1, trimmed, 0, trimmed.Length);
-            output = trimmed;
-        }
-
-        if (output.Length >= PlaintextLength)
-        {
-            return output;
-        }
-
-        var padded = new byte[PlaintextLength];
-        Buffer.BlockCopy(output, 0, padded, PlaintextLength - output.Length, output.Length);
-        return padded;
+        return ToFixedLength(value, PlaintextLength);
     }
 
     private static byte[] ConvertEncryptOutput(BigInteger value)
     {
+        return ToFixedLength(value, LENGTH);
+    }
+
+    private static byte[] ToFixedLength(BigInteger value, int length)
+    {
         var output = value.ToByteArray(isUnsigned: true, isBigEndian: true);
 
-        if (output.Length == LENGTH)
+        if (output.Length == length)
         {
             return output;
         }
 
-        if (output.Length > LENGTH)
+        if (output.Length > length)
         {
-            var trimmed = new byte[LENGTH];
-            Buffer.BlockCopy(output, output.Length - LENGTH, trimmed, 0, LENGTH);
+            var trimmed = new byte[length];
+            Buffer.BlockCopy(output, output.Length - length, trimmed, 0, length);
             return trimmed;
         }
 
-        var padded = new byte[LENGTH];
-        Buffer.BlockCopy(output, 0, padded, LENGTH - output.Length, output.Length);
+        var padded = new byte[length];
+        Buffer.BlockCopy(output, 0, padded, length - output.Length, output.Length);
         return padded;
     }
 }

--- a/src/ApplicationServer/NeoServer.Server.Security/RSA.cs
+++ b/src/ApplicationServer/NeoServer.Server.Security/RSA.cs
@@ -1,20 +1,31 @@
+using System;
 using System.IO;
-using Org.BouncyCastle.Crypto;
-using Org.BouncyCastle.Crypto.Engines;
-using Org.BouncyCastle.OpenSsl;
+using System.Numerics;
 
 namespace NeoServer.Server.Security;
 
 public static class Rsa
 {
     public const int LENGTH = 128;
-    private static RsaEngine RsaEngine { get; set; }
+    private const int PlaintextLength = LENGTH - 1;
+    private const byte PaddingFillByte = 0x33;
+
+    private static BigInteger _modulus;
+    private static BigInteger _publicExponent;
+    private static BigInteger _privateExponent;
 
     public static byte[] Decrypt(byte[] data)
     {
         try
         {
-            return data.Length > LENGTH ? null : RsaEngine.ProcessBlock(data, 0, data.Length);
+            if (data is null || data.Length > LENGTH)
+            {
+                return null;
+            }
+
+            var cipher = new BigInteger(data, isUnsigned: true, isBigEndian: true);
+            var plain = BigInteger.ModPow(cipher, _privateExponent, _modulus);
+            return ConvertDecryptOutput(plain);
         }
         catch
         {
@@ -22,12 +33,84 @@ public static class Rsa
         }
     }
 
+    public static byte[] Encrypt(ReadOnlySpan<byte> data)
+    {
+        if (data.Length > PlaintextLength)
+        {
+            throw new InvalidOperationException(
+                $"RSA payload length {data.Length} exceeds maximum {PlaintextLength}.");
+        }
+
+        var block = new byte[PlaintextLength];
+        data.CopyTo(block);
+
+        var paddingLength = PlaintextLength - data.Length - 1;
+        for (var index = 0; index < paddingLength; index++)
+        {
+            block[data.Length + index] = PaddingFillByte;
+        }
+
+        block[PlaintextLength - 1] = 0x00;
+
+        var plain = new BigInteger(block, isUnsigned: true, isBigEndian: true);
+        var cipher = BigInteger.ModPow(plain, _publicExponent, _modulus);
+        return ConvertEncryptOutput(cipher);
+    }
+
     public static void LoadPem(string basePath)
     {
-        using var reader = File.OpenText($"{basePath}/key.pem");
-        var keyPair = (AsymmetricCipherKeyPair)new PemReader(reader).ReadObject();
+        var pem = File.ReadAllText(Path.Combine(basePath, "key.pem"));
+        var key = RsaPemParser.Parse(pem);
 
-        RsaEngine = new RsaEngine();
-        RsaEngine.Init(false, keyPair.Private);
+        _modulus = key.Modulus;
+        _publicExponent = key.PublicExponent;
+        _privateExponent = key.PrivateExponent;
+    }
+
+    private static byte[] ConvertDecryptOutput(BigInteger value)
+    {
+        var output = value.ToByteArray(isUnsigned: true, isBigEndian: true);
+
+        if (output.Length == 0)
+        {
+            return new byte[PlaintextLength];
+        }
+
+        if (output.Length > PlaintextLength && output[0] == 0)
+        {
+            var trimmed = new byte[output.Length - 1];
+            Buffer.BlockCopy(output, 1, trimmed, 0, trimmed.Length);
+            output = trimmed;
+        }
+
+        if (output.Length >= PlaintextLength)
+        {
+            return output;
+        }
+
+        var padded = new byte[PlaintextLength];
+        Buffer.BlockCopy(output, 0, padded, PlaintextLength - output.Length, output.Length);
+        return padded;
+    }
+
+    private static byte[] ConvertEncryptOutput(BigInteger value)
+    {
+        var output = value.ToByteArray(isUnsigned: true, isBigEndian: true);
+
+        if (output.Length == LENGTH)
+        {
+            return output;
+        }
+
+        if (output.Length > LENGTH)
+        {
+            var trimmed = new byte[LENGTH];
+            Buffer.BlockCopy(output, output.Length - LENGTH, trimmed, 0, LENGTH);
+            return trimmed;
+        }
+
+        var padded = new byte[LENGTH];
+        Buffer.BlockCopy(output, 0, padded, LENGTH - output.Length, output.Length);
+        return padded;
     }
 }

--- a/src/ApplicationServer/NeoServer.Server.Security/RsaPemParser.cs
+++ b/src/ApplicationServer/NeoServer.Server.Security/RsaPemParser.cs
@@ -1,0 +1,162 @@
+using System;
+using System.Numerics;
+using System.Security.Cryptography;
+
+namespace NeoServer.Server.Security;
+
+internal readonly record struct RsaPrivateKeyParameters(
+    BigInteger Modulus,
+    BigInteger PublicExponent,
+    BigInteger PrivateExponent);
+
+internal static class RsaPemParser
+{
+    private const string Pkcs1Label = "RSA PRIVATE KEY";
+    private const byte SequenceTag = 0x30;
+    private const byte IntegerTag = 0x02;
+
+    public static RsaPrivateKeyParameters Parse(string pem)
+    {
+        // OT key.pem uses PKCS#1 with INTEGER sizes RSA.ImportFromPem rejects (p is 65 bytes).
+        if (pem.Contains($"BEGIN {Pkcs1Label}", StringComparison.Ordinal))
+        {
+            return ParsePkcs1(DecodePemBody(pem, Pkcs1Label));
+        }
+
+        using var rsa = RSA.Create();
+        rsa.ImportFromPem(pem);
+        var parameters = rsa.ExportParameters(includePrivateParameters: true);
+
+        return new RsaPrivateKeyParameters(
+            ToUnsignedBigInteger(parameters.Modulus),
+            ToUnsignedBigInteger(parameters.Exponent),
+            ToUnsignedBigInteger(parameters.D));
+    }
+
+    private static RsaPrivateKeyParameters ParsePkcs1(byte[] encodedKey)
+    {
+        var offset = 0;
+        if (encodedKey.Length == 0 || encodedKey[offset] != SequenceTag)
+        {
+            throw new InvalidOperationException("Invalid RSA private key PEM.");
+        }
+
+        offset++;
+        ReadLength(encodedKey, ref offset);
+
+        var index = 0;
+        BigInteger modulus = default;
+        BigInteger publicExponent = default;
+        BigInteger privateExponent = default;
+
+        while (offset < encodedKey.Length && encodedKey[offset] == IntegerTag)
+        {
+            var value = ReadInteger(encodedKey, ref offset);
+            if (index == 1)
+            {
+                modulus = value;
+            }
+
+            if (index == 2)
+            {
+                publicExponent = value;
+            }
+
+            if (index == 3)
+            {
+                privateExponent = value;
+                break;
+            }
+
+            index++;
+        }
+
+        if (modulus.IsZero || publicExponent.IsZero || privateExponent.IsZero)
+        {
+            throw new InvalidOperationException("RSA private key PEM is missing required parameters.");
+        }
+
+        return new RsaPrivateKeyParameters(modulus, publicExponent, privateExponent);
+    }
+
+    private static byte[] DecodePemBody(string pem, string label)
+    {
+        var header = $"-----BEGIN {label}-----";
+        var footer = $"-----END {label}-----";
+
+        var start = pem.IndexOf(header, StringComparison.Ordinal);
+        var end = pem.IndexOf(footer, StringComparison.Ordinal);
+        if (start < 0 || end < 0 || end <= start)
+        {
+            throw new InvalidOperationException("Invalid RSA private key PEM.");
+        }
+
+        start += header.Length;
+        var body = pem.AsSpan(start, end - start);
+        var buffer = new char[body.Length];
+        var length = 0;
+
+        foreach (var character in body)
+        {
+            if (char.IsWhiteSpace(character))
+            {
+                continue;
+            }
+
+            buffer[length] = character;
+            length++;
+        }
+
+        return Convert.FromBase64String(new string(buffer, 0, length));
+    }
+
+    private static BigInteger ReadInteger(byte[] data, ref int offset)
+    {
+        offset++;
+        var length = ReadLength(data, ref offset);
+        if (length <= 0 || offset + length > data.Length)
+        {
+            throw new InvalidOperationException("Invalid RSA private key PEM.");
+        }
+
+        var value = new BigInteger(data.AsSpan(offset, length), isUnsigned: true, isBigEndian: true);
+        offset += length;
+        return value;
+    }
+
+    private static int ReadLength(byte[] data, ref int offset)
+    {
+        if (offset >= data.Length)
+        {
+            throw new InvalidOperationException("Invalid RSA private key PEM.");
+        }
+
+        var lengthByte = data[offset];
+        offset++;
+
+        if (lengthByte < 0x80)
+        {
+            return lengthByte;
+        }
+
+        var lengthSize = lengthByte & 0x7F;
+        if (lengthSize is 0 or > 4 || offset + lengthSize > data.Length)
+        {
+            throw new InvalidOperationException("Invalid RSA private key PEM.");
+        }
+
+        var length = 0;
+        for (var i = 0; i < lengthSize; i++)
+        {
+            length = (length << 8) | data[offset];
+            offset++;
+        }
+
+        return length;
+    }
+
+    private static BigInteger ToUnsignedBigInteger(byte[] value)
+    {
+        return new BigInteger(value, isUnsigned: true, isBigEndian: true);
+    }
+}

--- a/src/ApplicationServer/NeoServer.Server/NeoServer.Server.csproj
+++ b/src/ApplicationServer/NeoServer.Server/NeoServer.Server.csproj
@@ -13,9 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle.NetCore" Version="2.2.1"/>
         <PackageReference Include="Serilog" Version="4.3.1" />
-
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -30,9 +30,6 @@
         <SerilogSettingsConfiguration_Version>3.3.0</SerilogSettingsConfiguration_Version>
         <SerilogSinkConsole_Version>4.0.1</SerilogSinkConsole_Version>
 
-        <!--BouncyCastle-->
-        <BouncyCastleNetCore_Version>1.8.10</BouncyCastleNetCore_Version>
-
         <!--Newtonsoft.Json-->
         <NewtonsoftJson_Version>13.0.1</NewtonsoftJson_Version>
 

--- a/tests/NeoServer.E2E.Tests/Client/Protocol/LoginPacketBuilder.cs
+++ b/tests/NeoServer.E2E.Tests/Client/Protocol/LoginPacketBuilder.cs
@@ -9,12 +9,11 @@ internal static class LoginPacketBuilder
 
     public static (byte[] Packet, uint[] XteaKey) BuildAccountLogin(
         string account,
-        string password,
-        string dataPath)
+        string password)
     {
         var xteaKey = GenerateXteaKey();
         var rsaPayload = BuildAccountRsaPayload(xteaKey, account, password);
-        var encryptedRsa = RsaEncryptor.Encrypt(rsaPayload, dataPath);
+        var encryptedRsa = RsaEncryptor.Encrypt(rsaPayload);
 
         var message = new NetworkMessage();
         message.AddByte((byte)GameIncomingPacketType.PlayerLoginRequest);
@@ -31,8 +30,7 @@ internal static class LoginPacketBuilder
         string password,
         string characterName,
         uint challengeTimeStamp,
-        byte challengeNumber,
-        string dataPath)
+        byte challengeNumber)
     {
         var xteaKey = GenerateXteaKey();
         var rsaPayload = BuildGameRsaPayload(
@@ -42,7 +40,7 @@ internal static class LoginPacketBuilder
             characterName,
             challengeTimeStamp,
             challengeNumber);
-        var encryptedRsa = RsaEncryptor.Encrypt(rsaPayload, dataPath);
+        var encryptedRsa = RsaEncryptor.Encrypt(rsaPayload);
 
         var message = new NetworkMessage();
         message.AddByte((byte)GameIncomingPacketType.PlayerLogIn);

--- a/tests/NeoServer.E2E.Tests/Client/Protocol/RsaEncryptor.cs
+++ b/tests/NeoServer.E2E.Tests/Client/Protocol/RsaEncryptor.cs
@@ -1,38 +1,12 @@
-using Org.BouncyCastle.Crypto.Engines;
-using Org.BouncyCastle.OpenSsl;
+using NeoServer.Server.Security;
 
 namespace NeoServer.E2E.Tests.Client.Protocol;
 
 internal static class RsaEncryptor
 {
-    private const int CiphertextSize = 128;
-    private const int MaxPlaintextSize = CiphertextSize - 1;
-
     public static byte[] Encrypt(ReadOnlySpan<byte> data, string dataPath)
     {
-        if (data.Length > MaxPlaintextSize)
-        {
-            throw new InvalidOperationException(
-                $"RSA payload length {data.Length} exceeds maximum {MaxPlaintextSize}.");
-        }
-
-        using var reader = File.OpenText(Path.Combine(dataPath, "key.pem"));
-        var keyPair = (Org.BouncyCastle.Crypto.AsymmetricCipherKeyPair)new PemReader(reader).ReadObject();
-
-        var block = new byte[MaxPlaintextSize];
-        data.CopyTo(block);
-
-        var paddingLength = MaxPlaintextSize - data.Length - 1;
-        for (var index = 0; index < paddingLength; index++)
-        {
-            block[data.Length + index] = 0x33;
-        }
-
-        block[MaxPlaintextSize - 1] = 0x00;
-
-        var engine = new RsaEngine();
-        engine.Init(true, keyPair.Public);
-
-        return engine.ProcessBlock(block, 0, MaxPlaintextSize);
+        Rsa.LoadPem(dataPath);
+        return Rsa.Encrypt(data);
     }
 }

--- a/tests/NeoServer.E2E.Tests/Client/Protocol/RsaEncryptor.cs
+++ b/tests/NeoServer.E2E.Tests/Client/Protocol/RsaEncryptor.cs
@@ -4,9 +4,8 @@ namespace NeoServer.E2E.Tests.Client.Protocol;
 
 internal static class RsaEncryptor
 {
-    public static byte[] Encrypt(ReadOnlySpan<byte> data, string dataPath)
+    public static byte[] Encrypt(ReadOnlySpan<byte> data)
     {
-        Rsa.LoadPem(dataPath);
         return Rsa.Encrypt(data);
     }
 }

--- a/tests/NeoServer.E2E.Tests/Login/E2ELoginHelper.cs
+++ b/tests/NeoServer.E2E.Tests/Login/E2ELoginHelper.cs
@@ -3,8 +3,6 @@ using NeoServer.E2E.Tests.Client;
 using NeoServer.E2E.Tests.Client.Protocol;
 using NeoServer.E2E.Tests.Harness;
 using NeoServer.Networking.Packets.Outgoing;
-using NeoServer.Server.Configurations;
-using NeoServer.Server.Standalone.IoC;
 
 namespace NeoServer.E2E.Tests.Login;
 
@@ -14,16 +12,12 @@ internal static class E2ELoginHelper
         E2EServerHost host,
         CancellationToken cancellationToken = default)
     {
-        var serverConfiguration = host.Services.Resolve<ServerConfiguration>();
-        var dataPath = serverConfiguration.Data;
-
         await using var loginClient = new ProtocolTestClient("127.0.0.1", host.LoginPort);
         await loginClient.ConnectAsync(cancellationToken);
 
         var (accountLoginPacket, loginXteaKey) = LoginPacketBuilder.BuildAccountLogin(
             LoginTestCredentials.Account,
-            LoginTestCredentials.Password,
-            dataPath);
+            LoginTestCredentials.Password);
 
         await loginClient.SendAsync(accountLoginPacket, cancellationToken);
         loginClient.SetXteaKey(loginXteaKey);
@@ -48,8 +42,7 @@ internal static class E2ELoginHelper
             LoginTestCredentials.Password,
             LoginTestCredentials.CharacterName,
             challengeTimeStamp,
-            challengeNumber,
-            dataPath);
+            challengeNumber);
 
         await gameClient.SendAsync(gameLoginPacket, cancellationToken);
         gameClient.SetXteaKey(gameXteaKey);

--- a/tests/NeoServer.E2E.Tests/NeoServer.E2E.Tests.csproj
+++ b/tests/NeoServer.E2E.Tests/NeoServer.E2E.Tests.csproj
@@ -9,7 +9,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="BouncyCastle.NetCore" Version="2.2.1" />
         <PackageReference Include="coverlet.collector" Version="8.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/NeoServer.Server.Tests/Security/RsaTests.cs
+++ b/tests/NeoServer.Server.Tests/Security/RsaTests.cs
@@ -56,9 +56,34 @@ public class RsaTests
 
     [Fact]
     [Trait("Category", "HappyPath")]
+    public void Rsa_decrypts_legacy_bouncycastle_ciphertext_from_default_key()
+    {
+        var dataPath = ResolveDataPath();
+        File.Exists(Path.Combine(dataPath, "key.pem")).Should().BeTrue();
+        Rsa.LoadPem(dataPath);
+
+        var payload = new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50 };
+        var ciphertext = Convert.FromHexString(
+            "4B83336C57B62B6F3B6E477326899C218513B5FF1F94CFC1418E5C402C321757" +
+            "F2AAD8B9F105FA00633EA73C17275287ECEDE144755C4673F402FA3F40F788CC" +
+            "28E928D8C85775E269709220A6BEB563384E383540D1DA6BC5B48E216A534FEB" +
+            "0CECE4C2EE6AB1947583A6F9CF9AFD00D5604002CEC03CE647FDE9D625CF6CE4");
+
+        var decrypted = Rsa.Decrypt(ciphertext);
+
+        decrypted.Should().NotBeNull();
+        decrypted.Should().HaveCount(127);
+        decrypted.AsSpan(0, payload.Length).ToArray().Should().Equal(payload);
+        decrypted[payload.Length].Should().Be(0x33);
+        decrypted[^1].Should().Be(0x00);
+        Rsa.Encrypt(payload).Should().Equal(ciphertext);
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
     public void Rsa_roundtrips_with_default_server_key_pem()
     {
-        var dataPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "data"));
+        var dataPath = ResolveDataPath();
         File.Exists(Path.Combine(dataPath, "key.pem")).Should().BeTrue();
 
         Rsa.LoadPem(dataPath);
@@ -115,6 +140,27 @@ public class RsaTests
         {
             Directory.Delete(keyDirectory, recursive: true);
         }
+    }
+
+    [Fact]
+    [Trait("Category", "EdgeCase")]
+    public void Rsa_decrypts_full_block_to_exactly_127_bytes()
+    {
+        var dataPath = ResolveDataPath();
+        Rsa.LoadPem(dataPath);
+
+        var ciphertext = new byte[Rsa.LENGTH];
+        ciphertext[^1] = 0x01;
+
+        var decrypted = Rsa.Decrypt(ciphertext);
+
+        decrypted.Should().NotBeNull();
+        decrypted.Should().HaveCount(127);
+    }
+
+    private static string ResolveDataPath()
+    {
+        return Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "data"));
     }
 
     private static string CreateTempKeyDirectory()

--- a/tests/NeoServer.Server.Tests/Security/RsaTests.cs
+++ b/tests/NeoServer.Server.Tests/Security/RsaTests.cs
@@ -1,0 +1,129 @@
+using System;
+using System.IO;
+using System.Security.Cryptography;
+using FluentAssertions;
+using NeoServer.Server.Security;
+using Xunit;
+
+namespace NeoServer.Server.Tests.Security;
+
+public class RsaTests
+{
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Rsa_decrypts_payload_when_encrypted_with_tibia_padding()
+    {
+        var keyDirectory = CreateTempKeyDirectory();
+        try
+        {
+            Rsa.LoadPem(keyDirectory);
+
+            var payload = new byte[] { 0x10, 0x20, 0x30, 0x40, 0x50 };
+            var encrypted = Rsa.Encrypt(payload);
+
+            var decrypted = Rsa.Decrypt(encrypted);
+
+            decrypted.Should().NotBeNull();
+            decrypted.Should().HaveCount(127);
+            decrypted.AsSpan(0, payload.Length).ToArray().Should().Equal(payload);
+            decrypted[payload.Length].Should().Be(0x33);
+            decrypted[^1].Should().Be(0x00);
+        }
+        finally
+        {
+            Directory.Delete(keyDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Rsa_encrypts_to_128_byte_ciphertext()
+    {
+        var keyDirectory = CreateTempKeyDirectory();
+        try
+        {
+            Rsa.LoadPem(keyDirectory);
+
+            var encrypted = Rsa.Encrypt([0x01, 0x02, 0x03]);
+
+            encrypted.Should().HaveCount(Rsa.LENGTH);
+        }
+        finally
+        {
+            Directory.Delete(keyDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "HappyPath")]
+    public void Rsa_roundtrips_with_default_server_key_pem()
+    {
+        var dataPath = Path.GetFullPath(Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "..", "data"));
+        File.Exists(Path.Combine(dataPath, "key.pem")).Should().BeTrue();
+
+        Rsa.LoadPem(dataPath);
+
+        var payload = "account-login"u8.ToArray();
+        var decrypted = Rsa.Decrypt(Rsa.Encrypt(payload));
+
+        decrypted.Should().NotBeNull();
+        decrypted.AsSpan(0, payload.Length).ToArray().Should().Equal(payload);
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Rsa_returns_null_when_ciphertext_is_null()
+    {
+        var decrypted = Rsa.Decrypt(null);
+
+        decrypted.Should().BeNull();
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Rsa_returns_null_when_ciphertext_is_longer_than_block()
+    {
+        var keyDirectory = CreateTempKeyDirectory();
+        try
+        {
+            Rsa.LoadPem(keyDirectory);
+
+            var decrypted = Rsa.Decrypt(new byte[Rsa.LENGTH + 1]);
+
+            decrypted.Should().BeNull();
+        }
+        finally
+        {
+            Directory.Delete(keyDirectory, recursive: true);
+        }
+    }
+
+    [Fact]
+    [Trait("Category", "Validation")]
+    public void Rsa_throws_when_encrypt_payload_exceeds_maximum()
+    {
+        var keyDirectory = CreateTempKeyDirectory();
+        try
+        {
+            Rsa.LoadPem(keyDirectory);
+
+            var act = () => Rsa.Encrypt(new byte[128]);
+
+            act.Should().Throw<InvalidOperationException>();
+        }
+        finally
+        {
+            Directory.Delete(keyDirectory, recursive: true);
+        }
+    }
+
+    private static string CreateTempKeyDirectory()
+    {
+        var directory = Path.Combine(Path.GetTempPath(), "opencoremmo-rsa-tests", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+
+        using var rsa = RSA.Create(1024);
+        File.WriteAllText(Path.Combine(directory, "key.pem"), rsa.ExportRSAPrivateKeyPem());
+        return directory;
+    }
+}


### PR DESCRIPTION
### Description
Account login now uses built-in .NET cryptography instead of BouncyCastle, with no change to the Tibia 8.60 login protocol.

Raw encrypt/decrypt uses `BigInteger.ModPow` rather than `RSA.Encrypt`/`RSA.Decrypt`, because `RSA.ImportFromPem` rejects the stock OT `key.pem` (non-canonical 65-byte prime) and the protocol needs raw blocks, not PKCS#1 padding.

Closes #1022

### Key Changes
- Decrypts login RSA payloads without a third-party crypto library
- Keeps the same 128-byte ciphertext and Tibia padding so OTClient, OTCv8, and OTCR still log in
- Aligns E2E login encryption with server decrypt without reloading static key state
- CI checks a BouncyCastle golden ciphertext against default `data/key.pem`

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [x] Code refactoring
- [ ] Merge Down

### Test Case
`dotnet test tests/NeoServer.Server.Tests --filter FullyQualifiedName~RsaTests`
`dotnet test tests/NeoServer.E2E.Tests --filter FullyQualifiedName~PlayerLoginTests`