### PR TITLE
chore: keep server NuGet dependencies current

### DIFF
--- a/benchmarks/NeoServer.Benchmarks/NeoServer.Benchmarks.csproj
+++ b/benchmarks/NeoServer.Benchmarks/NeoServer.Benchmarks.csproj
@@ -24,7 +24,7 @@
         <PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
         <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.15.8" />
         <PackageReference Include="MoonSharp" Version="2.0.0"/>
-        <PackageReference Include="NLua" Version="1.7.8" />
+        <PackageReference Include="NLua" Version="1.7.9" />
     </ItemGroup>
 
     <ItemGroup>

--- a/data/extensions/NeoServer.Extensions.csproj
+++ b/data/extensions/NeoServer.Extensions.csproj
@@ -7,7 +7,7 @@
 
     <ItemGroup>
         <PackageReference Include="System.Collections" Version="4.3.0"/>
-        <PackageReference Include="System.Collections.Immutable" Version="10.0.5" />
+        <PackageReference Include="System.Collections.Immutable" Version="10.0.12" />
     </ItemGroup>
     <ItemGroup>
         <ProjectReference Include="..\..\src\ApplicationServer\NeoServer.Server.Contracts\NeoServer.Server.Common.csproj"/>

--- a/src/ApplicationServer/NeoServer.Server.Commands/NeoServer.Server.Commands.csproj
+++ b/src/ApplicationServer/NeoServer.Server.Commands/NeoServer.Server.Commands.csproj
@@ -7,7 +7,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ApplicationServer/NeoServer.Server.Compiler/NeoServer.Server.Compiler.csproj
+++ b/src/ApplicationServer/NeoServer.Server.Compiler/NeoServer.Server.Compiler.csproj
@@ -8,7 +8,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4"/>
         <PackageReference Include="System.Reactive.Linq" Version="6.1.0"/>
     </ItemGroup>

--- a/src/ApplicationServer/NeoServer.Server.Contracts/NeoServer.Server.Common.csproj
+++ b/src/ApplicationServer/NeoServer.Server.Contracts/NeoServer.Server.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ApplicationServer/NeoServer.Server.Events/NeoServer.Server.Events.csproj
+++ b/src/ApplicationServer/NeoServer.Server.Events/NeoServer.Server.Events.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ApplicationServer/NeoServer.Server.Helpers/NeoServer.Server.Helpers.csproj
+++ b/src/ApplicationServer/NeoServer.Server.Helpers/NeoServer.Server.Helpers.csproj
@@ -7,9 +7,9 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.12" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.4"/>
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/ApplicationServer/NeoServer.Server.Security/NeoServer.Server.Security.csproj
+++ b/src/ApplicationServer/NeoServer.Server.Security/NeoServer.Server.Security.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
     </ItemGroup>
 
 </Project>

--- a/src/ApplicationServer/NeoServer.Server/NeoServer.Server.csproj
+++ b/src/ApplicationServer/NeoServer.Server/NeoServer.Server.csproj
@@ -13,7 +13,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Core/NeoServer.Domain/NeoServer.Domain.csproj
+++ b/src/Core/NeoServer.Domain/NeoServer.Domain.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Database/NeoServer.Data/NeoServer.Data.csproj
+++ b/src/Database/NeoServer.Data/NeoServer.Data.csproj
@@ -7,14 +7,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Dapper" Version="2.1.72" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Dapper" Version="2.1.79" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.12" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.12" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.12" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.12" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.12" />
+        <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.3" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Extensions/NeoServer.Scripts.LuaJIT/NeoServer.Scripts.LuaJIT.csproj
+++ b/src/Extensions/NeoServer.Scripts.LuaJIT/NeoServer.Scripts.LuaJIT.csproj
@@ -27,8 +27,8 @@
 
     <ItemGroup>
         <PackageReference Include="JAJ.Packages.LuaNET" Version="1.1.0"/>
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.12" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1"/>
     </ItemGroup>
 

--- a/src/Loaders/NeoServer.Loaders/NeoServer.Loaders.csproj
+++ b/src/Loaders/NeoServer.Loaders/NeoServer.Loaders.csproj
@@ -9,7 +9,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="serilog" Version="4.3.1" />
+        <PackageReference Include="serilog" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NeoServer.Aspire/NeoServer.Aspire.AppHost/NeoServer.Aspire.AppHost.csproj
+++ b/src/NeoServer.Aspire/NeoServer.Aspire.AppHost/NeoServer.Aspire.AppHost.csproj
@@ -13,8 +13,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.2.1" />
-        <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.2.1" />
+        <PackageReference Include="Aspire.Hosting.AppHost" Version="13.5.3" />
+        <PackageReference Include="Aspire.Hosting.PostgreSQL" Version="13.5.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NetworkingServer/NeoServer.Networking.Handlers/NeoServer.Networking.Handlers.csproj
+++ b/src/NetworkingServer/NeoServer.Networking.Handlers/NeoServer.Networking.Handlers.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NetworkingServer/NeoServer.Networking.Packets/NeoServer.Networking.Packets.csproj
+++ b/src/NetworkingServer/NeoServer.Networking.Packets/NeoServer.Networking.Packets.csproj
@@ -28,7 +28,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/NetworkingServer/NeoServer.Networking/NeoServer.Networking.csproj
+++ b/src/NetworkingServer/NeoServer.Networking/NeoServer.Networking.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Standalone/NeoServer.Server.Standalone.csproj
+++ b/src/Standalone/NeoServer.Server.Standalone.csproj
@@ -16,16 +16,16 @@
         <UserSecretsId>d00c6b5a-86dc-4f58-b885-056c3322a45a</UserSecretsId>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.5" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.5" />
-        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.5" />
-        <PackageReference Include="Serilog" Version="4.3.1" />
+        <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.12" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.12" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="10.0.12" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.12" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.12" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.12" />
+        <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="10.0.12" />
+        <PackageReference Include="Serilog" Version="4.4.0" />
         <PackageReference Include="Serilog.Extensions.Logging" Version="10.0.0"/>
-        <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0"/>
+        <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.1" />
         <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1"/>
         <PackageReference Include="Serilog.Sinks.Graylog" Version="3.1.1"/>
     </ItemGroup>

--- a/tests/NeoServer.Domain.Tests/NeoServer.Domain.Tests.csproj
+++ b/tests/NeoServer.Domain.Tests/NeoServer.Domain.Tests.csproj
@@ -9,16 +9,16 @@
 
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.18.1"/>
-        <PackageReference Include="coverlet.collector" Version="8.0.1">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.9.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="FluentAssertions" Version="8.10.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
         <PackageReference Include="Moq" Version="4.20.72"/>
         <PackageReference Include="xRetry" Version="1.9.0"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/NeoServer.E2E.Tests/NeoServer.E2E.Tests.csproj
+++ b/tests/NeoServer.E2E.Tests/NeoServer.E2E.Tests.csproj
@@ -9,18 +9,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="8.0.1">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="FluentAssertions" Version="8.9.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="FluentAssertions" Version="8.10.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
         <PackageReference Include="xunit" Version="2.9.3" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/NeoServer.Loaders.Tests/NeoServer.Loaders.Tests.csproj
+++ b/tests/NeoServer.Loaders.Tests/NeoServer.Loaders.Tests.csproj
@@ -8,15 +8,15 @@
 
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.18.1"/>
-        <PackageReference Include="FluentAssertions" Version="8.9.0" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="FluentAssertions" Version="8.10.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
         <PackageReference Include="Moq" Version="4.20.72"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="8.0.1">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/NeoServer.Networking.Tests/NeoServer.Networking.Tests.csproj
+++ b/tests/NeoServer.Networking.Tests/NeoServer.Networking.Tests.csproj
@@ -10,18 +10,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
         <PackageReference Include="xunit" Version="2.9.3"/>
         <PackageReference Include="xunit.extensibility.core" Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="8.0.1">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/tests/NeoServer.Server.Tests/NeoServer.Server.Tests.csproj
+++ b/tests/NeoServer.Server.Tests/NeoServer.Server.Tests.csproj
@@ -7,18 +7,18 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="coverlet.msbuild" Version="8.0.1">
+        <PackageReference Include="coverlet.msbuild" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.9.0" />
         <PackageReference Include="Moq" Version="4.20.72"/>
         <PackageReference Include="xunit" Version="2.9.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+        <PackageReference Include="xunit.runner.visualstudio" Version="4.0.0">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="8.0.1">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
### Description
Bump NuGet package versions across the server, data, Aspire, and test projects so the stack stays on current .NET 10 and tooling patches.

### Key Changes
- Update Microsoft.Extensions and Entity Framework Core packages from 10.0.5 to 10.0.12
- Update Serilog to 4.4.0 and related logging/config packages
- Update test tooling (coverlet, FluentAssertions, Microsoft.NET.Test.Sdk, xunit.runner.visualstudio)
- Update Aspire hosting, Dapper, Npgsql, Roslyn, and NLua to current compatible versions

### Types of Changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation fix (typos, incorrect content, missing content, etc.)
- [ ] Code refactoring
- [ ] Merge Down

### Test Case
dotnet test tests/